### PR TITLE
fix(popular-feed): refactor to correctly update window and refetch

### DIFF
--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -124,17 +124,6 @@ export default function FeedList({
     }
   }, [location.search, sortBy, queryClient, popularWindow]);
   
-  // Refetch popular posts when window changes (to ensure fresh data)
-  useEffect(() => {
-    if (sortBy === 'hot' && popularData && popularData.pages.length > 0) {
-      // Check if the current data matches the current window
-      // This is a safety check - React Query should handle this automatically via query key
-      if (process.env.NODE_ENV === 'development') {
-        console.log('[Popular Feed] Window changed, ensuring query is active for window:', popularWindow);
-      }
-    }
-  }, [popularWindow, sortBy, popularData]);
-
   // Helper to map a token object or websocket payload into a Post-like item
   const mapTokenCreatedToPost = useCallback((payload: any): PostDto => {
     const saleAddress: string = payload?.sale_address || payload?.address || "";
@@ -455,6 +444,17 @@ export default function FeedList({
     refetchOnMount: false, // Don't block on refetch - show cached data immediately
     refetchOnWindowFocus: true, // Refetch when window regains focus
   });
+
+  // Refetch popular posts when window changes (to ensure fresh data)
+  useEffect(() => {
+    if (sortBy === 'hot' && popularData && popularData.pages.length > 0) {
+      // Check if the current data matches the current window
+      // This is a safety check - React Query should handle this automatically via query key
+      if (process.env.NODE_ENV === 'development') {
+        console.log('[Popular Feed] Window changed, ensuring query is active for window:', popularWindow);
+      }
+    }
+  }, [popularWindow, sortBy, popularData]);
 
   // Track popular post IDs to filter them out from latest posts
   const popularPostIds = useMemo(() => {

--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -355,6 +355,7 @@ export default function FeedList({
   const {
     data: popularData,
     isLoading: popularLoading,
+    isFetching: popularFetching,
     error: popularError,
     fetchNextPage: fetchNextPopular,
     hasNextPage: hasMorePopular,
@@ -945,8 +946,9 @@ export default function FeedList({
   // Render helpers
   const renderEmptyState = () => {
     if (sortBy === "hot") {
-      // Only show loading if we don't have cached data
-      const initialLoading = popularLoading && (!popularData || (popularData as any)?.pages?.length === 0);
+      // Show loading if query is actively loading/fetching and we have no data
+      const hasNoData = !popularData || (popularData as any)?.pages?.length === 0;
+      const initialLoading = (popularLoading || popularFetching) && hasNoData;
       const err = popularError;
       if (err) {
         return <EmptyState type="error" error={err as any} onRetry={() => { refetchPopular(); }} />;
@@ -980,7 +982,7 @@ export default function FeedList({
     const hasCachedData = sortBy !== "hot" && (hasQueryData || (hasCachedPostsData && hasCachedActivitiesData));
     
     const initialLoading = sortBy === "hot"
-      ? (popularLoading && (!popularData || (popularData as any)?.pages?.length === 0))
+      ? ((popularLoading || popularFetching) && (!popularData || (popularData as any)?.pages?.length === 0))
       : (!hasCachedData && (latestLoading || activitiesLoading)); // Only show loading if no cached data and actually loading
     if (latestError) {
       return <EmptyState type="error" error={latestError as any} onRetry={refetchLatest} />;
@@ -1146,7 +1148,7 @@ export default function FeedList({
   
   const initialLoading =
     sortBy === "hot"
-      ? (popularLoading && (!popularData || (popularData as any)?.pages?.length === 0))
+      ? ((popularLoading || popularFetching) && (!popularData || (popularData as any)?.pages?.length === 0))
       : (!hasCachedDataForLatest && (latestLoading || activitiesLoading)); // Only show loading if no cached data and actually loading
   const [showLoadMore, setShowLoadMore] = useState(false);
   useEffect(() => { setShowLoadMore(false); }, [sortBy]);


### PR DESCRIPTION
- Update window correctly when refetching popular feed

- Fix refetch logic for popular feed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure popular feed window updates reset cache and invalidate queries to refetch, incorporate fetching state into loading, and add targeted debug logs.
> 
> - **Popular feed (hot)**:
>   - Sync `popularWindow` with URL; on change, reset cache via `removeQueries` and force refetch with `invalidateQueries` for `"popular-posts"` keyed by `window`.
>   - Expose `isFetching` as `popularFetching` and use it in initial loading/empty-state logic.
>   - Enhance query function and list memoization with development-only debug logs; add safety effect on window changes.
>   - Update `handlePopularWindowChange` to navigate with `window`, clear/invalidate queries, and fix hook dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08e2b9ff0432efa28d5d7c6540d91035851a4909. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->