### PR TITLE
feat: enhance update-package-type script to check for package.json ex…

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,9 @@ export default defineConfig(({ mode }) => {
         "@": path.resolve(__dirname, "./src"),
       },
     },
+    optimizeDeps: {
+      include: ['bctsl-sdk'],
+    },
     // Ensure env is loaded from the monorepo root so .env.* at repo root are picked up
     // Load envs from app directory only to avoid invalid envDir array issue
     envDir: __dirname,


### PR DESCRIPTION
…istence and update type to commonjs if necessary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `bctsl-sdk` uses CJS by conditionally patching its `package.json` and adds it to Vite’s prebundle list.
> 
> - **Scripts**:
>   - Update `scripts/update-package-type.cjs` to safely patch `node_modules/bctsl-sdk/package.json`: existence check, synchronous read/write, conditional `type: "commonjs"`, and adjust `main`/`exports.default` to CJS with improved logging/error handling.
> - **Build**:
>   - Add `optimizeDeps.include: ['bctsl-sdk']` to `vite.config.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10c12ba406eae40b6e7873e584b5f989849d7287. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->