### PR TITLE
refactor: remove unnecessary bignumber prop from PriceDataFormatter i…

### DIFF
--- a/src/components/explore/components/TokenListCards.tsx
+++ b/src/components/explore/components/TokenListCards.tsx
@@ -13,16 +13,16 @@ interface TokenListCardsProps {
   tokens: DexTokenDto[];
   sort: {
     key:
-      | "pairs_count"
-      | "name"
-      | "symbol"
-      | "created_at"
-      | "price"
-      | "tvl"
-      | "24hchange"
-      | "24hvolume"
-      | "7dchange"
-      | "7dvolume";
+    | "pairs_count"
+    | "name"
+    | "symbol"
+    | "created_at"
+    | "price"
+    | "tvl"
+    | "24hchange"
+    | "24hvolume"
+    | "7dchange"
+    | "7dvolume";
     asc: boolean;
   };
   onSortChange: (
@@ -133,18 +133,17 @@ export function TokenListCards({
 
               <button
                 onClick={() => handleSort(sort.key)}
-                className={`px-2 py-[6px] rounded-md border border-white/10 cursor-pointer backdrop-blur-[10px] transition-all duration-300 text-[13px] font-semibold min-w-7 h-7 flex items-center justify-center outline-none hover:-translate-y-px hover:scale-105 ${
-                  sort.asc 
-                    ? "bg-green-500 text-white" 
+                className={`px-2 py-[6px] rounded-md border border-white/10 cursor-pointer backdrop-blur-[10px] transition-all duration-300 text-[13px] font-semibold min-w-7 h-7 flex items-center justify-center outline-none hover:-translate-y-px hover:scale-105 ${sort.asc
+                    ? "bg-green-500 text-white"
                     : "bg-white/10 text-white hover:bg-green-500 hover:text-white"
-                }`}
+                  }`}
                 title={sort.asc ? "Sort Ascending" : "Sort Descending"}
               >
                 {sort.asc ? "↑" : "↓"}
               </button>
             </div>
             <div className="flex items-center justify-center w-auto flex-shrink-0">
-            <PerformanceTimeframeSelector />
+              <PerformanceTimeframeSelector />
             </div>
           </div>
 
@@ -227,7 +226,7 @@ export function TokenListCards({
                     Price
                   </div>
                   <div className="text-sm text-white font-semibold">
-                  <PriceDataFormatter priceData={token.price} />
+                    <PriceDataFormatter priceData={token.price} />
                   </div>
                 </div>
 
@@ -237,7 +236,7 @@ export function TokenListCards({
                     TVL
                   </div>
                   <div className="text-sm text-white font-semibold">
-                  <PriceDataFormatter priceData={token.summary.total_volume} bignumber />
+                    <PriceDataFormatter priceData={token.summary.total_volume} />
                   </div>
                 </div>
 
@@ -247,17 +246,17 @@ export function TokenListCards({
                     {timeBase} Change
                   </div>
                   <div className="text-sm font-semibold">
-                  <PriceDataFormatter priceData={token.summary.change[timeBase].volume} bignumber />
+                    <PriceDataFormatter priceData={token.summary.change[timeBase].volume} />
                   </div>
                 </div>
 
                 {/* 24h Volume */}
                 <div className="bg-white/[0.03] p-3 rounded-lg border border-white/5">
                   <div className="text-[11px] text-gray-300 font-medium mb-1 uppercase tracking-wider">
-                  {timeBase} Volume
+                    {timeBase} Volume
                   </div>
                   <div className="text-sm text-white font-semibold">
-                  <PriceDataFormatter priceData={token.summary.change[timeBase].volume} bignumber />
+                    <PriceDataFormatter priceData={token.summary.change[timeBase].volume} />
                   </div>
                 </div>
               </div>

--- a/src/components/explore/components/TokenListTable.tsx
+++ b/src/components/explore/components/TokenListTable.tsx
@@ -669,7 +669,6 @@ export function TokenListTable({
                 >
                   <PriceDataFormatter
                     priceData={token.summary?.change?.[timeBase]?.volume}
-                    bignumber
                   />
                 </td>
 

--- a/src/features/dex/views/DexExplorePools.tsx
+++ b/src/features/dex/views/DexExplorePools.tsx
@@ -273,7 +273,7 @@ export default function DexExplorePools() {
                           TVL (USD)
                         </div>
                         <div className="text-sm text-[var(--standard-font-color)] font-semibold">
-                          <PriceDataFormatter priceData={pair.summary?.total_volume} bignumber />
+                          <PriceDataFormatter priceData={pair.summary?.total_volume} />
                         </div>
                       </div>
                       <div className="bg-white/[0.03] p-3 rounded-lg border border-white/5">
@@ -281,7 +281,7 @@ export default function DexExplorePools() {
                           Volume{" "}
                         </div>
                         <div className="text-sm text-[var(--standard-font-color)] font-semibold">
-                          <PriceDataFormatter priceData={pair.summary.change[timeBase].volume} bignumber />
+                          <PriceDataFormatter priceData={pair.summary.change[timeBase].volume} />
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
…n TokenList components

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the bignumber prop from PriceDataFormatter across token list components and pool explore views where it’s unnecessary.
> 
> - **Explore UI**:
>   - **Token Lists**:
>     - `src/components/explore/components/TokenListCards.tsx`: Remove `bignumber` from `PriceDataFormatter` for TVL and timeframe volume; keep price formatting unchanged.
>     - `src/components/explore/components/TokenListTable.tsx`: Remove `bignumber` from `PriceDataFormatter` for timeframe volume column.
>   - **Pools**:
>     - `src/features/dex/views/DexExplorePools.tsx` (mobile cards): Remove `bignumber` from `PriceDataFormatter` for TVL and timeframe volume.
> - Minor JSX/template string formatting and type union reformatting without behavioral changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f84cbca5a8339ff4dfcde2e76c8c8c67f2d6fd85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->