### PR TITLE
feat(infra): configure Nginx SPA fallback for client routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /srv
 COPY --from=builder /app/dist /usr/share/nginx/html
 RUN cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.template.html
 COPY docker/override-env.sh /docker-entrypoint.d/99-override-env.sh
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 RUN apk add --no-cache gettext && chmod +x /docker-entrypoint.d/99-override-env.sh
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,23 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location ~* \.(?:js|css|png|jpg|jpeg|gif|svg|ico|woff2?|ttf|otf)$ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    try_files $uri =404;
+  }
+
+  # Prevent caching of index.html so env replacements take effect
+  location = /index.html {
+    add_header Cache-Control "no-cache";
+  }
+}
+
+


### PR DESCRIPTION
- Add custom nginx.conf with try_files to index.html

- Copy nginx.conf in Dockerfile to override default site

- Ensure index.html is not cached for env injection

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds custom Nginx config and updates Dockerfile to enable SPA index fallback and set caching (immutable assets, no-cache index.html).
> 
> - **Infra / Docker**:
>   - Update `Dockerfile` to copy `docker/nginx.conf` into `/etc/nginx/conf.d/default.conf`.
> - **Nginx Configuration (`docker/nginx.conf`)**:
>   - **SPA routing**: `try_files $uri $uri/ /index.html` for client-side routes.
>   - **Caching**: 1y immutable cache for static assets (`js`, `css`, images, fonts); `index.html` explicitly `no-cache`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4584e009af0386c16ac15794e477057f5c56cd66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->