### PR TITLE
fix: wrong total volume data on the token list table

### DIFF
--- a/src/components/explore/components/TokenListTable.tsx
+++ b/src/components/explore/components/TokenListTable.tsx
@@ -685,7 +685,6 @@ export function TokenListTable({
                 >
                   <PriceDataFormatter
                     priceData={token.summary?.total_volume}
-                    bignumber
                   />
                 </td>
                 <td style={{ textAlign: "center", padding: "16px 12px" }}>


### PR DESCRIPTION
Fix #323 

1. Fixes the total volume ✅
2. The price difference bug between the explore page and swap page has been fixed.✅
3. Price calculation must be fixed from the backend. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects TokenListTable total volume display by removing `bignumber` formatting from `PriceDataFormatter` for `summary.total_volume`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b8c87cd88d2c13d2adf42b46c1937123bdf3310. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->