### PR TITLE
fix(bridge): show 6-decimal balances and compute max with gas reserve

### DIFF
--- a/src/features/ae-eth-bridge/hooks/useTokenBalances.ts
+++ b/src/features/ae-eth-bridge/hooks/useTokenBalances.ts
@@ -107,7 +107,7 @@ export function useTokenBalances({ assets, direction, aeAccount, ethAccount, sdk
                 const balance = await provider.getBalance(userAddress);
                 const balanceFormatted = new BigNumber(balance.toString())
                   .shiftedBy(-18)
-                  .toFixed(4);
+                  .toFixed(6, BigNumber.ROUND_DOWN);
                 newEthBalances[asset.symbol] = balanceFormatted;
               } else {
                 // ERC-20 token
@@ -127,7 +127,7 @@ export function useTokenBalances({ assets, direction, aeAccount, ethAccount, sdk
                   const balance = await Promise.race([balancePromise, timeoutPromise]);
                   const balanceFormatted = new BigNumber(balance.toString())
                     .shiftedBy(-asset.decimals)
-                    .toFixed(4);
+                    .toFixed(6, BigNumber.ROUND_DOWN);
                   newEthBalances[asset.symbol] = balanceFormatted;
                 } catch (error) {
                   console.error(`Error fetching balance for ${asset.symbol}:`, error);
@@ -204,7 +204,7 @@ export function useTokenBalances({ assets, direction, aeAccount, ethAccount, sdk
               const balance = await getTokenBalance(currentSdk, 'AE', currentAeAccount as `ak_${string}`);
               const balanceFormatted = new BigNumber(balance.toString())
                 .shiftedBy(-18)
-                .toFixed(4);
+                .toFixed(6, BigNumber.ROUND_DOWN);
               newAeBalances[asset.symbol] = balanceFormatted;
             } else {
               // AEX-9 token - check middleware first, fallback to contract call
@@ -213,7 +213,7 @@ export function useTokenBalances({ assets, direction, aeAccount, ethAccount, sdk
                 // Use middleware data
                 const balanceFormatted = new BigNumber(middlewareBalance.amount)
                   .shiftedBy(-middlewareBalance.decimals)
-                  .toFixed(4);
+                  .toFixed(6, BigNumber.ROUND_DOWN);
                 newAeBalances[asset.symbol] = balanceFormatted;
               } else {
                 // Fallback to contract call for tokens not in middleware
@@ -221,7 +221,7 @@ export function useTokenBalances({ assets, direction, aeAccount, ethAccount, sdk
                   const balance = await getTokenBalance(currentSdk, asset.aeAddress, currentAeAccount as `ak_${string}`);
                   const balanceFormatted = new BigNumber(balance.toString())
                     .shiftedBy(-asset.decimals)
-                    .toFixed(4);
+                    .toFixed(6, BigNumber.ROUND_DOWN);
                   newAeBalances[asset.symbol] = balanceFormatted;
                 } catch (contractError) {
                   console.warn(`Contract call failed for ${asset.symbol}, setting balance to 0:`, contractError);
@@ -246,13 +246,13 @@ export function useTokenBalances({ assets, direction, aeAccount, ethAccount, sdk
                 const balance = await getTokenBalance(currentSdk, 'AE', currentAeAccount as `ak_${string}`);
                 const balanceFormatted = new BigNumber(balance.toString())
                   .shiftedBy(-18)
-                  .toFixed(4);
+                  .toFixed(6, BigNumber.ROUND_DOWN);
                 newAeBalances[asset.symbol] = balanceFormatted;
               } else {
                 const balance = await getTokenBalance(currentSdk, asset.aeAddress, currentAeAccount as `ak_${string}`);
                 const balanceFormatted = new BigNumber(balance.toString())
                   .shiftedBy(-asset.decimals)
-                  .toFixed(4);
+                  .toFixed(6, BigNumber.ROUND_DOWN);
                 newAeBalances[asset.symbol] = balanceFormatted;
               }
             } catch (fallbackError) {

--- a/src/features/ae-eth-bridge/services/ethplorer.ts
+++ b/src/features/ae-eth-bridge/services/ethplorer.ts
@@ -85,7 +85,7 @@ export function getTokenBalanceFromEthplorer(
   // Check if it's native ETH
   if (isNativeEth) {
     const ethBalance = ethplorerData.ETH?.balance || 0;
-    return new BigNumber(ethBalance).toFixed(4);
+    return new BigNumber(ethBalance).toFixed(6, BigNumber.ROUND_DOWN);
   }
   
   // Find the token in the tokens array
@@ -100,7 +100,7 @@ export function getTokenBalanceFromEthplorer(
   // Convert raw balance to formatted balance using token decimals
   const balance = new BigNumber(token.rawBalance)
     .shiftedBy(-decimals)
-    .toFixed(4);
+    .toFixed(6, BigNumber.ROUND_DOWN);
     
   return balance;
 }


### PR DESCRIPTION
Fix https://github.com/superhero-com/superhero/issues/237

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves balance precision and Max amount handling for the AE↔ETH bridge.
> 
> - Balances now use 6-decimal precision rounded down across ETH, ERC‑20, AE, and AEX‑9 sources (`useTokenBalances`, `ethplorer` helpers)
> - Adds a gas-aware `Max` for native ETH when bridging Ethereum→æternity: estimates `bridge_out` gas, applies safety buffer, and subtracts from wallet balance (`AeEthBridge.tsx`)
> - Introduces `maxBusy` state and disables Max while loading; updates balance text gating based on active account
> - Uses `effectiveEthAccount` for balance fetching and fixes hook dependencies; adds `AETERNITY_FUNDS_ADDRESS` fallback for gas estimation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcefa9fc9083cbaa5e192a622aa9e6339e8ea64b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->