### PR TITLE
fix(feed): popular feed

### DIFF
--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -675,17 +675,22 @@ export default function FeedList({
   // Auto-fetch latest posts if we have less than 10 popular posts and haven't fetched yet
   useEffect(() => {
     const popularListLength = popularData?.pages ? ((popularData.pages as any[]) || []).flatMap((page: any) => page?.items ?? []).length : 0;
-    if (sortBy === "hot" && queryEnabledWithEnoughPosts && popularListLength < 10 && latestDataForHot?.pages?.length === 0 && !fetchingMoreLatestForHot && hasMoreLatestForHot) {
+    // Check if latestDataForHot hasn't been fetched yet (undefined or empty pages array)
+    // Use falsy check instead of === 0 because undefined !== 0
+    const hasNotFetchedLatest = !latestDataForHot?.pages || latestDataForHot.pages.length === 0;
+    if (sortBy === "hot" && queryEnabledWithEnoughPosts && popularListLength < 10 && hasNotFetchedLatest && !fetchingMoreLatestForHot && hasMoreLatestForHot) {
       if (process.env.NODE_ENV === 'development') {
         console.log('🔍 [DEBUG] Auto-fetching latest posts because popular posts < 10:', {
           popularListLength,
           hasEnoughPopularPosts,
           popularExhausted,
+          hasNotFetchedLatest,
+          latestDataForHotPagesLength: latestDataForHot?.pages?.length,
         });
       }
       fetchNextLatestForHot();
     }
-  }, [sortBy, queryEnabledWithEnoughPosts, popularData, popularExhausted, latestDataForHot?.pages?.length, fetchingMoreLatestForHot, hasMoreLatestForHot, fetchNextLatestForHot, hasEnoughPopularPosts]);
+  }, [sortBy, queryEnabledWithEnoughPosts, popularData, popularExhausted, latestDataForHot, fetchingMoreLatestForHot, hasMoreLatestForHot, fetchNextLatestForHot, hasEnoughPopularPosts]);
   
   // Force check hasMorePopular whenever popularData changes
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reworks the hot feed to load popular posts first and then latest posts excluding popular ones, with robust pagination, de-duplication, and improved infinite scroll/load-more behavior.
> 
> - **Hot feed logic**:
>   - Popular query now async with safer `getNextPageParam`, `initialPageParam`, and detailed debug logging.
>   - Track `popularPostIds` and compute `popularExhausted` to determine when to fetch latest.
>   - New latest-for-hot query (`latest-posts-for-hot`) filters out popular IDs; continues pagination regardless of filtered page size.
>   - Combine `popularList` + filtered `latestListForHot` (de-duplicated) for rendering.
>   - Enable latest fetch when popular are exhausted or <10 items; auto-fetch on short initial result.
> - **Infinite scroll & Load more**:
>   - IntersectionObserver and button now conditionally fetch popular or latest-for-hot, preventing concurrent fetches; expanded effect deps.
> - **Rendering & UX**:
>   - Render hot feed when either popular or latest-for-hot has pages; refined empty/loading states; added targeted debug logs throughout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f595fe411781375476a6d73d11e7e177bae4e1d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->