### PR TITLE
fix: correct translation keys for invite page buttons

### DIFF
--- a/src/features/trending/components/Invitation/InviteAndEarnCard.tsx
+++ b/src/features/trending/components/Invitation/InviteAndEarnCard.tsx
@@ -220,11 +220,11 @@ export default function InviteAndEarnCard({
                     {t('creatingInvites', { ns: 'common' })}
                   </>
                 ) : (
-                  t('generateInviteLinks', { ns: 'common' })
+                  t('buttons.generateInviteLinks', { ns: 'common' })
                 )}
               </button>
             ) : (
-              <WalletConnectBtn label={t('connectWalletToGenerate', { ns: 'common' })} className="text-sm" />
+              <WalletConnectBtn label={t('buttons.connectWalletToGenerate', { ns: 'common' })} className="text-sm" />
             )}
           </form>
         </div>


### PR DESCRIPTION
Fix https://github.com/superhero-com/superhero/issues/336 and https://github.com/superhero-com/superhero/issues/336#issuecomment-3551017533

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes invite page button labels to `buttons.*` i18n keys in `InviteAndEarnCard.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c5e300073b327d865cd8ee1a17288c413c2990f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->