### PR TITLE
fix: be able to show more than 100 created trends

### DIFF
--- a/src/components/Account/AccountCreatedToken.tsx
+++ b/src/components/Account/AccountCreatedToken.tsx
@@ -2,6 +2,7 @@ import { TokensService } from "@/api/generated/services/TokensService";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import TokenListTable from "@/features/trending/components/TokenListTable";
+import { DataTablePagination } from "@/features/shared/components/DataTable/DataTablePagination";
 
 interface AccountCreatedTokenProps {
   address: string;
@@ -17,29 +18,34 @@ export default function AccountCreatedToken({
     "market_cap" | "name" | "price" | "created_at" | "holders_count"
   >("market_cap");
   const [orderDirection, setOrderDirection] = useState<"ASC" | "DESC">("DESC");
-  // Created tokens
-  const { data: createdTokensResp, isFetching: loadingCreated } = useQuery({
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(20);
+  // Created tokens (paged like Owned tab)
+  const { data: createdResp, isFetching: loadingCreated } = useQuery({
     queryKey: [
       "TokensService.listAll",
       "created",
       address,
       orderBy,
       orderDirection,
+      page,
+      limit,
     ],
+    enabled: !!address && tab === "created",
     queryFn: () =>
       TokensService.listAll({
         creatorAddress: address,
         orderBy,
         orderDirection,
-        limit: 100,
-        page: 1,
+        limit,
+        page,
       }) as unknown as Promise<{ items: any[]; meta?: any }>,
-    enabled: !!address && tab === "created",
     staleTime: 60_000,
+    placeholderData: (prev) => prev,
   });
   return (
     <div className="mt-4">
-      {!loadingCreated && (createdTokensResp?.items?.length ?? 0) === 0 && (
+      {!loadingCreated && ((createdResp?.items?.length ?? 0) === 0) && (
         <div className="text-center py-12 px-6 bg-white/5 rounded-2xl border border-white/10 backdrop-blur-xl">
           <div className="text-4xl mb-3 opacity-30">✨</div>
           <div className="text-white font-semibold mb-1">No created tokens</div>
@@ -49,11 +55,7 @@ export default function AccountCreatedToken({
         </div>
       )}
       <TokenListTable
-        pages={
-          createdTokensResp
-            ? [{ items: (createdTokensResp.items || []) as any[] }]
-            : [{ items: [] }]
-        }
+        pages={createdResp ? [{ items: (createdResp.items || []) as any[] }] : [{ items: [] }]}
         loading={loadingCreated}
         showCollectionColumn={false}
         orderBy={orderBy as any}
@@ -62,17 +64,35 @@ export default function AccountCreatedToken({
           if (key === "newest") {
             setOrderBy("created_at");
             setOrderDirection("DESC");
+            setPage(1);
           } else if (key === "oldest") {
             setOrderBy("created_at");
             setOrderDirection("ASC");
+            setPage(1);
           } else if (key === orderBy) {
             setOrderDirection(orderDirection === "DESC" ? "ASC" : "DESC");
+            setPage(1);
           } else {
             setOrderBy(key as any);
             setOrderDirection("DESC");
+            setPage(1);
           }
         }}
+        rankOffset={((createdResp?.meta?.currentPage || page) - 1) * (createdResp?.meta?.itemsPerPage || limit)}
       />
+      <div className="mt-2">
+        {createdResp?.meta && (
+          <DataTablePagination
+            meta={createdResp.meta}
+            onPageChange={(p) => setPage(p)}
+            onItemsPerPageChange={(n) => {
+              setLimit(n);
+              setPage(1);
+            }}
+            isLoading={loadingCreated}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/trending/components/TokenListTable.tsx
+++ b/src/features/trending/components/TokenListTable.tsx
@@ -78,9 +78,10 @@ interface TokenListTableProps {
   orderBy: OrderByOption;
   orderDirection: OrderDirection;
   onSort: (sortKey: OrderByOption) => void;
+  rankOffset?: number;
 }
 
-export default function TokenListTable({ pages, loading, showCollectionColumn, orderBy, orderDirection, onSort }: TokenListTableProps) {
+export default function TokenListTable({ pages, loading, showCollectionColumn, orderBy, orderDirection, onSort, rankOffset = 0 }: TokenListTableProps) {
 
 
   const allItems = useMemo(() => 
@@ -169,7 +170,7 @@ export default function TokenListTable({ pages, loading, showCollectionColumn, o
                 key={token.address}
                 token={token}
                 showCollectionColumn={showCollectionColumn}
-                rank={index + 1}
+                rank={rankOffset + index + 1}
               />
             ))}
           </tbody>


### PR DESCRIPTION
fixes https://github.com/superhero-com/superhero/issues/253

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds server-side pagination to the Created Tokens list with UI controls and corrects row ranking via a rank offset.
> 
> - **Account Created Tokens (`src/components/Account/AccountCreatedToken.tsx`)**:
>   - Add server-side pagination: new `page`/`limit` state, pass to `TokensService.listAll`, and enable `placeholderData`.
>   - Integrate `DataTablePagination` with handlers to change page and items per page; reset page on sort changes.
>   - Update query `queryKey` to include pagination; use paged response to render table and compute `rankOffset`.
> - **Token List Table (`src/features/trending/components/TokenListTable.tsx`)**:
>   - Add optional `rankOffset` prop and use it to compute row `rank`.
>   - Keep existing sorting UI; no structural changes beyond rank calculation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dec30d85074db6ac4324a1e656826a7ebc1825dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->