### PR TITLE
fix: improve trends menu clickability and highlight invite and earn button in the trends page

### DIFF
--- a/src/components/layout/app-header/WebAppHeader.tsx
+++ b/src/components/layout/app-header/WebAppHeader.tsx
@@ -5,7 +5,6 @@ import { HeaderLogo } from '../../../icons';
 import HeaderWalletButton from './HeaderWalletButton';
 import { getNavigationItems } from './navigationItems';
 
-
 export default function WebAppHeader() {
   const { t: tNav } = useTranslation('navigation');
   const { t } = useTranslation('common');
@@ -38,8 +37,6 @@ export default function WebAppHeader() {
     return pathname.startsWith(path);
   };
 
-  // Dropdown menus removed; show only top-level links
-
   return (
     <header className="sticky top-0 z-[1000] hidden md:block border-b" style={{ 
       backgroundColor: 'rgba(12, 12, 20, 0.5)',
@@ -59,44 +56,29 @@ export default function WebAppHeader() {
             .map((item: any) => {
               const commonClass = `no-underline font-medium px-3 py-2 rounded-lg transition-all duration-200 relative`;
 
-              // Special: add dropdown for Trends only
-              const isTrendsWithChildren = item.id === 'trending' && Array.isArray(item.children) && item.children.length > 0;
+              // For Trends: render as simple link (no dropdown)
+              const isTrends = item.id === 'trending';
 
-              if (isTrendsWithChildren) {
+              if (isTrends) {
+                const isActive = isActiveRoute(item.path);
                 return (
-                  <div key={item.id} className="relative group">
-                    <Link
-                      to={item.path}
-                      className={commonClass}
-                      style={{
-                        color: isActiveRoute(item.path) ? 'var(--custom-links-color)' : 'var(--light-font-color)',
-                        backgroundColor: isActiveRoute(item.path) ? 'rgba(0,255,157,0.1)' : 'transparent',
-                      }}
-                    >
-                      {item.label}
-                      <span className="ml-1">▾</span>
-                      {isActiveRoute(item.path) && (
-                        <span 
-                          className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 w-5 h-0.5 rounded-sm"
-                          style={{ backgroundColor: 'var(--custom-links-color)' }}
-                        />
-                      )}
-                    </Link>
-
-                    {/* Dropdown */}
-                    <div className="hidden group-hover:block absolute left-0 top-full mt-2 min-w-[220px] rounded-xl border border-white/10 bg-[var(--background-color)] shadow-[0_12px_32px_rgba(0,0,0,0.35)] py-2 z-[1001]">
-                      {item.children.map((child: any) => (
-                        <Link
-                          key={child.id}
-                          to={child.path}
-                          className="no-underline flex items-center gap-2 px-4 py-2 text-[var(--light-font-color)] hover:text-[var(--standard-font-color)] hover:bg-white/10"
-                        >
-                          <span className="w-5 text-center">{child.icon}</span>
-                          <span className="text-sm font-medium">{child.label}</span>
-                        </Link>
-                      ))}
-                    </div>
-                  </div>
+                  <Link
+                    key={item.id}
+                    to={item.path}
+                    className={commonClass}
+                    style={{
+                      color: isActive ? 'var(--custom-links-color)' : 'var(--light-font-color)',
+                      backgroundColor: isActive ? 'rgba(0,255,157,0.1)' : 'transparent',
+                    }}
+                  >
+                    {item.label}
+                    {isActive && (
+                      <span 
+                        className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 w-5 h-0.5 rounded-sm"
+                        style={{ backgroundColor: 'var(--custom-links-color)' }}
+                      />
+                    )}
+                  </Link>
                 );
               }
 
@@ -162,8 +144,8 @@ export default function WebAppHeader() {
             })}
         </nav>
 
-        {/* Right area lives inside the boxed header container */}
-        <div className="ml-auto flex items-center gap-4 justify-end">
+        {/* Right area: Wallet button */}
+        <div className="ml-auto flex items-center gap-3 justify-end">
           <HeaderWalletButton />
         </div>
       </div>

--- a/src/features/trending/components/TrendminerBanner.tsx
+++ b/src/features/trending/components/TrendminerBanner.tsx
@@ -36,17 +36,61 @@ export default function TrendminerBanner() {
                 >
                   EXPLORE DAOS
                 </AeButton>
-                <AeButton
-                  variant="ghost"
-                  size="md"
-                  rounded
-                  onClick={() =>
-                    (window.location.href = "/trends/invite")
-                  }
-                  className="bg-gradient-to-r from-slate-600 to-slate-700 hover:from-slate-500 hover:to-slate-600 border-0 shadow-lg hover:shadow-xl transition-all duration-300"
+                {/* Highlighted Invite & Earn Button */}
+                <button
+                  onClick={() => (window.location.href = "/trends/invite")}
+                  className="group relative px-5 py-2.5 rounded-xl font-bold text-sm uppercase tracking-wide overflow-hidden transition-all duration-300 hover:scale-105 hover:-translate-y-0.5"
+                  style={{
+                    background: 'linear-gradient(135deg, #fbbf24 0%, #f59e0b 50%, #d97706 100%)',
+                    boxShadow: '0 0 25px rgba(251, 191, 36, 0.4), 0 4px 15px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.3)',
+                    color: '#000',
+                    border: '1px solid rgba(255,255,255,0.2)',
+                  }}
                 >
-                  INVITE & EARN
-                </AeButton>
+                  {/* Animated shimmer effect */}
+                  <span 
+                    className="absolute inset-0 opacity-60"
+                    style={{
+                      background: 'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.5) 50%, transparent 100%)',
+                      animation: 'invite-shimmer 2.5s ease-in-out infinite',
+                    }}
+                  />
+                  {/* Pulse glow behind */}
+                  <span 
+                    className="absolute -inset-1 rounded-xl -z-10"
+                    style={{
+                      background: 'linear-gradient(135deg, #fbbf24, #f59e0b)',
+                      filter: 'blur(12px)',
+                      opacity: 0.6,
+                      animation: 'invite-pulse 2s ease-in-out infinite',
+                    }}
+                  />
+                  {/* Content */}
+                  <span className="relative z-10 flex items-center gap-2">
+                    <span className="text-base">🎁</span>
+                    <span>INVITE & EARN</span>
+                    <span 
+                      className="ml-1 px-1.5 py-0.5 text-[10px] font-bold rounded-full"
+                      style={{
+                        background: 'rgba(0,0,0,0.25)',
+                        color: '#fff',
+                      }}
+                    >
+                      AE
+                    </span>
+                  </span>
+                </button>
+                {/* Animations for the button */}
+                <style>{`
+                  @keyframes invite-shimmer {
+                    0% { transform: translateX(-100%); }
+                    50%, 100% { transform: translateX(100%); }
+                  }
+                  @keyframes invite-pulse {
+                    0%, 100% { opacity: 0.4; transform: scale(1); }
+                    50% { opacity: 0.7; transform: scale(1.02); }
+                  }
+                `}</style>
               </div>
 
             </div>


### PR DESCRIPTION
Fix #152 

Solution: 

1. Simplified Trends navigation - Removed the dropdown, making "Trends" a simple clickable link like "Social" and "DeFi"
2. Relocated Invite & Earn - Removed from global header, keeping it only on the Trends page where it belongs
3. Highlighted the button - Enhanced "Invite & Earn" on the Trends page with:
      Golden gradient (amber → orange)
      Animated shimmer effect
      Pulsing glow
      Gift emoji + "AE" badge
      
      

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Streamlines navigation and emphasizes the invite CTA.
> 
> - **Navigation:** `trending` is now a simple top-level link (no dropdown); active-state styling retained in `WebAppHeader.tsx`.
> - **Trends page CTA:** Replaces `AeButton` for `INVITE & EARN` with a custom, animated gradient button (shimmer + pulse, emoji + `AE` badge) in `TrendminerBanner.tsx`; keeps existing create/explore buttons.
> - *Minor:* Adjusted header right-side spacing around the wallet button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7d8f606eafafa499b866e0fe2dc44e81fec7d3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->