### PR TITLE
fix: connect wallet correctly

### DIFF
--- a/src/context/AeSdkProvider.tsx
+++ b/src/context/AeSdkProvider.tsx
@@ -46,7 +46,7 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
     const [currentBlockHeight, setCurrentBlockHeight] = useState<number | null>(null);
     const [activeNetwork, setActiveNetwork] = useState<INetwork>(NETWORK_MAINNET);
     const [transactionsQueue, setTransactionsQueue] = useAtom(transactionsQueueAtom);
-    const [walletInfo] = useAtom(walletInfoAtom);
+    const [walletInfo, setWalletInfo] = useAtom(walletInfoAtom);
     const transactionsQueueRef = useRef(transactionsQueue);
     const activeAccountRef = useRef<string | undefined>(activeAccount);
     const generationPollIntervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -120,6 +120,8 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
                 }
             },
             onDisconnect: () => {
+                // walletInfoAtom is persisted; clear it so polling can't "resurrect" connection state after disconnect
+                setWalletInfo(undefined);
                 setActiveAccount(undefined);
                 setAccounts([]);
             },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens wallet connection lifecycle and prevents stale reconnections.
> 
> - Adds periodic 1s polling in `AeSdkProvider` to detect `activeAccount` changes via SDK state; updates atoms accordingly
> - Clears persisted `walletInfo` in `onDisconnect` to avoid rehydrating stale connection state
> - Introduces robust cleanup for wallet detection: store `walletDetector` stop fn and `BrowserWindowMessageConnection`; disconnect/stop on unmount and on explicit disconnect
> - Makes wallet scanning concurrency-safe by reusing an in-flight scan promise and centralizing cleanup/timeout handling
> - Replaces SDK const-enum with string literal for `subscribeAddress` to resolve TS isolatedModules issue
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ff0b91337f74c16a7aa683a294cf803e3ae84ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->