### PR TITLE
fix: show correct status of the invitation links with new details

### DIFF
--- a/src/atoms/invitationAtoms.ts
+++ b/src/atoms/invitationAtoms.ts
@@ -20,6 +20,9 @@ export interface InvitationStatus {
   revokedAt?: string;
   revokeTxHash?: string;
   claimed: boolean;
+  claimedBy?: string; // Address of the user who claimed the invite
+  claimedAt?: string; // When the invite was claimed
+  claimTxHash?: string; // Transaction hash of the claim
   secretKey?: string;
 }
 
@@ -29,8 +32,13 @@ export const invitationListAtom = atomWithStorage<InvitationInfo[]>('invite_list
 // Current invitation code from URL
 export const invitationCodeAtom = atomWithStorage<string | undefined>('invite_code', undefined);
 
-// Claimed invitations cache
-export const claimedInvitationsAtom = atom<Record<string, boolean>>({});
+// Claimed invitations cache - stores claimer info
+export interface ClaimedInfo {
+  claimedBy: string;
+  claimedAt?: number;
+  claimTxHash?: string;
+}
+export const claimedInvitationsAtom = atom<Record<string, ClaimedInfo | boolean>>({});
 
 // Recently revoked invitations (for optimistic UI updates)
 export const recentlyRevokedInvitationsAtom = atom<string[]>([]);


### PR DESCRIPTION
Fix https://github.com/superhero-com/superhero/issues/313

- Show "Awaiting claim" for pending invites with copyable invite link
- Show "Revoked" status for revoked invites
- Embed copyable link directly in details (chip style, no dialog)

New design
<img width="1344" height="487" alt="Screenshot 2026-01-12 at 4 16 37 PM" src="https://github.com/user-attachments/assets/dfef069f-702f-405a-839a-32fd59b30437" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves invitation status handling and UI with inline copy links and claimer metadata.
> 
> - Extends `InvitationStatus` and `claimedInvitationsAtom` to store claimer details (`claimedBy`, `claimedAt`, `claimTxHash`), adding `ClaimedInfo`
> - Updates `useInvitations` to parse redeem transactions for claimer address, format dates, and compute accurate statuses; prepares shareable invite links
> - Refactors `InvitationList` to display contextual details: "Awaiting claim" with inline copyable link, "Revoked" with timestamp, and "Claimed" showing claimer address and claim time; removes dialog and limits actions to Revoke
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1359bfed79ba76e695fac9b2b1eb0a7b4bbcb0a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->