### PR TITLE
feat: show account owned tokens more compact on mobile

### DIFF
--- a/src/components/Account/AccountOwnedTokens.tsx
+++ b/src/components/Account/AccountOwnedTokens.tsx
@@ -39,10 +39,10 @@ export default function AccountOwnedTokens({
   
 
   return (
-    <div className="mt-4 space-y-4">
+    <div className="mt-3">
       <div className="bg-white/[0.02] border border-white/10 rounded-2xl overflow-hidden">
         {/* Header */}
-        <div className="hidden md:grid md:grid-cols-[2fr_1fr_1fr_1fr] gap-4 px-6 py-4 border-b border-white/10 text-xs font-semibold text-white/60 uppercase tracking-wide">
+        <div className="hidden md:grid md:grid-cols-[2fr_1fr_1fr_1fr] gap-3 px-4 py-2.5 border-b border-white/10 text-[11px] font-semibold text-white/60 uppercase tracking-wide">
           <div>Token</div>
           <div>Price</div>
           <button
@@ -84,51 +84,94 @@ export default function AccountOwnedTokens({
               return (
                 <div
                   key={`${token?.address || token?.name || index}`}
-                  className="owned-token-row grid grid-cols-1 gap-4 px-6 py-4 rounded-xl relative overflow-hidden transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] md:grid md:grid-cols-[2fr_1fr_1fr_1fr]"
+                  className="owned-token-row px-4 py-3 md:px-4 md:py-2.5 rounded-xl relative overflow-hidden transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]"
                 >
-                  <div className="flex items-center min-w-0">
-                    <span className="text-white/60 text-[.85em] mr-0.5 align-baseline font-semibold">#</span>
-                    {tokenHref ? (
-                      <a
-                        href={tokenHref}
-                        className="token-name text-md font-bold hover:underline truncate"
-                      >
-                        <span className="bg-gradient-to-r from-orange-400 to-yellow-500 bg-clip-text text-transparent font-bold">{tokenName}</span>
-                      </a>
-                    ) : (
-                      <div className="token-name text-md font-bold truncate">
-                        <span className="bg-gradient-to-r from-orange-400 to-yellow-500 bg-clip-text text-transparent font-bold">{tokenName}</span>
+                  {/* Compact mobile layout */}
+                  <div className="md:hidden">
+                    {/* Name on its own row */}
+                    <div className="flex items-center min-w-0">
+                      <span className="text-white/60 text-[.85em] mr-0.5 align-baseline font-semibold">#</span>
+                      {tokenHref ? (
+                        <a href={tokenHref} className="token-name text-sm font-bold hover:underline truncate">
+                          <span className="bg-gradient-to-r from-orange-400 to-yellow-500 bg-clip-text text-transparent font-bold">{tokenName}</span>
+                        </a>
+                      ) : (
+                        <div className="token-name text-sm font-bold truncate">
+                          <span className="bg-gradient-to-r from-orange-400 to-yellow-500 bg-clip-text text-transparent font-bold">{tokenName}</span>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Two columns aligned: Price | Amount (with labels) */}
+                    <div className="mt-1 grid grid-cols-2 gap-3 items-start">
+                      <div>
+                        <div className="text-white/60 text-xs font-medium mb-0.5">Price</div>
+                        <div className="bg-gradient-to-r text-[12px] from-yellow-400 to-cyan-500 bg-clip-text text-transparent">
+                          <PriceDataFormatter watchPrice={false} priceData={priceData} />
+                        </div>
                       </div>
-                    )}
-                  </div>
-
-                  <div className="flex items-center">
-                    <div className="bg-gradient-to-r text-sm from-yellow-400 to-cyan-500 bg-clip-text text-transparent">
-                      <PriceDataFormatter
-                        watchPrice={false}
-                        priceData={priceData}
-                      />
+                      <div className="text-right">
+                        <div className="text-white/60 text-xs font-medium mb-0.5">Amount</div>
+                        <div className="bg-gradient-to-r text-[12px] from-cyan-400 to-blue-500 bg-clip-text text-transparent font-medium">
+                          {Decimal.from(balance).div(10 ** (token?.decimals || 18)).prettify()}
+                        </div>
+                        <div className="mt-0.5 w-full text-left md:text-right" style={{ display: 'flex', justifyContent: 'end' }}>
+                          <PriceDataFormatter
+                            bignumber
+                            watchPrice={false}
+                            className="text-[11px] text-white/70"
+                            priceData={calculateTotalValue(balance, priceData)}
+                            rowOnSm={true}
+                          />
+                        </div>
+                      </div>
                     </div>
                   </div>
 
-                  <div className="flex items-center">
-                    <div className="bg-gradient-to-r text-sm from-cyan-400 to-blue-500 bg-clip-text text-transparent font-medium">
-                      {Decimal.from(balance)
-                        .div(10 ** (token?.decimals || 18))
-                        .prettify()}
+                  {/* Desktop grid layout */}
+                  <div className="hidden md:grid md:grid-cols-[2fr_1fr_1fr_1fr] gap-3">
+                    <div className="flex items-center min-w-0">
+                      <span className="text-white/60 text-[.85em] mr-0.5 align-baseline font-semibold">#</span>
+                      {tokenHref ? (
+                        <a
+                          href={tokenHref}
+                          className="token-name text-[15px] font-bold hover:underline truncate"
+                        >
+                          <span className="bg-gradient-to-r from-orange-400 to-yellow-500 bg-clip-text text-transparent font-bold">{tokenName}</span>
+                        </a>
+                      ) : (
+                        <div className="token-name text-[15px] font-bold truncate">
+                          <span className="bg-gradient-to-r from-orange-400 to-yellow-500 bg-clip-text text-transparent font-bold">{tokenName}</span>
+                        </div>
+                      )}
                     </div>
-                  </div>
 
-                  <div className="flex items-center">
-                   
-                      <div className="bg-gradient-to-r text-sm from-cyan-400 to-blue-500 bg-clip-text text-transparent">
+                    <div className="flex items-center">
+                      <div className="bg-gradient-to-r text-sm from-yellow-400 to-cyan-500 bg-clip-text text-transparent">
                         <PriceDataFormatter
-                          bignumber
                           watchPrice={false}
-                          priceData={calculateTotalValue(balance, priceData)}
+                          priceData={priceData}
                         />
                       </div>
-                   
+                    </div>
+
+                    <div className="flex items-center">
+                      <div className="bg-gradient-to-r text-sm from-cyan-400 to-blue-500 bg-clip-text text-transparent font-medium">
+                        {Decimal.from(balance)
+                          .div(10 ** (token?.decimals || 18))
+                          .prettify()}
+                      </div>
+                    </div>
+
+                    <div className="flex items-center">
+                        <div className="bg-gradient-to-r text-sm from-cyan-400 to-blue-500 bg-clip-text text-transparent">
+                          <PriceDataFormatter
+                            bignumber
+                            watchPrice={false}
+                            priceData={calculateTotalValue(balance, priceData)}
+                          />
+                        </div>
+                    </div>
                   </div>
                 </div>
               );
@@ -142,7 +185,7 @@ export default function AccountOwnedTokens({
             }}
             itemsPerPage={10}
             emptyMessage="This user doesn't own any Trendminer tokens yet."
-            className="space-y-4"
+            className="space-y-2 md:space-y-1"
           />
         </div>
         <style>{`
@@ -152,8 +195,8 @@ export default function AccountOwnedTokens({
                   background-clip: text;
                 }
                 .owned-token-row:hover {
-                  transform: translateY(-2px);
-                  box-shadow: 0 8px 25px rgba(17, 97, 254, 0.15);
+                  transform: translateY(-1px);
+                  box-shadow: 0 6px 18px rgba(17, 97, 254, 0.12);
                 }
                 .owned-token-row:active {
                   transform: translateY(0);


### PR DESCRIPTION
fixes #204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make Account Owned Tokens list more compact on mobile with a dedicated layout and refine desktop spacing and header styles, including clear price/balance/total value presentation.
> 
> - **UI (AccountOwnedTokens.tsx)**:
>   - **Mobile (new compact layout)**:
>     - Token name on its own row; two-column grid for `Price` and `Amount` with labels.
>     - Displays `Total Value` beneath amount using `PriceDataFormatter(bignumber)` with `calculateTotalValue`.
>     - Reduced paddings, gaps, font sizes; tighter row spacing; softer hover shadow/transform.
>   - **Desktop**:
>     - Maintains 4-column grid (`Token | Price | Balance | Total Value`) with refined paddings/gaps and text sizes.
>     - Uses `PriceDataFormatter` for price and total value; balance formatting unchanged.
>   - **Misc**: container top margin reduced (`mt-3`); `DataTable` row spacing tightened (`space-y-2 md:space-y-1`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb52ad1f9627cc423acd8841cf955aa77ef956dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->