### PR TITLE
fix(dex): prevent memory leak in PoolCandlestickChart touch handlers

### DIFF
--- a/src/features/dex/components/charts/PoolCandlestickChart.tsx
+++ b/src/features/dex/components/charts/PoolCandlestickChart.tsx
@@ -385,6 +385,12 @@ export function PoolCandlestickChart({
     });
 
     // Add touch handlers for mobile drag support
+    // Clean up any existing touch handlers first to prevent memory leaks
+    if (touchHandlersCleanup.current) {
+      touchHandlersCleanup.current();
+      touchHandlersCleanup.current = null;
+    }
+
     const container = chartContainer.current;
     if (container) {
       const handleTouchStart = (e: TouchEvent) => {


### PR DESCRIPTION
- Clean up existing touch event listeners before adding new ones in initializeSeries

- Prevents duplicate event listeners when fromToken, pair, or convertTo changes

- Fixes issue where cleanup effect only ran on chart instance change, not on initializeSeries recreation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clean up existing touch event listeners before adding new ones in `PoolCandlestickChart` to prevent duplicate handlers and memory leaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19cfb6deeace3a631cd93c2d888aab565396af11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->