### PR TITLE
fix(dao): redirect to token page correctly

### DIFF
--- a/src/features/dao/views/DaoListView.tsx
+++ b/src/features/dao/views/DaoListView.tsx
@@ -278,7 +278,7 @@ export default function Daos() {
                 <a
                   className="text-xs opacity-95 text-white no-underline px-3 py-2 rounded-xl border-0 bg-white/5 backdrop-blur-md shadow-lg hover:bg-white/10 transition-all duration-150"
                   href={`/trends/tokens/${encodeURIComponent(
-                    t.sale_address || t.address
+                    t.name
                   )}`}
                 >
                   View token


### PR DESCRIPTION
fixes [#260](https://github.com/superhero-com/superhero/issues/260)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update the "View token" link to route to /trends/tokens/{token.name} instead of an address-based path.
> 
> - **DAO List View (`src/features/dao/views/DaoListView.tsx`)**:
>   - Update "View token" link to use `t.name` in `/trends/tokens/{...}` instead of `t.sale_address || t.address`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37d120e12b69f745ed5fd9f4bcc4a39bbb10c3af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->