### PR TITLE
fix: show correct trend performance info on mobile

### DIFF
--- a/src/features/trending/components/TokenLineChart.tsx
+++ b/src/features/trending/components/TokenLineChart.tsx
@@ -13,6 +13,7 @@ interface TokenLineChartProps {
   height?: number;
   hideTimeframe?: boolean;
   timeframe?: string;
+  className?: string;
 }
 
 
@@ -30,6 +31,7 @@ export function TokenLineChart({
   saleAddress,
   height = 200,
   hideTimeframe = false,
+  className,
 }: TokenLineChartProps) {
   const [loading, setLoading] = useState(false);
   const areaSeries = useRef<ISeriesApi<'Area'> | undefined>();
@@ -142,8 +144,8 @@ export function TokenLineChart({
   }
 
   return (
-    <div className="chart-container relative mr-2">
-      <div ref={chartContainer} className="lw-chart h-full" />
+    <div className={`chart-container relative ${className ?? ""}`}>
+      <div ref={chartContainer} className="lw-chart h-full w-full" />
       {!hideTimeframe && (data as ChartResponse)?.timeframe && (
         <div className="timeframe-indicator absolute bottom-0 right-0 text-xs lowercase">
           {(data as ChartResponse).timeframe}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the mobile 24h% column with an inline sparkline chart, removes per-row preview fetching, and tweaks mobile header/layout; adds className support to TokenLineChart.
> 
> - **Trending Tokens Table** (`src/features/trending/components/TokenListTable.tsx`, `TokenListTableRow.tsx`)
>   - Replace mobile "24h %" with inline `TokenLineChart` sparkline in each row; remove `Token24hChange` and related `react-query` fetching/state.
>   - Simplify row props by removing `changePercentMap`; drop unused imports.
>   - Update mobile header label to "Performance" and refine mobile styles (font sizes, alignment, widths, wrapping, spacing).
> - **Chart Component** (`src/features/trending/components/TokenLineChart.tsx`)
>   - Add optional `className` prop and apply full-width chart container (`w-full`); minor container class adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85a5f9a1652115e6c4b060037dab6d9bc7dbb699. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->