### PR TITLE
fix(add-liquidity): prefill tokens on add liquidity button clicked

### DIFF
--- a/src/features/dex/components/AddLiquidityForm.tsx
+++ b/src/features/dex/components/AddLiquidityForm.tsx
@@ -198,6 +198,27 @@ export default function AddLiquidityForm() {
     };
   }, [tokens, location.search, tokenA, tokenB, selectedTokenA, selectedTokenB, findTokenByAddressOrSymbol, findToken]);
 
+  // Sync tokens from Pool context when a position is selected for adding liquidity
+  useEffect(() => {
+    if (!tokens.length) return;
+    if (currentAction !== "add") return;
+
+    const nextA = selectedTokenA ? findToken(selectedTokenA) : null;
+    const nextB = selectedTokenB ? findToken(selectedTokenB) : null;
+
+    const currentAId = tokenA?.is_ae ? "AE" : tokenA?.address;
+    const currentBId = tokenB?.is_ae ? "AE" : tokenB?.address;
+    const nextAId = nextA?.is_ae ? "AE" : nextA?.address;
+    const nextBId = nextB?.is_ae ? "AE" : nextB?.address;
+
+    if (nextA && nextAId !== currentAId) {
+      setTokenA(nextA);
+    }
+    if (nextB && nextBId !== currentBId) {
+      setTokenB(nextB);
+    }
+  }, [tokens, currentAction, selectedTokenA, selectedTokenB]);
+
   // Update URL parameters when tokens change (after initial load)
   useEffect(() => {
     // Skip URL updates during initial load or when tokens are being set from URL params


### PR DESCRIPTION
fixes https://github.com/superhero-com/superhero/issues/183

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Syncs Add Liquidity form tokens with Pool context selection when adding liquidity, ensuring tokenA/tokenB prefill and URL params stay updated.
> 
> - **Frontend**:
>   - **`src/features/dex/components/AddLiquidityForm.tsx`**:
>     - Add effect to sync `tokenA`/`tokenB` from Pool context (`selectedTokenA`/`selectedTokenB`) when `currentAction === "add"`, normalizing AE vs address IDs before updating state.
>     - Preserve existing behavior to update URL params when tokens change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9633a9b61d6513563cf21da2f73c6a8205db9e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->