### PR TITLE
fix(portfolio): center loader pill on desktop chart

### DIFF
--- a/src/components/Account/AccountPortfolio.tsx
+++ b/src/components/Account/AccountPortfolio.tsx
@@ -1530,7 +1530,7 @@ export default function AccountPortfolio({ address }: AccountPortfolioProps) {
             </div>
           ) : (
             // Lightweight-charts for desktop
-            <div className="px-4 md:px-6">
+            <div className="px-4 md:px-6 relative">
               <div 
                 ref={chartContainerRef} 
                 className="w-full h-[180px] min-w-0"
@@ -1539,7 +1539,7 @@ export default function AccountPortfolio({ address }: AccountPortfolioProps) {
               
               {/* Loading indicator */}
               {isLoading && (
-                <div className="absolute left-0 right-0 top-[30%] flex justify-center z-10">
+                <div className="absolute inset-0 flex items-center justify-center z-10">
                   <div className="inline-flex items-center gap-1.5 px-2.5 py-1 bg-black/40 border border-white/10 rounded-full text-white text-xs font-medium">
                     <div className="w-3.5 h-3.5 rounded-full border-2 border-white/20 border-t-white animate-spin" aria-label="loading" />
                     <span>Loading portfolio data...</span>


### PR DESCRIPTION
- Add relative positioning to desktop chart container

- Change loader positioning from top-[30%] to inset-0 with flex centering

- Ensures loader pill is properly centered in front of chart

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centers the desktop chart loading pill by making the container `relative` and switching loader positioning to `inset-0` with flex centering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c03df2bebd5b8612808ba19e16f5bacc4af08fa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->