### PR TITLE
fix(token-list-card): show correct token price

### DIFF
--- a/src/components/explore/components/TokenListCards.tsx
+++ b/src/components/explore/components/TokenListCards.tsx
@@ -226,7 +226,7 @@ export function TokenListCards({
                     Price
                   </div>
                   <div className="text-sm text-white font-semibold">
-                  <PriceDataFormatter priceData={token.price} bignumber />
+                  <PriceDataFormatter priceData={token.price} />
                   </div>
                 </div>
 


### PR DESCRIPTION
fixes #266 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use standard price formatter (no bignumber) for token price in `TokenListCards`, leaving bignumber for TVL and volume.
> 
> - **Explore UI**
>   - **TokenListCards**: Render `token.price` with `PriceDataFormatter` without `bignumber`.
>   - TVL and volume fields continue using `bignumber` formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7db6dede502324642d282754069b0c0b4fb96278. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->