### PR TITLE
fix: use actual created tokens count instead of accountInfo field

### DIFF
--- a/src/views/UserProfile.tsx
+++ b/src/views/UserProfile.tsx
@@ -154,6 +154,25 @@ export default function UserProfile({
     staleTime: 60_000,
   });
 
+  // Fetch created tokens count for stats display
+  const { data: createdTokensResp } = useQuery({
+    queryKey: [
+      "TokensService.listAll",
+      "created-count",
+      effectiveAddress,
+    ],
+    queryFn: () =>
+      TokensService.listAll({
+        creatorAddress: effectiveAddress,
+        orderBy: "created_at",
+        orderDirection: "DESC",
+        limit: 1,
+        page: 1,
+      }) as unknown as Promise<{ items: any[]; meta?: any }>,
+    enabled: !!effectiveAddress,
+    staleTime: 60_000,
+  });
+
   // Get posts from the query data
   const posts = data?.items || [];
 
@@ -564,7 +583,7 @@ export default function UserProfile({
               Created Trends
             </div>
             <div className="text-base md:text-lg font-bold text-white">
-              {(accountInfo?.total_created_tokens ?? 0).toLocaleString()}
+              {((createdTokensResp as any)?.meta?.totalItems ?? accountInfo?.total_created_tokens ?? 0).toLocaleString()}
             </div>
           </button>
           <button


### PR DESCRIPTION
Fix #https://github.com/superhero-com/superhero/issues/259

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show accurate “Created Trends” count by querying `TokensService.listAll` and using `meta.totalItems` instead of the account info field.
> 
> - **User Profile (`src/views/UserProfile.tsx`)**
>   - Add query to `TokensService.listAll` (creator-scoped) to fetch created tokens count via `meta.totalItems`.
>   - Update “Created Trends” stat to display `createdTokensResp.meta.totalItems` with fallback to `accountInfo.total_created_tokens`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1ad846db206136b735f23a2e801ce814e50e064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->