### PR TITLE
fix: be able to click start posting on mobile

### DIFF
--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -14,7 +14,6 @@ import CreatePost, { CreatePostRef } from "../components/CreatePost";
 import SortControls from "../components/SortControls";
 import EmptyState from "../components/EmptyState";
 import ReplyToFeedItem from "../components/ReplyToFeedItem";
-import TokenCreatedFeedItem from "../components/TokenCreatedFeedItem";
 import TokenCreatedActivityItem from "../components/TokenCreatedActivityItem";
 import { PostApiResponse } from "../types";
 
@@ -31,7 +30,8 @@ export default function FeedList({
   const { chainNames } = useWallet();
   const queryClient = useQueryClient();
   const ACTIVITY_PAGE_SIZE = 50;
-  const createPostRef = useRef<CreatePostRef>(null);
+  const createPostRefMobile = useRef<CreatePostRef>(null);
+  const createPostRefDesktop = useRef<CreatePostRef>(null);
 
   // Comment counts are now provided directly by the API in post.total_comments
 
@@ -427,18 +427,26 @@ export default function FeedList({
     return () => observer.disconnect();
   }, [initialLoading, hasNextPage, isFetchingNextPage, fetchNextPage, sortBy, hasMoreActivities, fetchingMoreActivities, fetchNextActivities]);
 
+  const focusVisibleCreatePost = useCallback(() => {
+    const isDesktop = typeof window !== 'undefined'
+      && typeof window.matchMedia === 'function'
+      && window.matchMedia('(min-width: 768px)').matches;
+    const target = isDesktop ? createPostRefDesktop.current : createPostRefMobile.current;
+    target?.focus();
+  }, []);
+
   const content = (
     <div className="w-full">
       {!standalone && (
         <div className="mb-3 md:mb-4">
           <HeroBannerCarousel 
-            onStartPosting={() => createPostRef.current?.focus()} 
+            onStartPosting={focusVisibleCreatePost} 
           />
         </div>
       )}
       {/* Mobile: CreatePost first, then SortControls */}
       <div className="md:hidden">
-        <CreatePost ref={createPostRef} onSuccess={refetch} autoFocus={shouldAutoFocusPost} />
+        <CreatePost ref={createPostRefMobile} onSuccess={refetch} autoFocus={shouldAutoFocusPost} />
         <SortControls
           sortBy={sortBy}
           onSortChange={handleSortChange}
@@ -448,7 +456,7 @@ export default function FeedList({
 
       {/* Desktop: CreatePost first, then SortControls */}
       <div className="hidden md:block">
-        <CreatePost ref={createPostRef} onSuccess={refetch} autoFocus={shouldAutoFocusPost} />
+        <CreatePost ref={createPostRefDesktop} onSuccess={refetch} autoFocus={shouldAutoFocusPost} />
         <SortControls sortBy={sortBy} onSortChange={handleSortChange} />
       </div>
 


### PR DESCRIPTION
fixes https://github.com/superhero-com/superhero/issues/199

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes Start Posting to focus the visible CreatePost by adding desktop/mobile refs and a media-query-based focus handler.
> 
> - **UI (FeedList)**:
>   - Replace single `createPostRef` with `createPostRefMobile` and `createPostRefDesktop`.
>   - Add `focusVisibleCreatePost` using `matchMedia('(min-width: 768px)')` to focus the appropriate ref.
>   - Wire `HeroBannerCarousel.onStartPosting` to `focusVisibleCreatePost`.
>   - Update `CreatePost` refs in mobile and desktop sections.
>   - Remove unused `TokenCreatedFeedItem` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a298583e474de1f508e1bd6dd6babdf2f8c0863e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->