### PR TITLE
fix: be able to enter decimals on iOS

### DIFF
--- a/src/features/shared/components/FractionFormatter.tsx
+++ b/src/features/shared/components/FractionFormatter.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-
-export interface FormattedFractionalPrice {
-  number: string;
-  zerosCount?: string;
-  significantDigits?: string;
-}
+import type { FormattedFractionalPrice } from '@/utils/types';
 
 interface FractionFormatterProps {
   fractionalPrice: FormattedFractionalPrice;


### PR DESCRIPTION
fixes https://github.com/superhero-com/superhero/issues/390

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves decimal input reliability on iOS and tightens slippage editing UX.
> 
> - AssetInput: normalize commas to dots, relax formatting (no thousands separators), sanitize to a single decimal point, and preserve intermediate states (e.g., trailing zeros) while emitting a cleaned value
> - TokenTradeCard: replace numeric slippage input with text+decimal input, buffer user typing (e.g., "0."), normalize commas, clamp to 0–50, commit on blur and on Done; sync buffer when settings open
> - FractionFormatter: switch to using shared `FormattedFractionalPrice` type import and update call sites
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c921d2970fbf274de404eb7967a61322ef531da2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->