### PR TITLE
fix: show owned label on token correctly

### DIFF
--- a/src/features/trending/views/TokenSaleDetails.tsx
+++ b/src/features/trending/views/TokenSaleDetails.tsx
@@ -143,10 +143,20 @@ export default function TokenSaleDetails() {
 
   // Check if user owns this token
   const ownsThisToken = useMemo(() => {
-    // This would need to be implemented based on your wallet/account system
-    return token && ownedTokens
-      ? ownedTokens.some((it: any) => it.id === token.id)
-      : false;
+    if (!token || !ownedTokens?.length) return false;
+
+    // `useOwnedTokens` returns the nested `row.token` objects from
+    // `/api/accounts/{address}/tokens`, so we can match directly by address.
+    const tokenAddress = String((token as any)?.address || "").toLowerCase();
+    const tokenSaleAddress = String((token as any)?.sale_address || "").toLowerCase();
+    const target = tokenSaleAddress || tokenAddress;
+    if (!target) return false;
+
+    return ownedTokens.some((t: any) => {
+      const addr = String(t?.address || "").toLowerCase();
+      const sale = String(t?.sale_address || "").toLowerCase();
+      return addr === target || sale === target;
+    });
   }, [activeAccount, token, ownedTokens]);
 
   // Render error state (token not found)

--- a/src/hooks/useOwnedTokens.ts
+++ b/src/hooks/useOwnedTokens.ts
@@ -1,67 +1,69 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAeSdk } from "./useAeSdk";
-import { TokenDto, TokensService } from "@/api/generated";
+import { AccountTokensService } from "@/api/generated";
 
-// Define the API response structure for tokens
-interface TokensResponse {
-  items: TokenDto[];
-  meta?: {
-    totalItems: number;
-    totalPages: number;
-    currentPage: number;
-  };
+type AccountTokensResponse = {
+  items?: unknown[];
+  meta?: unknown;
+};
+
+export type OwnedTokenLike = Record<string, any>;
+
+function extractTokenLike(item: unknown): OwnedTokenLike | null {
+  if (!item || typeof item !== "object") return null;
+
+  // Matches how other parts of the app treat the account tokens response.
+  // Usually it's `{ token, balance, ... }`, but some environments may return
+  // "flattened" fields like `token_name` / `token_symbol`.
+  const asAny = item as any;
+  if (asAny?.token && typeof asAny.token === "object") return asAny.token;
+
+  // Fallback: if the API returns token-like fields on the item itself.
+  const maybeTokenLike =
+    asAny?.token_address ||
+    asAny?.token_name ||
+    asAny?.token_symbol ||
+    asAny?.sale_address ||
+    asAny?.address;
+  if (maybeTokenLike) return asAny;
+
+  return null;
 }
 
 /**
- * React hook for fetching tokens owned or created by the current user
- * 
- * This hook is equivalent to the Vue composable useOwnedTokens.
- * It fetches tokens where the current user is either the owner or creator.
- * 
+ * React hook for fetching tokens owned by the current user.
+ *
+ * Important: the app’s “Owned Trends” is backed by the account tokens endpoint
+ * (`AccountTokensService.listTokenHolders`), not `TokensService.listAll`.
+ *
  * @returns Object containing ownedTokens array and isFetching status
  */
 export function useOwnedTokens() {
   const { activeAccount } = useAeSdk();
 
-  const { data, isFetching, error } = useQuery<TokensResponse>({
-    queryKey: ["TokensService.ownedTokens", activeAccount],
-    queryFn: async (): Promise<TokensResponse> => {
-      if (!activeAccount) {
-        return { items: [] };
-      }
+  const { data: ownedTokens = [], isFetching, error } = useQuery<OwnedTokenLike[]>({
+    queryKey: ["AccountTokensService.listTokenHolders", "ownedTokens", activeAccount],
+    queryFn: async (): Promise<OwnedTokenLike[]> => {
+      if (!activeAccount) return [];
 
-      try {
-        const response = await TokensService.listAll({
-          ownerAddress: activeAccount,
-          creatorAddress: activeAccount,
-          limit: 1000,
-        });
+      const resp = (await AccountTokensService.listTokenHolders({
+        address: activeAccount,
+        orderBy: "balance",
+        orderDirection: "DESC",
+        limit: 1000,
+        page: 1,
+      })) as unknown as AccountTokensResponse;
 
-        // Handle the case where the API returns any type
-        // The API response should have an 'items' property with TokenDto array
-        if (response && typeof response === 'object' && 'items' in response) {
-          return response as TokensResponse;
-        }
-
-        // Fallback: if response is directly an array (legacy API format)
-        if (Array.isArray(response)) {
-          return { items: response };
-        }
-
-        // Fallback: empty result
-        return { items: [] };
-      } catch (error) {
-        console.error('Failed to fetch owned tokens:', error);
-        throw error;
-      }
+      const items = Array.isArray(resp?.items) ? resp.items : [];
+      return items.map(extractTokenLike).filter(Boolean) as OwnedTokenLike[];
     },
     enabled: !!activeAccount,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    refetchInterval: 2 * 60 * 1000, // 2 minutes
+    // While this hook is mounted/used, refetch every 8s. React Query will
+    // automatically stop interval refetching once the hook is unmounted.
+    refetchInterval: 8_000,
+    refetchIntervalInBackground: false,
+    staleTime: 0,
   });
-
-  // Extract the tokens array from the response
-  const ownedTokens = data?.items ?? [];
 
   return {
     ownedTokens,


### PR DESCRIPTION
fixes #389 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes ownership detection for token pages by aligning data sourcing and matching logic with the account tokens API.
> 
> - Rewrites `useOwnedTokens` to use `AccountTokensService.listTokenHolders`, normalizing nested/flattened responses via `extractTokenLike`; returns a flat list of token-like objects and increases freshness (`refetchInterval` 8s, `staleTime` 0)
> - Updates `TokenSaleDetails` to compute `ownsThisToken` by matching the token’s `sale_address` (fallback `address`) against owned tokens’ `address`/`sale_address`, ensuring the `OWNED` badge shows correctly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbb2309d6bd7e9c07b665270d75db67352efab39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->