### PR TITLE
fix(token-list-item): be able to use Swap and Add buttons

### DIFF
--- a/src/components/explore/components/TokenListTable.tsx
+++ b/src/components/explore/components/TokenListTable.tsx
@@ -711,7 +711,10 @@ export function TokenListTable({
                     }}
                   >
                     <button
-                      onClick={() => handleSwapClick(token)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleSwapClick(token);
+                      }}
                       style={{
                         padding: "6px 12px",
                         borderRadius: 8,
@@ -740,7 +743,10 @@ export function TokenListTable({
                       Swap
                     </button>
                     <button
-                      onClick={() => handleAddClick(token)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleAddClick(token);
+                      }}
                       style={{
                         padding: "6px 12px",
                         borderRadius: 8,


### PR DESCRIPTION
fixes https://github.com/superhero-com/superhero/issues/225

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents row click navigation from triggering when pressing `Swap` or `Add` in `TokenListTable` by stopping event propagation on those buttons.
> 
> - **Explore UI**
>   - Update `src/components/explore/components/TokenListTable.tsx`:
>     - `Swap` and `Add` button handlers now call `e.stopPropagation()` to avoid triggering row navigation when clicked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4429524c7bf06ccd478e6e2f4daa8b0d84eb377. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->