### PR TITLE
feat(feed): add polls to popular feed

### DIFF
--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -1464,8 +1464,8 @@ export default function FeedList({
                   <PollItemWrapper
                     key={item.id}
                     pollAddress={pollMetadata.poll_address}
-                    title={item.content.split(' - ')[0] || 'Untitled poll'}
-                    description={item.content.includes(' - ') ? item.content.split(' - ').slice(1).join(' - ') : undefined}
+                    title={item.content ? item.content.split(' - ')[0] || 'Untitled poll' : 'Untitled poll'}
+                    description={item.content && item.content.includes(' - ') ? item.content.split(' - ').slice(1).join(' - ') : undefined}
                     author={item.sender_address}
                     closeHeight={pollMetadata.close_height}
                     createHeight={pollMetadata.create_height}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds simplified poll cards to the hot feed by parsing poll metadata and rendering read-only PollCreatedCard entries with click-through to full polls.
> 
> - **Feed (FeedList.tsx)**:
>   - Add `PollItemWrapper` leveraging `useAeSdk` to fetch chain height and render `PollCreatedCard` in read-only mode (no voting handlers).
>   - In hot feed rendering, detect poll items (`item.type === \`poll\``), adapt `metadata` (`vote_options`, `votes_count_by_option`, totals) to `PollCreatedCard` `options`/props, and wire `onOpen` to navigate.
>   - Non-poll items continue to render via `ReplyToFeedItem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b345f4a6a28e929a76ecc227125007d4f604b9f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->