### PR TITLE
fix(social): exclude hyphenated hashtags from topic feed matches

### DIFF
--- a/src/features/social/components/TokenTopicFeed.tsx
+++ b/src/features/social/components/TokenTopicFeed.tsx
@@ -33,8 +33,12 @@ export default function TokenTopicFeed({ topicName, showHeader = false, displayT
   }, [posts]);
 
   // Build a unified hashtag regex early to check if posts match the filter
+  // Exclude matches where the hashtag is followed by a hyphen and more characters
+  // (e.g., #superhero should not match #superhero-devs)
   const hashtagRegex = useMemo(() => {
-    return new RegExp(`(^|[^A-Za-z0-9_])#${escapeRegExp(baseName)}(?![A-Za-z0-9_])`, 'i');
+    // Match the hashtag only if it's not followed by a hyphen and more characters
+    // The negative lookahead checks: not (word char OR hyphen followed by at least one char)
+    return new RegExp(`(^|[^A-Za-z0-9_])#${escapeRegExp(baseName)}(?![A-Za-z0-9_]|-[A-Za-z0-9_])`, 'i');
   }, [baseName]);
 
   // Check if any posts match the hashtag filter (not just if posts exist)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update hashtag regex in `TokenTopicFeed` to prevent matching hyphenated variants (e.g., `#superhero` no longer matches `#superhero-devs`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ac1379cc54774833d02eaa9b22021bd7b46710f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->