### PR TITLE
feat: override network through env variables after build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ COPY . .
 RUN npm run build
 
 # Serve stage
-FROM caddy:2-alpine
+FROM nginx:1.25-alpine
 WORKDIR /srv
-COPY --from=builder /app/dist /srv
-
-# Dump Caddyfile
-RUN printf ":80 {\n  root * /srv\n  file_server\n  try_files {path} /index.html\n}" > /etc/caddy/Caddyfile
+COPY --from=builder /app/dist /usr/share/nginx/html
+RUN cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.template.html
+COPY docker/override-env.sh /docker-entrypoint.d/99-override-env.sh
+RUN apk add --no-cache gettext && chmod +x /docker-entrypoint.d/99-override-env.sh
 EXPOSE 80
-CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/override-env.sh
+++ b/docker/override-env.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Ensure envsubst is available
+if ! command -v envsubst >/dev/null 2>&1; then
+  echo "envsubst not found" >&2
+  exit 1
+fi
+
+# Replace placeholders in index.template.html into index.html
+if [ -f /usr/share/nginx/html/index.template.html ]; then
+  envsubst < /usr/share/nginx/html/index.template.html > /usr/share/nginx/html/index.html
+fi
+
+

--- a/index.html
+++ b/index.html
@@ -32,6 +32,36 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Synchronous runtime configuration injected at container start via envsubst
+      window.__SUPERCONFIG__ = {
+        BACKEND_URL: '$BACKEND_URL',
+        SUPERHERO_API_URL: '$SUPERHERO_API_URL',
+        SUPERHERO_WS_URL: '$SUPERHERO_WS_URL',
+        NODE_URL: '$NODE_URL',
+        WALLET_URL: '$WALLET_URL',
+        MIDDLEWARE_URL: '$MIDDLEWARE_URL',
+        DEX_BACKEND_URL: '$DEX_BACKEND_URL',
+        MAINNET_DEX_BACKEND_URL: '$MAINNET_DEX_BACKEND_URL',
+        TESTNET_DEX_BACKEND_URL: '$TESTNET_DEX_BACKEND_URL',
+        CONTRACT_V1_ADDRESS: '$CONTRACT_V1_ADDRESS',
+        CONTRACT_V2_ADDRESS: '$CONTRACT_V2_ADDRESS',
+        CONTRACT_V3_ADDRESS: '$CONTRACT_V3_ADDRESS',
+        WORD_REGISTRY_ADDRESS: '$WORD_REGISTRY_ADDRESS',
+        PROFILE_REGISTRY_ADDRESS: '$PROFILE_REGISTRY_ADDRESS',
+        LANDING_ENABLED: '$LANDING_ENABLED',
+        WORDBAZAAR_ENABLED: '$WORDBAZAAR_ENABLED',
+        JITSI_DOMAIN: '$JITSI_DOMAIN',
+        GOVERNANCE_API_URL: '$GOVERNANCE_API_URL',
+        GOVERNANCE_CONTRACT_ADDRESS: '$GOVERNANCE_CONTRACT_ADDRESS',
+        EXPLORER_URL: '$EXPLORER_URL',
+        IMGUR_API_CLIENT_ID: '$IMGUR_API_CLIENT_ID',
+        GIPHY_API_KEY: '$GIPHY_API_KEY',
+        UNFINISHED_FEATURES: '$UNFINISHED_FEATURES',
+        COMMIT_HASH: '$COMMIT_HASH',
+        BONDING_CURVE_18_DECIMALS_ADDRESS: '$BONDING_CURVE_18_DECIMALS_ADDRESS',
+      };
+    </script>
     <script type="module" src="/src/main.tsx"></script>
     <script>
       // Re-enable transitions after first paint

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,11 +68,11 @@ const defaultConfig: AppConfig = {
 const envApiUrl = (import.meta as any)?.env?.VITE_SUPERHERO_API_URL as string | undefined;
 const envWsUrl = (import.meta as any)?.env?.VITE_SUPERHERO_WS_URL as string | undefined;
 
-export const CONFIG: AppConfig = {
-  ...defaultConfig,
-  ...(envApiUrl ? { SUPERHERO_API_URL: envApiUrl } : {}),
-  ...(envWsUrl ? { SUPERHERO_WS_URL: envWsUrl } : {}),
-};
+declare global {
+  interface Window {
+    __SUPERCONFIG__?: Partial<AppConfig>;
+  }
+}
 
 function toBool(v: any): boolean {
   if (typeof v === "boolean") return v;
@@ -80,3 +80,29 @@ function toBool(v: any): boolean {
   if (typeof v === "string") return v.toLowerCase() === "true" || v === "1";
   return false;
 }
+
+function isPlaceholder(v: unknown): boolean {
+  return typeof v === 'string' && (/^\$[A-Z0-9_]+$/.test(v) || v.trim() === '');
+}
+
+function coerceValue(key: keyof AppConfig, v: any): any {
+  if (key === 'LANDING_ENABLED' || key === 'WORDBAZAAR_ENABLED') return toBool(v);
+  return v;
+}
+
+const runtimeRaw = (typeof window !== 'undefined' ? window.__SUPERCONFIG__ : undefined) as Partial<AppConfig> | undefined;
+const runtimeConfig: Partial<AppConfig> = runtimeRaw
+  ? Object.fromEntries(
+      Object.entries(runtimeRaw)
+        .filter(([, v]) => v !== undefined && v !== null && !isPlaceholder(v))
+        .map(([k, v]) => [k, coerceValue(k as keyof AppConfig, v)])
+    ) as Partial<AppConfig>
+  : {};
+
+export const CONFIG: AppConfig = {
+  ...defaultConfig,
+  ...runtimeConfig,
+  // Vite env overrides for local builds
+  ...(envApiUrl ? { SUPERHERO_API_URL: envApiUrl } : {}),
+  ...(envWsUrl ? { SUPERHERO_WS_URL: envWsUrl } : {}),
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { OpenAPI } from './api/generated';
+import { CONFIG } from './config';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 import ToastProvider from './components/ToastProvider';
@@ -12,9 +13,7 @@ import './i18n';
 import './styles/base.scss';
 import './styles/tailwind.css';
 
-// TODO: should be based on the active network
-// OpenAPI.BASE = `http://localhost:3000`;
-OpenAPI.BASE = `https://api.superhero.com`;
+OpenAPI.BASE = (CONFIG.SUPERHERO_API_URL || 'https://api.superhero.com').replace(/\/$/, '');
 
 const root = ReactDOM.createRoot(document.getElementById('root')!);
 


### PR DESCRIPTION
fixes #24 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds runtime env-based configuration by switching to Nginx and injecting values into the app, which now reads them to configure APIs and features at startup.
> 
> - **Runtime configuration**:
>   - Injects `window.__SUPERCONFIG__` into `index.html` with `$VAR` placeholders for URLs, addresses, flags, and keys.
>   - `src/config.ts` reads `window.__SUPERCONFIG__`, filters placeholders/empty, coerces booleans, and merges with defaults; retains Vite env overrides for local builds.
>   - `src/main.tsx` sets `OpenAPI.BASE` from `CONFIG.SUPERHERO_API_URL` with fallback and trims trailing slash.
> - **Docker/serving**:
>   - Switches serve image from `caddy` to `nginx`.
>   - Serves built assets from `/usr/share/nginx/html`; creates `index.template.html` and uses `envsubst` at container start via `docker/override-env.sh` (adds `gettext`).
>   - Updates container entrypoint/CMD to run Nginx in foreground.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eccf236166e1cc68fcbc7987486e5e446f52b04b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->