### PR TITLE
fix: show pool information correctly on mobile

### DIFF
--- a/src/features/dex/views/DexExplorePools.tsx
+++ b/src/features/dex/views/DexExplorePools.tsx
@@ -273,7 +273,7 @@ export default function DexExplorePools() {
                           TVL (USD)
                         </div>
                         <div className="text-sm text-[var(--standard-font-color)] font-semibold">
-                          <PriceDataFormatter priceData={pair.summary?.total_volume} />
+                          <PriceDataFormatter priceData={pair.summary?.total_volume} bignumber />
                         </div>
                       </div>
                       <div className="bg-white/[0.03] p-3 rounded-lg border border-white/5">
@@ -281,7 +281,7 @@ export default function DexExplorePools() {
                           Volume{" "}
                         </div>
                         <div className="text-sm text-[var(--standard-font-color)] font-semibold">
-                          <PriceDataFormatter priceData={pair.summary.change[timeBase].volume} />
+                          <PriceDataFormatter priceData={pair.summary.change[timeBase].volume} bignumber />
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
fixes https://github.com/superhero-com/superhero/issues/382

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes mobile pool stats formatting in `DexExplorePools.tsx`.
> 
> - Adds `bignumber` prop to `PriceDataFormatter` for `TVL (USD)` and timeframe `Volume` in the mobile card view to correctly display large values
> - UI-only change; no API or business logic updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5805a4ac106eabe2711f3f757cf5348601ebf53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->