### PR TITLE
refactor: change trending assets panel appearing

### DIFF
--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -1064,7 +1064,7 @@ export default function FeedList({
     let i = 0;
     let renderedCount = 0;
     const rng = createSeededRandom(trendingInsertSeed.current);
-    let nextInsertAt = 5;
+    let nextInsertAt = 2;
 
     const maybeInsertTrending = () => {
       if (renderedCount === nextInsertAt) {
@@ -1180,7 +1180,7 @@ export default function FeedList({
     const nodes: React.ReactNode[] = [];
     let renderedCount = 0;
     const rng = createSeededRandom(trendingInsertSeed.current);
-    let nextInsertAt = 5;
+    let nextInsertAt = 2;
 
     const maybeInsertTrending = () => {
       if (renderedCount === nextInsertAt) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes the trending assets panel appear sooner in both feeds.
> 
> - In `FeedList.tsx`, initialize `nextInsertAt` to `2` (was `5`) in both `renderFeedItems` and `renderHotFeedItems`, causing `TrendingAssetsFeedItem` to be inserted earlier while keeping the subsequent randomized step logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40bbb83f518d11b4dbd27db44b9f2d0f5f9d9061. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->