### PR TITLE
fix(social): reply button opens post instead of toggling inline replies

### DIFF
--- a/src/components/Account/AccountFeed.tsx
+++ b/src/components/Account/AccountFeed.tsx
@@ -30,6 +30,7 @@ export default function AccountFeed({ address, tab }: AccountFeedProps) {
           key={item.id}
           item={item}
           commentCount={item.total_comments ?? 0}
+          allowInlineRepliesToggle={false}
           onOpenPost={(id: string) => navigate(`/post/${String(id).replace(/_v3$/,'')}`)}
         />
       )}

--- a/src/features/social/components/ReplyToFeedItem.tsx
+++ b/src/features/social/components/ReplyToFeedItem.tsx
@@ -313,6 +313,7 @@ const ReplyToFeedItem = memo(({ item, onOpenPost, commentCount = 0, hideParentCo
                   item={reply}
                   commentCount={reply.total_comments ?? 0}
                   hideParentContext
+                  allowInlineRepliesToggle={false}
                   onOpenPost={(id) => onOpenPost(String(id).replace(/_v3$/,''))}
                 />
               ))}

--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -157,6 +157,7 @@ export default function FeedList({
           key={postId}
           item={item}
           commentCount={commentCount}
+          allowInlineRepliesToggle={false}
           onOpenPost={handleItemClick}
         />
       );


### PR DESCRIPTION
- Feed: pass allowInlineRepliesToggle=false to ReplyToFeedItem
- Account feed: pass allowInlineRepliesToggle=false to ReplyToFeedItem
- Nested replies: pass allowInlineRepliesToggle=false to inner ReplyToFeedItem
- DirectReplies already disabled inline toggling
- Ensures clicking the reply button navigates to the post