### PR TITLE
fix: enable token ranking on mobile

### DIFF
--- a/src/features/trending/views/TokenSaleDetails.tsx
+++ b/src/features/trending/views/TokenSaleDetails.tsx
@@ -441,6 +441,7 @@ export default function TokenSaleDetails() {
                 <TokenSummary
                   token={{ ...token, decimals: String(token.decimals ?? '') as any }}
                 />
+                <TokenRanking token={token} />
                 {/* Quali.chat CTA visible on mobile Info tab */}
                 <TokenChat
                   token={{


### PR DESCRIPTION
Fix https://github.com/superhero-com/superhero/issues/240#issuecomment-3516522161

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows `TokenRanking` in the mobile “Info” tab of `src/features/trending/views/TokenSaleDetails.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59f1d0e53021514ca28e4a7831d0bcb1aa6c98ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->