### PR TITLE
fix: redirect to aescan account correctly

### DIFF
--- a/src/components/wallet/WalletOverviewCard.tsx
+++ b/src/components/wallet/WalletOverviewCard.tsx
@@ -212,7 +212,7 @@ export default function WalletOverviewCard({
             <button
               type="button"
               className="px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-200 bg-white/10 text-white hover:bg-white/20 border border-white/20"
-              onClick={() => window.open(`https://www.aescan.io/account/${activeAccount}`, '_blank')}
+              onClick={() => window.open(`https://www.aescan.io/accounts/${activeAccount}`, '_blank')}
             >
               🔗 Open on aeScan
             </button>


### PR DESCRIPTION
fixes https://github.com/superhero-com/superhero/issues/249

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update aeScan link to use `/accounts/{address}` so the account page opens correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f651f7ef279c4e5bf9aa93f5df9bd9276b9ced7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->