### PR TITLE
fix(invitations): detect revoke_invitation_code tx and keep status stable

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -89,6 +89,7 @@ export const AETERNITY_TOKEN_BASE_DATA = {
     sell: "sell",
     create_community: "create_community",
     register_invitation_code: "register_invitation_code",
+    revoke_invitation_code: "revoke_invitation_code",
     redeem_invitation_code: "redeem_invitation_code",
 
     transfer: "transfer",


### PR DESCRIPTION
Fix https://github.com/superhero-com/superhero/issues/252

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Detects `revoke_invitation_code` transactions** in `useInvitations` by matching `TX_FUNCTIONS.revoke_invitation_code` and robustly parsing argument shapes (single `address` or `list` of addresses)
> - Keeps status stable by combining middleware detection with `recentlyRevokedInvitations`
> - **Triggers a refresh** after `revokeInvitation` to surface on-chain updates promptly
> - Adds `revoke_invitation_code` to `TX_FUNCTIONS` in `constants.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9c1a28e00641fabe080d3f0eeeb58298778c7b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->