### PR TITLE
fix: display usd price for average token price and improve small number formatting

### DIFF
--- a/src/features/shared/components/FiatPriceFormatter.tsx
+++ b/src/features/shared/components/FiatPriceFormatter.tsx
@@ -1,5 +1,6 @@
-import FractionFormatter from "@/features/shared/components/FractionFormatter";
+import FractionFormatter, { FormattedFractionalPrice } from "@/features/shared/components/FractionFormatter";
 import { Decimal } from '../../../libs/decimal';
+import { formatFractionalPrice } from '@/utils/common';
 
 interface FiatPriceFormatterProps {
   fiatPrice: Decimal;
@@ -9,46 +10,25 @@ interface FiatPriceFormatterProps {
 
 const DEFAULT_CURRENCY_SYMBOL = '$';
 
-/**
- * Formats a fiat price without fractional notation (always shows actual number)
- * This is different from formatFractionalPrice which uses notation for very small numbers
- */
-function formatFiatPrice(price: Decimal) {
-  if (price.isZero) {
-    return {
-      number: '0.00',
-    };
-  }
-  if (price.gte(Decimal.from('1'))) {
-    return {
-      number: price.prettify(2),
-    };
-  }
-  if (price.gte(Decimal.from('0.01'))) {
-    return {
-      number: price.prettify(4),
-    };
-  }
-  if (price.gte(Decimal.from('0.0001'))) {
-    return {
-      number: price.prettify(6),
-    };
-  }
-  // For very small amounts, show up to 8 decimal places (no fractional notation)
-  return {
-    number: price.prettify(8),
-  };
-}
-
 export default function FiatPriceFormatter({
   fiatPrice,
   currencySymbol = DEFAULT_CURRENCY_SYMBOL,
   className = '',
 }: FiatPriceFormatterProps) {
+  // Use formatFractionalPrice to show fractional notation for very small amounts (as QA prefers)
+  const formattedPriceRaw = formatFractionalPrice(fiatPrice);
+  
+  // Convert to FractionFormatter's expected type (zerosCount as string)
+  const formattedPrice: FormattedFractionalPrice = {
+    number: formattedPriceRaw.number,
+    zerosCount: formattedPriceRaw.zerosCount !== undefined ? String(formattedPriceRaw.zerosCount) : undefined,
+    significantDigits: formattedPriceRaw.significantDigits,
+  };
+  
   return (
     <div className={`inline-flex items-center ${className}`}>
       <div className={className}>{currencySymbol}</div>
-      <FractionFormatter fractionalPrice={formatFiatPrice(fiatPrice)} />
+      <FractionFormatter fractionalPrice={formattedPrice} />
     </div>
   );
 }

--- a/src/features/trending/components/AssetInput.tsx
+++ b/src/features/trending/components/AssetInput.tsx
@@ -21,6 +21,7 @@ interface AssetInputProps {
   errorMessages?: string[];
   color?: 'success' | 'default';
   aeValue?: Decimal;
+  fiatValue?: Decimal;
   className?: string;
 }
 
@@ -47,6 +48,7 @@ const AssetInput = forwardRef<AssetInputRef, AssetInputProps>(({
   errorMessages = [],
   color = 'default',
   aeValue = Decimal.ZERO,
+  fiatValue,
   className = '',
 }, ref) => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -57,8 +59,13 @@ const AssetInput = forwardRef<AssetInputRef, AssetInputProps>(({
   const [internalValue, setInternalValue] = useState<string>(String(modelValue));
 
   const fiatPrice = useMemo(() => {
+    // Use provided fiatValue if available (more accurate for large token amounts)
+    if (fiatValue !== undefined) {
+      return fiatValue;
+    }
+    // Fallback to calculating from AE value
     return getFiat(isCoin ? Decimal.from(modelValue) : aeValue);
-  }, [modelValue, aeValue, isCoin]);
+  }, [modelValue, aeValue, isCoin, fiatValue, getFiat]);
 
   // Update internal value when modelValue changes (similar to Vue watcher)
   useEffect(() => {
@@ -215,9 +222,16 @@ const AssetInput = forwardRef<AssetInputRef, AssetInputProps>(({
                 <FractionFormatter fractionalPrice={formatFractionalPrice(fiatPrice) as any} />
               </div>
             ) : (
-              <div className="text-sm text-white/70">
-                <span className="opacity-60">Balance:&nbsp;</span>
-                <span>{Decimal.from(tokenBalance).prettify()}</span>
+              <div className="flex items-center gap-2 text-sm text-white/70">
+                <div className="flex items-center gap-1">
+                  <span>{currentCurrencyInfo.symbol} </span>
+                  <FractionFormatter fractionalPrice={formatFractionalPrice(fiatPrice) as any} />
+                </div>
+                <span className="opacity-60">|</span>
+                <div>
+                  <span className="opacity-60">Balance:&nbsp;</span>
+                  <span>{Decimal.from(tokenBalance).prettify()}</span>
+                </div>
               </div>
             )}
 


### PR DESCRIPTION
Fix https://github.com/superhero-com/superhero/issues/335

Fixed precision handling for small fial values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute and display more accurate fiat prices using token price_data and currency rates, and show fractional formatting for very small values across trading UI.
> 
> - **Pricing/Formatting**
>   - Use `formatFractionalPrice` with `FractionFormatter` in `FiatPriceFormatter` (adapts `zerosCount` type) to improve tiny-value display.
>   - `LivePriceFormatter` computes fiat via priority: provided `fiatPrice` → `getFiat` (with `currentCurrencyRate`) → `aeternityData.currentPrice` fallback.
> - **Trading UI**
>   - `TokenTradeCard`: derives `averageTokenPriceUsd` from `token.price_data` (per-currency) or falls back to `getFiat`; passes to `LivePriceFormatter`.
>   - `TradeTokenInput`: computes AE and fiat values for `tokenA`/`tokenB` using `price_data` (fiat per token preferred) with fallbacks; passes `aeValue`/`fiatValue` to `AssetInput`.
>   - `AssetInput`: adds `aeValue` and optional `fiatValue` props; prefers provided fiat, otherwise converts via `getFiat`; updates balance row to also show current fiat value with fractional formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a705c3a26e44af6ef35f0e53c073ebd250b2b71c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->