### PR TITLE
feat: add validation error messages for bridge and buy ae screens

### DIFF
--- a/src/utils/balance.ts
+++ b/src/utils/balance.ts
@@ -1,0 +1,18 @@
+import BigNumber from 'bignumber.js';
+
+/**
+ * Compare human-readable decimal strings safely (no JS float rounding).
+ * Returns false if inputs are empty/invalid.
+ */
+export function isAmountGreaterThanBalance(amount: string, balance: string): boolean {
+  if (!amount) return false;
+
+  const a = new BigNumber(amount);
+  const b = new BigNumber(balance || '0');
+
+  if (!a.isFinite() || a.isNaN() || !b.isFinite() || b.isNaN()) return false;
+
+  return a.gt(b);
+}
+
+


### PR DESCRIPTION
Fix https://github.com/superhero-com/superhero/issues/255

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces user-facing balance protection and clearer errors across bridge and buy flows.
> 
> - Adds `isAmountGreaterThanBalance` in `utils/balance.ts` for precise decimal comparisons
> - Bridge (`AeEthBridge.tsx`)
>   - Computes `hasInsufficientBalance` from live token balances and shows an inline “Insufficient balance” banner
>   - Disables the bridge button when amount > available balance
> - Buy AE (`BuyAeWidget.tsx`)
>   - Estimates gas via `ethers` `Contract` to derive ETH `ethSpendable` and shows it in balance text `(max: ...)`
>   - Updates `Max` to use gas-aware spendable and rounds down to avoid exceeding funds
>   - Adds insufficient-balance check with inline banner and integrates it into button disabling
>   - Minor balance fetch/cleanup tweaks when wallets connect/disconnect
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cd0bdb3556545972584bcbc723ea64ecdff37b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->