### PR TITLE
fix: show correct fiat value

### DIFF
--- a/src/atoms/currencyAtoms.ts
+++ b/src/atoms/currencyAtoms.ts
@@ -1,0 +1,19 @@
+import { atom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
+
+import type { CurrencyRates } from '../utils/types';
+
+// Persisted currency state shared across the app.
+export const currencyRatesAtom = atomWithStorage<CurrencyRates>(
+  'currency:rates',
+  {},
+);
+
+// Updated whenever currencyRatesAtom is refreshed by the global poller.
+export const currencyRatesUpdatedAtAtom = atom<number>(0);
+
+// Updated whenever the global poller fails to fetch rates.
+// Used by UI to distinguish "loading/checking" from "offline".
+export const currencyRatesLastErrorAtAtom = atom<number>(0);
+
+

--- a/src/components/layout/RightRail.tsx
+++ b/src/components/layout/RightRail.tsx
@@ -1,15 +1,14 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { useTranslation } from 'react-i18next';
-import { SuperheroApi } from "../../api/backend";
 import { useAccountBalances } from "../../hooks/useAccountBalances";
 import WalletOverviewCard from "@/components/wallet/WalletOverviewCard";
 import { useAeSdk } from "../../hooks/useAeSdk";
-import Sparkline from "../Trendminer/Sparkline";
 import { BuyAeWidget } from "../../features/ae-eth-buy";
 
 import { useWallet } from "../../hooks";
 import { useAddressByChainName } from "../../hooks/useChainName";
+import { useCurrencies } from "@/hooks/useCurrencies";
 
 export default function RightRail({
   hidePriceSection = true,
@@ -21,6 +20,7 @@ export default function RightRail({
   const location = useLocation();
   const params = useParams();
   const { activeAccount } = useAeSdk();
+  const { currentCurrencyCode, setCurrentCurrency, currencyRates } = useCurrencies();
   
   // Resolve chain name if present
   const isChainName = params.address?.endsWith(".chain");
@@ -38,47 +38,14 @@ export default function RightRail({
     if (!activeAccount || !effectiveProfileAddress) return false;
     return effectiveProfileAddress === activeAccount;
   }, [location.pathname, effectiveProfileAddress, activeAccount]);
-  const [prices, setPrices] = useState<any>(() => {
-    // Initialize from cache if available
-    try {
-      const cached = sessionStorage.getItem("ae_prices");
-      if (cached) {
-        const parsed = JSON.parse(cached);
-        // Check if cache is recent (less than 5 minutes old)
-        if (parsed.timestamp && Date.now() - parsed.timestamp < 5 * 60 * 1000) {
-          return parsed.data;
-        }
-      }
-    } catch {
-      // Ignore cache errors
-    }
-    return null;
-  });
-  const [selectedCurrency, setSelectedCurrency] = useState<
-    "usd" | "eur" | "cny"
-  >("usd");
-
-  const [usdSpark, setUsdSpark] = useState<number[]>(() => {
-    try {
-      const raw = sessionStorage.getItem("ae_spark_usd");
-      if (!raw) return [];
-      const arr = JSON.parse(raw);
-      return Array.isArray(arr) ? arr.slice(-50) : [];
-    } catch {
-      return [];
-    }
-  });
-
-  const [eurSpark, setEurSpark] = useState<number[]>(() => {
-    try {
-      const raw = sessionStorage.getItem("ae_spark_eur");
-      if (!raw) return [];
-      const arr = JSON.parse(raw);
-      return Array.isArray(arr) ? arr.slice(-50) : [];
-    } catch {
-      return [];
-    }
-  });
+  const selectedCurrency = (currentCurrencyCode as any) as "usd" | "eur" | "cny";
+  const prices = useMemo(() => {
+    return {
+      usd: (currencyRates as any)?.usd ?? null,
+      eur: (currencyRates as any)?.eur ?? null,
+      cny: (currencyRates as any)?.cny ?? null,
+    };
+  }, [currencyRates]);
 
   const address = useWallet().address;
   const accountId = useMemo(
@@ -99,229 +66,6 @@ export default function RightRail({
     });
     return formatter.format(price);
   };
-
-  const formatMarketCap = (amount: number): string => {
-    if (amount >= 1000000) {
-      return `$${(amount / 1000000).toFixed(1)}M`;
-    } else if (amount >= 1000) {
-      return `$${(amount / 1000).toFixed(1)}K`;
-    }
-    return `$${amount.toFixed(0)}`;
-  };
-
-  const getPriceChangeColor = (change: number) => {
-    if (change > 0) return "var(--neon-green)";
-    if (change < 0) return "var(--neon-pink)";
-    return "#94a3b8";
-  };
-
-  // Load data
-  useEffect(() => {
-    async function loadPrice() {
-      try {
-        // Step 1: First, try to load today's daily price from historical data (fast, cached on backend)
-        // This gives us immediate price data without waiting for CoinGecko
-        // Only fetch the selected currency first for instant display
-        try {
-          const historicalData = await SuperheroApi.getHistoricalPrice(selectedCurrency, 1, 'daily');
-          if (historicalData && Array.isArray(historicalData) && historicalData.length > 0) {
-            // Get the latest price point (last item in array)
-            const latestPrice = historicalData[historicalData.length - 1];
-            if (Array.isArray(latestPrice) && latestPrice.length >= 2) {
-              const price = latestPrice[1];
-              
-              // Update prices immediately with quick data for selected currency
-              setPrices((prevPrices) => {
-                const quickPriceData: any = {
-                  usd: prevPrices?.usd ?? null,
-                  eur: prevPrices?.eur ?? null,
-                  cny: prevPrices?.cny ?? null,
-                  [selectedCurrency]: price,
-                };
-                
-                // Preserve existing market stats
-                quickPriceData.change24h = prevPrices?.change24h ?? null;
-                quickPriceData.marketCap = prevPrices?.marketCap ?? null;
-                quickPriceData.volume24h = prevPrices?.volume24h ?? null;
-                
-                return quickPriceData;
-              });
-            }
-          }
-        } catch (error) {
-          if (process.env.NODE_ENV === 'development') {
-            console.warn("Failed to load quick historical price:", error);
-          }
-        }
-
-        // Step 2: Fetch current currency rates and market data asynchronously (may hit CoinGecko)
-        // This updates with the latest data in the background
-        const [ratesResult, marketDataResult] = await Promise.allSettled([
-          SuperheroApi.getCurrencyRates(),
-          SuperheroApi.getMarketData(selectedCurrency),
-        ]);
-
-        const rates = ratesResult.status === 'fulfilled' ? ratesResult.value : null;
-        const marketData = marketDataResult.status === 'fulfilled' ? marketDataResult.value : null;
-
-        // Log errors for failed requests
-        if (ratesResult.status === 'rejected') {
-          console.error("Failed to load currency rates:", ratesResult.reason);
-        } else if (ratesResult.status === 'fulfilled' && rates === null) {
-          if (process.env.NODE_ENV === 'development') {
-            console.warn("Currency rates API returned empty response");
-          }
-        }
-        
-        if (marketDataResult.status === 'rejected') {
-          console.error("Failed to load market data:", marketDataResult.reason);
-        } else if (marketDataResult.status === 'fulfilled' && marketData === null) {
-          if (process.env.NODE_ENV === 'development') {
-            console.warn("Market data API returned empty response");
-          }
-        }
-
-        // Update sparklines whenever rates are available (regardless of marketData)
-        if (rates) {
-          if (rates.usd != null) {
-            setUsdSpark((prev) => {
-              const next = [...prev, Number(rates.usd)].slice(-50);
-              sessionStorage.setItem("ae_spark_usd", JSON.stringify(next));
-              return next;
-            });
-          }
-
-          if (rates.eur != null) {
-            setEurSpark((prev) => {
-              const next = [...prev, Number(rates.eur)].slice(-50);
-              sessionStorage.setItem("ae_spark_eur", JSON.stringify(next));
-              return next;
-            });
-          }
-        }
-
-        // Update price data, preserving existing market stats when marketData fails
-        // Use API rates if available, otherwise fallback to latest sparkline value
-        setPrices((prevPrices) => {
-          const priceData: any = {
-            usd: rates?.usd ?? null,
-            eur: rates?.eur ?? null,
-            cny: rates?.cny ?? null,
-          };
-
-          // Fallback to sparkline data if API rates are null but we have sparkline data
-          // Read from sessionStorage to get the most current values
-          if (!priceData.usd) {
-            try {
-              const usdSparkData = sessionStorage.getItem("ae_spark_usd");
-              if (usdSparkData) {
-                const usdSparkArray = JSON.parse(usdSparkData);
-                if (Array.isArray(usdSparkArray) && usdSparkArray.length > 0) {
-                  priceData.usd = usdSparkArray[usdSparkArray.length - 1];
-                }
-              }
-            } catch {
-              // Ignore errors reading sparkline data
-            }
-          }
-          
-          if (!priceData.eur) {
-            try {
-              const eurSparkData = sessionStorage.getItem("ae_spark_eur");
-              if (eurSparkData) {
-                const eurSparkArray = JSON.parse(eurSparkData);
-                if (Array.isArray(eurSparkArray) && eurSparkArray.length > 0) {
-                  priceData.eur = eurSparkArray[eurSparkArray.length - 1];
-                }
-              }
-            } catch {
-              // Ignore errors reading sparkline data
-            }
-          }
-
-          // Only update market stats if marketData is available
-          // Otherwise preserve existing values to prevent overwriting with null
-          if (marketData) {
-            priceData.change24h = marketData.priceChangePercentage24h || 
-                                  marketData.price_change_percentage_24h || 
-                                  null;
-            priceData.marketCap = marketData.marketCap || 
-                                 marketData.market_cap || 
-                                 null;
-            priceData.volume24h = marketData.totalVolume || 
-                                 marketData.total_volume || 
-                                 null;
-          } else {
-            // Preserve existing market stats when marketData fails
-            priceData.change24h = prevPrices?.change24h ?? null;
-            priceData.marketCap = prevPrices?.marketCap ?? null;
-            priceData.volume24h = prevPrices?.volume24h ?? null;
-          }
-
-          // Only update if we have at least one currency price
-          if (priceData.usd != null || priceData.eur != null || priceData.cny != null) {
-            // Cache the price data
-            try {
-              sessionStorage.setItem("ae_prices", JSON.stringify({
-                data: priceData,
-                timestamp: Date.now(),
-              }));
-            } catch {
-              // Ignore cache errors
-            }
-            return priceData;
-          }
-
-          // Return previous prices if no new data available
-          return prevPrices;
-        });
-      } catch (error) {
-        console.error("Failed to load price data:", error);
-        // On error, try to use cached data or sparkline fallback
-        setPrices((prevPrices) => {
-          if (prevPrices) return prevPrices;
-          
-          // Fallback to sparkline data if available
-          const fallbackData: any = {};
-          try {
-            const usdSparkData = sessionStorage.getItem("ae_spark_usd");
-            if (usdSparkData) {
-              const usdSparkArray = JSON.parse(usdSparkData);
-              if (Array.isArray(usdSparkArray) && usdSparkArray.length > 0) {
-                fallbackData.usd = usdSparkArray[usdSparkArray.length - 1];
-              }
-            }
-          } catch {
-            // Ignore errors
-          }
-          
-          try {
-            const eurSparkData = sessionStorage.getItem("ae_spark_eur");
-            if (eurSparkData) {
-              const eurSparkArray = JSON.parse(eurSparkData);
-              if (Array.isArray(eurSparkArray) && eurSparkArray.length > 0) {
-                fallbackData.eur = eurSparkArray[eurSparkArray.length - 1];
-              }
-            }
-          } catch {
-            // Ignore errors
-          }
-          
-          if (fallbackData.usd != null || fallbackData.eur != null) {
-            return fallbackData;
-          }
-          
-          return null;
-        });
-      }
-    }
-
-    loadPrice();
-    const t = window.setInterval(loadPrice, 30000);
-    return () => {
-      window.clearInterval(t);
-    };
-  }, [selectedCurrency]);
 
   return (
     <div id="right-rail-root" className="grid gap-4 h-fit min-w-0 scrollbar-thin scrollbar-track-white/[0.02] scrollbar-thumb-gradient-to-r scrollbar-thumb-from-pink-500/60 scrollbar-thumb-via-[rgba(0,255,157,0.6)] scrollbar-thumb-to-pink-500/60 scrollbar-thumb-rounded-[10px] scrollbar-thumb-border scrollbar-thumb-border-white/10 hover:scrollbar-thumb-from-pink-500/80 hover:scrollbar-thumb-via-[rgba(0,255,157,0.8)] hover:scrollbar-thumb-to-pink-500/80">
@@ -351,7 +95,7 @@ export default function RightRail({
                       ? "bg-[var(--neon-teal)] text-white border-[var(--neon-teal)]"
                       : "text-[var(--light-font-color)]"
                   }`}
-                  onClick={() => setSelectedCurrency(currency)}
+                  onClick={() => setCurrentCurrency(currency as any)}
                 >
                   {currency.toUpperCase()}
                 </button>
@@ -368,23 +112,11 @@ export default function RightRail({
                     : "-"}
                 </div>
                 <div className="text-xs font-semibold">
-                  {prices?.change24h && (
-                    <span
-                      style={{ color: getPriceChangeColor(prices.change24h) }}
-                    >
-                      {prices.change24h > 0 ? "+" : ""}
-                      {prices.change24h.toFixed(2)}% (24h)
-                    </span>
-                  )}
+                  {/* 24h stats removed: market-data endpoint is not available right now */}
                 </div>
               </div>
               <div className="flex-shrink-0">
-                <Sparkline
-                  points={selectedCurrency === "usd" ? usdSpark : eurSpark}
-                  width={80}
-                  height={24}
-                  stroke={selectedCurrency === "usd" ? "#66d19e" : "#5bb0ff"}
-                />
+                {/* Sparkline removed: AE price is now globally polled via AePricePollingProvider */}
               </div>
             </div>
 
@@ -394,7 +126,7 @@ export default function RightRail({
                   Market Cap
                 </span>
                 <span className="text-[11px] text-[var(--standard-font-color)] font-semibold">
-                  {prices?.marketCap ? formatMarketCap(prices.marketCap) : "-"}
+                  -
                 </span>
               </div>
               <div className="flex justify-between items-center py-2 border-b border-white/5 last:border-b-0">
@@ -402,7 +134,7 @@ export default function RightRail({
                   24h Volume
                 </span>
                 <span className="text-[11px] text-[var(--standard-font-color)] font-semibold">
-                  {prices?.volume24h ? formatMarketCap(prices.volume24h) : "-"}
+                  -
                 </span>
               </div>
             </div>

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export type AppConfig = {
 };
 
 const defaultConfig: AppConfig = {
-  BACKEND_URL: "https://raendom-backend.z52da5wt.xyz",
+  BACKEND_URL: "https://api.superhero.com",
   SUPERHERO_API_URL: "https://api.superhero.com",
   SUPERHERO_WS_URL: "https://api.superhero.com",
   NODE_URL: "https://mdw.wordcraft.fun",

--- a/src/context/AePricePollingProvider.tsx
+++ b/src/context/AePricePollingProvider.tsx
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSetAtom } from 'jotai';
+import { PropsWithChildren } from 'react';
+
+import { SuperheroApi } from '@/api/backend';
+import { currencyRatesAtom, currencyRatesLastErrorAtAtom, currencyRatesUpdatedAtAtom } from '@/atoms/currencyAtoms';
+import type { CurrencyRates } from '@/utils/types';
+
+/**
+ * Polls AE->fiat conversion rates globally (once) and stores them in Jotai.
+ * This prevents multiple components from each starting their own polling loop.
+ */
+export function AePricePollingProvider({ children }: PropsWithChildren) {
+  const setCurrencyRates = useSetAtom(currencyRatesAtom);
+  const setUpdatedAt = useSetAtom(currencyRatesUpdatedAtAtom);
+  const setLastErrorAt = useSetAtom(currencyRatesLastErrorAtAtom);
+
+  const normalizeRates = (raw: any): CurrencyRates | null => {
+    if (!raw || typeof raw !== 'object') return null;
+    const out: Record<string, number> = {};
+    for (const [k, v] of Object.entries(raw)) {
+      const key = String(k).toLowerCase();
+      const num = typeof v === 'number' ? v : v == null ? NaN : Number(v);
+      if (Number.isFinite(num)) out[key] = num;
+    }
+    return Object.keys(out).length ? (out as CurrencyRates) : null;
+  };
+
+  useQuery({
+    queryKey: ['currency-rates'],
+    queryFn: async () => {
+      try {
+        const raw = await SuperheroApi.getCurrencyRates();
+        const rates = normalizeRates(raw);
+        if (!rates) throw new Error('Invalid currency rates response');
+
+        setCurrencyRates(rates);
+        setUpdatedAt(Date.now());
+        // Clear error marker on success
+        setLastErrorAt(0);
+        return rates;
+      } catch (e) {
+        setLastErrorAt(Date.now());
+        throw e;
+      }
+    },
+    staleTime: 20_000,
+    refetchInterval: 20_000,
+    // Prevent extra refetches during route changes / tab focus.
+    // We want a single global poller on a fixed interval.
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchIntervalInBackground: true,
+    retry: 1,
+  });
+
+  return children as any;
+}
+
+

--- a/src/features/shared/components/PriceDataFormatter.tsx
+++ b/src/features/shared/components/PriceDataFormatter.tsx
@@ -65,7 +65,7 @@ export default function PriceDataFormatter({
     return bignumber
       ? Decimal.from(toAe(priceData[currentCurrencyCode]))
       : Decimal.from(priceData[currentCurrencyCode]);
-  }, [priceData, currentCurrencyCode, bignumber]);
+  }, [priceData, currentCurrencyCode, bignumber, getFiat]);
 
   return (
     <PriceFormatter

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 import ToastProvider from './components/ToastProvider';
 import { AeSdkProvider } from './context/AeSdkProvider';
+import { AePricePollingProvider } from './context/AePricePollingProvider';
 import './i18n';
 import './styles/base.scss';
 import './styles/tailwind.css';
@@ -39,15 +40,17 @@ const queryClient = new QueryClient({
         </Helmet>
         <QueryClientProvider client={queryClient}>
           <Provider>
-            <ToastProvider>
-              <BrowserRouter>
-                <ErrorBoundary>
-                  <AeSdkProvider>
-                    <App />
-                  </AeSdkProvider>
-                </ErrorBoundary>
-              </BrowserRouter>
-            </ToastProvider>
+            <AePricePollingProvider>
+              <ToastProvider>
+                <BrowserRouter>
+                  <ErrorBoundary>
+                    <AeSdkProvider>
+                      <App />
+                    </AeSdkProvider>
+                  </ErrorBoundary>
+                </BrowserRouter>
+              </ToastProvider>
+            </AePricePollingProvider>
           </Provider>
         </QueryClientProvider>
       </HelmetProvider>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -46,6 +46,11 @@ export const AETERNITY_TOKEN_BASE_DATA = {
       symbol: '€',
     },
     {
+      name: 'Chinese Yuan',
+      code: 'cny',
+      symbol: '¥',
+    },
+    {
       name: 'Australia Dollar',
       code: 'aud',
       symbol: 'AU$',

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -60,6 +60,7 @@ export interface Wallets {
 export type CurrencyCode =
   | "usd"
   | "eur"
+  | "cny"
   | "aud"
   | "brl"
   | "cad"


### PR DESCRIPTION
fixes https://github.com/superhero-com/superhero/issues/392,
fixes https://github.com/superhero-com/superhero/issues/394,
fixes https://github.com/superhero-com/superhero/issues/335


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies and fixes fiat pricing across the app by polling AE→fiat rates once and sharing them via Jotai.
> 
> - **Global polling**: New `AePricePollingProvider` polls `GET /api/coins/aeternity/rates` every 20s and stores rates in `currencyRatesAtom` with `updatedAt`/`lastErrorAt` markers
> - **Footer**: Derives backend status from shared rates freshness/error signals instead of issuing its own requests
> - **Right rail**: Uses `useCurrencies` for prices and currency switching; removes local polling, sparklines, and 24h market stats placeholders remain
> - **Hook cleanup**: `useCurrencies` relies on global rates (adds imperative fallback), keeps formatting helpers, and limits switching to `usd|eur|cny`
> - **Currency support**: Adds `cny` to `CURRENCIES` and `CurrencyCode`
> - **Config**: Sets `BACKEND_URL` to `https://api.superhero.com`
> - **API cleanup**: Removes unused mock fetch utilities and the historical price endpoint; retains `getCurrencyRates`/`getMarketData`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5810db2d9f9000f568bc7f7cb5ef7c99eb8f6c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->