### PR TITLE
Release

### DIFF
--- a/src/components/layout/app-header/MobileAppHeader.tsx
+++ b/src/components/layout/app-header/MobileAppHeader.tsx
@@ -141,7 +141,7 @@ export default function MobileAppHeader() {
   };
 
   return (
-    <div className="z-[1100] fixed top-0 left-0 right-0 w-full md:hidden pt-[env(safe-area-inset-top)] h-[calc(var(--mobile-navigation-height)+env(safe-area-inset-top))] border-b" style={{
+    <div className="z-[1100] fixed top-0 left-0 right-0 w-full lg:hidden pt-[env(safe-area-inset-top)] h-[calc(var(--mobile-navigation-height)+env(safe-area-inset-top))] border-b" style={{
       backgroundColor: 'rgba(12, 12, 20, 0.5)',
       backdropFilter: 'blur(12px)',
       WebkitBackdropFilter: 'blur(12px)',

--- a/src/components/layout/app-header/MobileNavigation.tsx
+++ b/src/components/layout/app-header/MobileNavigation.tsx
@@ -1,18 +1,22 @@
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import SearchInput from '../../SearchInput';
 import { HeaderLogo, IconSearch, IconMobileMenu } from '../../../icons';
 import HeaderWalletButton from './HeaderWalletButton';
+import { getNavigationItems } from './navigationItems';
 
 export default function MobileNavigation() {
   const [showOverlay, setShowOverlay] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
+  const { t: tNav } = useTranslation('navigation');
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     const t = (document.documentElement.dataset.theme as 'light' | 'dark' | undefined) || 'dark';
     return t;
   });
   const { pathname } = useLocation();
   const isOnFeed = pathname === '/';
+  const navigationItems = getNavigationItems(tNav);
 
   const handleSearchToggle = () => {
     setShowSearch(!showSearch);
@@ -33,8 +37,22 @@ export default function MobileNavigation() {
     setShowSearch(false);
   };
 
+  const activeNavPath = React.useMemo(() => {
+    const matches = navigationItems
+      .filter((item: any) => !!item?.path && !item?.isExternal)
+      .filter((item: any) =>
+        item.path === '/'
+          ? pathname === '/'
+          : pathname === item.path || pathname.startsWith(`${item.path}/`)
+      )
+      .sort((a: any, b: any) => String(b.path).length - String(a.path).length);
+    return matches[0]?.path || '';
+  }, [navigationItems, pathname]);
+
+  const isActiveRoute = (path: string) => path === activeNavPath;
+
   return (
-    <div className="z-[101] fixed top-0 left-0 right-0 w-full bg-[rgba(var(--background-color-rgb),0.95)] backdrop-blur-[20px] border-b border-white/10 shadow-[0_2px_20px_rgba(0,0,0,0.1)] md:hidden pt-[env(safe-area-inset-top)] h-[calc(var(--mobile-navigation-height)+env(safe-area-inset-top))]">
+    <div className="z-[101] fixed top-0 left-0 right-0 w-full bg-[rgba(var(--background-color-rgb),0.95)] backdrop-blur-[20px] border-b border-white/10 shadow-[0_2px_20px_rgba(0,0,0,0.1)] lg:hidden pt-[env(safe-area-inset-top)] h-[calc(var(--mobile-navigation-height)+env(safe-area-inset-top))]">
       {/* Search Mode */}
       {showSearch ? (
         <div className="px-3 flex items-center gap-3 w-full pt-[env(safe-area-inset-top)] h-[calc(var(--mobile-navigation-height)+env(safe-area-inset-top))]">
@@ -109,32 +127,42 @@ export default function MobileNavigation() {
             </div>
 
             <nav className="flex flex-col py-4 px-6 gap-2 flex-1 sm:py-3 sm:px-5 sm:gap-1.5">
-              <Link to="/" onClick={handleNavigationClick} className="flex items-center py-4 px-5 bg-white/5 rounded-xl text-[var(--standard-font-color)] no-underline font-medium transition-all duration-200 min-h-[56px] gap-4 hover:bg-white/10 hover:translate-x-1 active:bg-white/15 active:translate-x-0.5 active:scale-[0.98] sm:py-3.5 sm:px-4 sm:min-h-[52px] sm:gap-3">
-                <span className="text-xl w-6 text-center sm:text-lg sm:w-5">🏠</span>
-                <span className="text-base sm:text-[15px]">Feed</span>
-              </Link>
-              <Link to="/trends" onClick={handleNavigationClick} className="flex items-center py-4 px-5 bg-white/5 rounded-xl text-[var(--standard-font-color)] no-underline font-medium transition-all duration-200 min-h-[56px] gap-4 hover:bg-white/10 hover:translate-x-1 active:bg-white/15 active:translate-x-0.5 active:scale-[0.98] sm:py-3.5 sm:px-4 sm:min-h-[52px] sm:gap-3">
-                <span className="text-xl w-6 text-center sm:text-lg sm:w-5">📈</span>
-                <span className="text-base sm:text-[15px]">Trends</span>
-              </Link>
-              <Link to="/trends/invite" onClick={handleNavigationClick} className="flex items-center py-4 px-5 bg-white/5 rounded-xl text-[var(--standard-font-color)] no-underline font-medium transition-all duration-200 min-h-[56px] gap-4 hover:bg-white/10 hover:translate-x-1 active:bg-white/15 active:translate-x-0.5 active:scale-[0.98] sm:py-3.5 sm:px-4 sm:min-h-[52px] sm:gap-3">
-                <span className="text-xl w-6 text-center sm:text-lg sm:w-5">🎁</span>
-                <span className="text-base sm:text-[15px]">Invite & Earn</span>
-              </Link>
-              <Link to="/landing" onClick={handleNavigationClick} className="flex items-center py-4 px-5 bg-white/5 rounded-xl text-[var(--standard-font-color)] no-underline font-medium transition-all duration-200 min-h-[56px] gap-4 hover:bg-white/10 hover:translate-x-1 active:bg-white/15 active:translate-x-0.5 active:scale-[0.98] sm:py-3.5 sm:px-4 sm:min-h-[52px] sm:gap-3">
-                <span className="text-xl w-6 text-center sm:text-lg sm:w-5">ℹ️</span>
-                <span className="text-base sm:text-[15px]">Info</span>
-              </Link>
-              <a
-                href="https://github.com/aeternity/superhero-ui"
-                target="_blank"
-                rel="noreferrer"
-                className="flex items-center py-4 px-5 bg-white/5 rounded-xl text-[var(--standard-font-color)] no-underline font-medium transition-all duration-200 min-h-[56px] gap-4 hover:bg-white/10 hover:translate-x-1 active:bg-white/15 active:translate-x-0.5 active:scale-[0.98] sm:py-3.5 sm:px-4 sm:min-h-[52px] sm:gap-3"
-                onClick={handleNavigationClick}
-              >
-                <span className="text-xl w-6 text-center sm:text-lg sm:w-5">🐙</span>
-                <span className="text-base sm:text-[15px]">GitHub</span>
-              </a>
+              {navigationItems
+                .filter((item: any) => !!item && !!item.id)
+                .map((item: any) => {
+                  const isActive = isActiveRoute(item.path);
+                  const baseClass =
+                    "flex items-center py-4 px-5 rounded-xl text-[var(--standard-font-color)] no-underline font-medium transition-all duration-200 min-h-[56px] gap-4 hover:bg-white/10 hover:translate-x-1 active:bg-white/15 active:translate-x-0.5 active:scale-[0.98] sm:py-3.5 sm:px-4 sm:min-h-[52px] sm:gap-3";
+                  const activeClass = isActive ? "bg-white/15" : "bg-white/5";
+
+                  if (item.isExternal) {
+                    return (
+                      <a
+                        key={item.id}
+                        href={item.path}
+                        target="_blank"
+                        rel="noreferrer"
+                        className={`${baseClass} ${activeClass}`}
+                        onClick={handleNavigationClick}
+                      >
+                        <span className="text-xl w-6 text-center sm:text-lg sm:w-5">{item.icon}</span>
+                        <span className="text-base sm:text-[15px]">{item.label}</span>
+                      </a>
+                    );
+                  }
+
+                  return (
+                    <Link
+                      key={item.id}
+                      to={item.path}
+                      onClick={handleNavigationClick}
+                      className={`${baseClass} ${activeClass}`}
+                    >
+                      <span className="text-xl w-6 text-center sm:text-lg sm:w-5">{item.icon}</span>
+                      <span className="text-base sm:text-[15px]">{item.label}</span>
+                    </Link>
+                  );
+                })}
             </nav>
           </div>
         </div>

--- a/src/components/layout/app-header/navigationItems.ts
+++ b/src/components/layout/app-header/navigationItems.ts
@@ -7,7 +7,6 @@ export interface NavigationItem {
   path: string;
   icon: string;
   isExternal?: boolean;
-  children?: Array<Pick<NavigationItem, "id" | "label" | "path" | "icon">>;
 }
 
 export const getNavigationItems = (t: TFunction): NavigationItem[] => [
@@ -22,46 +21,72 @@ export const getNavigationItems = (t: TFunction): NavigationItem[] => [
     label: t('trending'),
     path: "/trends/tokens",
     icon: "📈",
-    children: [
-      { id: "leaderboard", label: t('trendingChildren.leaderboard'), path: "/trends/leaderboard", icon: "🏆" },
-      { id: "invite", label: t('trendingChildren.invite'), path: "/trends/invite", icon: "🎁" },
-    ],
+  },
+  configs.features.trending && {
+    id: "trending-leaderboard",
+    label: t('trendingChildren.leaderboard'),
+    path: "/trends/leaderboard",
+    icon: "🏆",
+  },
+  configs.features.trending && {
+    id: "trending-invite",
+    label: t('trendingChildren.invite'),
+    path: "/trends/invite",
+    icon: "🎁",
   },
   {
     id: "dex",
     label: t('defi'),
     path: "/defi",
     icon: "💱",
-    children: [
-      { id: "dex-swap", label: t('defiChildren.swap'), path: "/defi/swap", icon: "🔄" },
-      { id: "dex-wrap", label: t('defiChildren.wrap'), path: "/defi/wrap", icon: "📦" },
-      { id: "dex-bridge", label: t('defiChildren.bridge'), path: "/defi/bridge", icon: "🌉" },
-      {
-        id: "dex-buy-ae",
-        label: t('defiChildren.buyAe'),
-        path: "/defi/buy-ae-with-eth",
-        icon: "💎",
-      },
-      { id: "dex-pool", label: t('defiChildren.pool'), path: "/defi/pool", icon: "💧" },
-      {
-        id: "dex-explore-tokens",
-        label: t('defiChildren.exploreTokens'),
-        path: "/defi/explore/tokens",
-        icon: "🪙",
-      },
-      {
-        id: "dex-explore-pools",
-        label: t('defiChildren.explorePools'),
-        path: "/defi/explore/pools",
-        icon: "🏊",
-      },
-      {
-        id: "dex-explore-transactions",
-        label: t('defiChildren.transactions'),
-        path: "/defi/explore/transactions",
-        icon: "📋",
-      },
-    ],
+  },
+  {
+    id: "dex-swap",
+    label: t('defiChildren.swap'),
+    path: "/defi/swap",
+    icon: "🔄",
+  },
+  {
+    id: "dex-wrap",
+    label: t('defiChildren.wrap'),
+    path: "/defi/wrap",
+    icon: "📦",
+  },
+  {
+    id: "dex-bridge",
+    label: t('defiChildren.bridge'),
+    path: "/defi/bridge",
+    icon: "🌉",
+  },
+  {
+    id: "dex-buy-ae",
+    label: t('defiChildren.buyAe'),
+    path: "/defi/buy-ae-with-eth",
+    icon: "💎",
+  },
+  {
+    id: "dex-pool",
+    label: t('defiChildren.pool'),
+    path: "/defi/pool",
+    icon: "💧",
+  },
+  {
+    id: "dex-explore-tokens",
+    label: t('defiChildren.exploreTokens'),
+    path: "/defi/explore/tokens",
+    icon: "🪙",
+  },
+  {
+    id: "dex-explore-pools",
+    label: t('defiChildren.explorePools'),
+    path: "/defi/explore/pools",
+    icon: "🏊",
+  },
+  {
+    id: "dex-explore-transactions",
+    label: t('defiChildren.transactions'),
+    path: "/defi/explore/transactions",
+    icon: "📋",
   },
   // {
   //     id: 'landing',

--- a/src/components/social/PostHashtagLink.tsx
+++ b/src/components/social/PostHashtagLink.tsx
@@ -28,6 +28,7 @@ interface PostHashtagLinkProps {
   tag: string;
   label: string;
   trendMentions?: TrendMention[];
+  variant?: "pill" | "inline";
 }
 
 function normalizeTag(tag: string) {
@@ -46,7 +47,7 @@ async function fetchTokenForTag(tag: string): Promise<TokenLike | null> {
   return match || items[0] || null;
 }
 
-export default function PostHashtagLink({ tag, label, trendMentions }: PostHashtagLinkProps) {
+export default function PostHashtagLink({ tag, label, trendMentions, variant = "pill" }: PostHashtagLinkProps) {
   const normalized = normalizeTag(tag);
   const target = `/trends/tokens/${encodeURIComponent(normalized.toUpperCase())}?showTrade=0`;
 
@@ -89,13 +90,18 @@ export default function PostHashtagLink({ tag, label, trendMentions }: PostHasht
     <Link
       to={target}
       className={cn(
-        "inline-flex items-center gap-1.5 px-0.5 py-0.5 rounded-full",
-        // "bg-white/10 border border-white/15 text-white/90 text-[12px] font-semibold",
-        "hover:bg-white/15 hover:border-white/25 no-underline",
-        "outline-none focus:outline-none focus-visible:outline-none focus-visible:ring-0",
-        "break-words"
+        variant === "pill"
+          ? "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-white/10 border border-white/15 text-[var(--neon-blue)] text-[12px] font-semibold hover:bg-white/15 hover:border-white/25"
+          : "inline-flex items-baseline gap-1 text-[var(--neon-blue)] underline-offset-2 hover:underline text-[13px] font-medium",
+        "no-underline outline-none focus:outline-none focus-visible:outline-none focus-visible:ring-0 break-words"
       )}
-      style={{ outline: "none" }}
+      style={{
+        outline: "none",
+        background: "none",
+        WebkitTextFillColor: "currentColor",
+        WebkitBackgroundClip: "initial",
+        backgroundClip: "initial",
+      }}
       onClick={(e) => e.stopPropagation()}
     >
       <span className="leading-none">{label}</span>

--- a/src/features/social/components/ReplyToFeedItem.tsx
+++ b/src/features/social/components/ReplyToFeedItem.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { PostDto, PostsService } from "../../../api/generated";
 import { IconComment } from "../../../icons";
 import { linkify } from "../../../utils/linkify";
+import { formatAddress } from "../../../utils/address";
 import BlockchainInfoPopover from "./BlockchainInfoPopover";
 import { Badge } from "@/components/ui/badge";
 import { useTransactionStatus } from "@/hooks/useTransactionStatus";
@@ -190,10 +191,10 @@ const ReplyToFeedItem = memo(({
   return (
     <article
       className={cn(
-        "relative w-[100dvw] ml-[calc(50%-50dvw)] mr-[calc(50%-50dvw)] px-2 pt-4 pb-5 md:w-full md:mx-0 md:p-5 bg-transparent md:bg-[var(--glass-bg)] md:border md:border-[var(--glass-border)] md:rounded-2xl md:backdrop-blur-xl transition-colors",
-        !isActive && "cursor-pointer hover:border-white/25 hover:shadow-none",
-        isActive && "bg-white/[0.06] md:bg-white/[0.08] md:border-white/40",
-        isContextMuted && "md:bg-white/[0.03] md:border-white/10"
+        "relative w-full px-3 md:px-4 py-4 md:py-5 border-b border-white/10 bg-transparent transition-colors",
+        !isActive && "cursor-pointer hover:bg-white/[0.04]",
+        isActive && "bg-white/[0.06] border-white/25",
+        isContextMuted && "bg-white/[0.02] border-white/10"
       )}
       onClick={isActive ? undefined : handleOpen}
       role={isActive ? undefined : "button"}
@@ -213,11 +214,11 @@ const ReplyToFeedItem = memo(({
           />
         </div>
       )}
-      {/* Main row: avatar next to name/time like X */}
-      <div className="flex gap-2 md:gap-3 items-start">
+      {/* Main row: avatar left, content right */}
+      <div className="flex gap-3 items-start">
         <div className="flex-shrink-0 pt-0.5">
           <div className="md:hidden">
-            <AddressAvatarWithChainNameFeed address={authorAddress} size={34} overlaySize={16} showAddressAndChainName={false} />
+            <AddressAvatarWithChainNameFeed address={authorAddress} size={36} overlaySize={16} showAddressAndChainName={false} />
           </div>
           <div className="hidden md:block">
             <AddressAvatarWithChainNameFeed address={authorAddress} size={40} overlaySize={20} showAddressAndChainName={false} />
@@ -225,30 +226,32 @@ const ReplyToFeedItem = memo(({
         </div>
 
         <div className="flex-1 min-w-0">
-          {/* Header: name · time */}
-          <div className="flex items-center justify-between gap-2.5">
-            <div className="flex items-baseline gap-2.5 min-w-0">
-              <div className="text-[15px] font-semibold text-white truncate">{displayName}</div>
-              <span className="text-white/50 shrink-0">·</span>
-              {item.tx_hash ? (
-                <BlockchainInfoPopover
-                  txHash={(item as any).tx_hash}
-                  createdAt={item.created_at as unknown as string}
-                  sender={(item as any).sender_address}
-                  contract={(item as any).contract_address}
-                  postId={String(item.id)}
-                  triggerContent={
-                    <span className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={fullTimestamp(item.created_at as unknown as string)}>
-                      {compactTime(item.created_at as unknown as string)}
-                    </span>
-                  }
-                />
-              ) : (
-                <div className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={fullTimestamp(item.created_at as unknown as string)}>{compactTime(item.created_at as unknown as string)}</div>
-              )}
-            </div>
+          {/* Header: name · handle (wide desktop) · time */}
+          <div className="flex items-center gap-2 min-w-0">
+            <div className="text-[15px] font-semibold text-white truncate">{displayName}</div>
+            <span className="hidden 2xl:inline text-[13px] text-white/60 font-mono truncate">@{authorAddress}</span>
+            <span className="text-white/50 shrink-0">·</span>
+            {item.tx_hash ? (
+              <BlockchainInfoPopover
+                txHash={(item as any).tx_hash}
+                createdAt={item.created_at as unknown as string}
+                sender={(item as any).sender_address}
+                contract={(item as any).contract_address}
+                postId={String(item.id)}
+                triggerContent={
+                  <span className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={fullTimestamp(item.created_at as unknown as string)}>
+                    {compactTime(item.created_at as unknown as string)}
+                  </span>
+                }
+              />
+            ) : (
+              <div className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={fullTimestamp(item.created_at as unknown as string)}>{compactTime(item.created_at as unknown as string)}</div>
+            )}
           </div>
-          <div className="mt-1 text-[9px] md:text-[10px] text-white/65 font-mono leading-[1.2] truncate">{authorAddress}</div>
+
+          <div className="mt-1 text-[12px] text-white/60 font-mono leading-[1.2] truncate 2xl:hidden">
+            {formatAddress(authorAddress, 4, true)}
+          </div>
 
           {/* Trend token holder pill (when viewing a token feed and author holds the token) */}
           {tokenHolderLabel && (
@@ -307,7 +310,7 @@ const ReplyToFeedItem = memo(({
           )}
 
           {/* Body */}
-          <div className="mt-3 text-[15px] text-foreground leading-snug">
+          <div className="mt-2 text-[15px] text-foreground leading-snug">
             {linkify(item.content, {
               knownChainNames: new Set(Object.values(chainNames || {}).map((n) => n?.toLowerCase())),
               hashtagVariant: 'post-inline',
@@ -336,29 +339,28 @@ const ReplyToFeedItem = memo(({
           )}
 
           {/* Actions */}
-          <div className="mt-4 flex items-center justify-between">
-            <div className="inline-flex items-center gap-4 md:gap-2">
+          <div className="mt-3 flex items-center justify-between">
+            <div className="inline-flex items-center gap-5 text-[13px] text-white/70">
+              <button
+                type="button"
+                onClick={(e) => {
+                  if (allowInlineRepliesToggle) {
+                    e.stopPropagation();
+                    toggleReplies();
+                    if (!showReplies) setTimeout(() => refetchChildReplies(), 0);
+                  } else {
+                    e.stopPropagation();
+                    handleOpen();
+                  }
+                }}
+                className="inline-flex items-center gap-1.5 px-0 py-0 rounded-lg bg-transparent border-0 h-auto min-h-0 min-w-0 hover:text-white"
+                aria-expanded={allowInlineRepliesToggle ? showReplies : undefined}
+                aria-controls={`replies-${postId}`}
+              >
+                <MessageCircle className="w-[15px] h-[15px]" strokeWidth={2} />
+                {typeof descendantCount === 'number' ? descendantCount : commentCount}
+              </button>
               <PostTipButton toAddress={authorAddress} postId={String(postId)} />
-            <button
-              type="button"
-              onClick={(e) => {
-                if (allowInlineRepliesToggle) {
-                  e.stopPropagation();
-                  toggleReplies();
-                  if (!showReplies) setTimeout(() => refetchChildReplies(), 0);
-                } else {
-                  // On post pages: do not toggle, just open the post
-                  e.stopPropagation();
-                  handleOpen();
-                }
-              }}
-              className="inline-flex items-center gap-1.5 text-[13px] px-0 py-0 rounded-lg bg-transparent border-0 h-auto min-h-0 min-w-0 md:px-2.5 md:py-1 md:h-[28px] md:min-h-[28px] md:bg-white/[0.04] md:border md:border-white/25 md:hover:border-white/40 md:ring-1 md:ring-white/15 md:hover:ring-white/25 md:transition-colors"
-              aria-expanded={allowInlineRepliesToggle ? showReplies : undefined}
-              aria-controls={`replies-${postId}`}
-            >
-              <MessageCircle className="w-[14px] h-[14px]" strokeWidth={2.25} />
-            {typeof descendantCount === 'number' ? descendantCount : commentCount}
-            </button>
             </div>
             <SharePopover postId={item.id} postSlug={(item as any)?.slug} />
           </div>
@@ -391,8 +393,6 @@ const ReplyToFeedItem = memo(({
           )}
         </div>
       </div>
-      {/* Full-bleed divider on mobile */}
-      <div className="md:hidden pointer-events-none absolute bottom-0 left-[calc(50%-50dvw)] w-[100dvw] h-px bg-white/10" />
     </article>
   );
 });

--- a/src/features/social/components/TokenCreatedActivityItem.tsx
+++ b/src/features/social/components/TokenCreatedActivityItem.tsx
@@ -77,7 +77,7 @@ const TokenCreatedActivityItem = memo(({ item, hideMobileDivider = false, mobile
             <span className="text-white/70 shrink-0">created</span>
             {tokenName && (
               <span className="truncate max-w-[24ch] text-white/90">
-                {linkify(`#${tokenName}`)}
+                {linkify(`#${tokenName}`, { hashtagVariant: 'post-inline' })}
               </span>
             )}
             <span className="text-white/50 shrink-0">·</span>

--- a/src/features/social/components/TokenCreatedFeedItem.tsx
+++ b/src/features/social/components/TokenCreatedFeedItem.tsx
@@ -52,7 +52,7 @@ const TokenCreatedFeedItem = memo(({ item, onOpenPost }: TokenCreatedFeedItemPro
   return (
     <article
       className={cn(
-        "relative w-[100dvw] ml-[calc(50%-50dvw)] mr-[calc(50%-50dvw)] px-2 pt-4 pb-5 md:w-full md:mx-0 md:p-5 bg-transparent md:bg-[var(--glass-bg)] md:border md:border-[var(--glass-border)] md:rounded-2xl md:backdrop-blur-xl transition-colors hover:border-white/25 hover:shadow-none"
+        "relative w-full px-3 md:px-4 py-4 md:py-5 border-b border-white/10 bg-transparent transition-colors hover:bg-white/[0.04]"
       )}
       onClick={handleOpen}
       role="button"
@@ -102,7 +102,7 @@ const TokenCreatedFeedItem = memo(({ item, onOpenPost }: TokenCreatedFeedItemPro
               <span className="text-[11px] text-white/65 shrink-0">{displayName}</span>
               <span className="text-[11px] text-white/65 shrink-0">created</span>
               {tokenName && (
-                <span className="text-[12px] text-white/90 truncate">
+                <span className="text-[12px] truncate">
                   {linkify(`#${tokenName}`, {
                     knownChainNames: new Set(Object.values(chainNames || {}).map((n) => n?.toLowerCase())),
                     hashtagVariant: 'post-inline',
@@ -131,7 +131,6 @@ const TokenCreatedFeedItem = memo(({ item, onOpenPost }: TokenCreatedFeedItemPro
           </div>
         </div>
       </div>
-      <div className="md:hidden pointer-events-none absolute bottom-0 left-[calc(50%-50dvw)] w-[100dvw] h-px bg-white/10" />
     </article>
   );
 });

--- a/src/features/social/components/TradeActivityItem.tsx
+++ b/src/features/social/components/TradeActivityItem.tsx
@@ -60,8 +60,8 @@ const TradeActivityItem = memo(({ item }: TradeActivityItemProps) => {
   return (
     <article
       className={cn(
-        "relative w-[100dvw] ml-[calc(50%-50dvw)] mr-[calc(50%-50dvw)] px-2 pt-4 pb-5 md:w-full md:mx-0 md:p-5 bg-transparent md:bg-[var(--glass-bg)] md:border md:border-[var(--glass-border)] md:rounded-2xl md:backdrop-blur-xl transition-colors",
-        "cursor-pointer hover:border-white/25 hover:shadow-none"
+        "relative w-full px-3 md:px-4 py-4 md:py-5 border-b border-white/10 bg-transparent transition-colors",
+        "cursor-pointer hover:bg-white/[0.04]"
       )}
       onClick={onOpen}
       role="button"
@@ -102,7 +102,7 @@ const TradeActivityItem = memo(({ item }: TradeActivityItemProps) => {
             <span className="font-semibold text-white">{volumeText}</span>
             <span className="text-white/60">of</span>
             {tokenTag ? (
-              <PostHashtagLink tag={tokenTag} label={`#${tokenTag}`} />
+              <PostHashtagLink tag={tokenTag} label={`#${tokenTag}`} variant="inline" />
             ) : (
               <span className="text-white/80">{tokenLabel}</span>
             )}
@@ -134,7 +134,6 @@ const TradeActivityItem = memo(({ item }: TradeActivityItemProps) => {
           )}
         </div>
       </div>
-      <div className="md:hidden pointer-events-none absolute bottom-0 left-[calc(50%-50dvw)] w-[100dvw] h-px bg-white/10" />
     </article>
   );
 });

--- a/src/features/social/components/TrendingAssetsFeedItem.tsx
+++ b/src/features/social/components/TrendingAssetsFeedItem.tsx
@@ -54,8 +54,8 @@ export default function TrendingAssetsFeedItem() {
   }
 
   return (
-    <div className="w-screen -mx-[calc((100vw-100%)/2)] md:w-full md:mx-0 p-0 md:bg-[var(--glass-bg)] md:border md:border-[var(--glass-border)] md:backdrop-blur-[20px] md:rounded-[20px]">
-      <div className="p-4 md:p-5">
+    <div className="relative w-full px-3 md:px-4 py-4 md:py-5 border-b border-white/10 bg-transparent transition-colors hover:bg-white/[0.04]">
+      <div className="w-full">
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-[15px] md:text-[16px] font-semibold text-white m-0 flex items-center gap-2">
             <TrendingUp className="h-4 w-4 text-emerald-300" />

--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -1373,7 +1373,7 @@ export default function FeedList({
   ]);
 
   const content = (
-    <div className="w-full">
+    <div className="w-full md:border md:border-white/10 md:rounded-2xl md:overflow-hidden">
       {isHomepage && (
         <Head
           title="Superhero.com – The All‑in‑One Social + Crypto App"
@@ -1434,7 +1434,7 @@ export default function FeedList({
         </div>
       </div>
 
-      <div className="w-full flex flex-col gap-0 md:gap-2 md:mx-0">
+      <div className="w-full flex flex-col gap-0 md:mx-0">
         {renderEmptyState()}
         {/* Non-hot: existing renderer - show feed if we have data, even while refetching */}
         {sortBy !== "hot" && (latestData?.pages.length > 0 || activityList.length > 0) && renderFeedItems}
@@ -1544,7 +1544,7 @@ export default function FeedList({
   );
 
   return standalone ? (
-    <Shell right={<RightRail hideTrends />} containerClassName="max-w-[1080px] mx-auto">
+    <Shell right={<RightRail />} containerClassName="max-w-[1080px] mx-auto">
       {content}
     </Shell>
   ) : (

--- a/src/features/trending/views/TokenSaleDetails.tsx
+++ b/src/features/trending/views/TokenSaleDetails.tsx
@@ -371,34 +371,9 @@ export default function TokenSaleDetails() {
       )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Desktop Sidebar (Left Column) */}
-        {!isMobile && (
-          <div className="lg:col-span-1 flex flex-col gap-6">
-            {!token?.sale_address ? (
-              <TokenSaleSidebarSkeleton boilerplate={isTokenPending} />
-            ) : (
-              <>
-                {showTradePanels && <TokenTradeCard token={token} />}
-                <TokenSummary
-                  token={token}
-                />
-                <TokenRanking token={token} />
-                {/* Quali.chat CTA - old design cards */}
-                <TokenChat
-                  token={{
-                    name: String(token.name || token.symbol || ''),
-                    address: String((token as any).sale_address || (token as any).address || (token as any).token_address || ''),
-                  }}
-                  mode="ctaOnly"
-                />
-              </>
-            )}
-          </div>
-        )}
-
-        {/* Main Content (Right Column on Desktop, Full Width on Mobile) */}
+        {/* Main Content (Left Column on Desktop, Full Width on Mobile) */}
         <div
-          className={`${isMobile ? "col-span-1 mb-8" : "lg:col-span-2"
+          className={`${isMobile ? "col-span-1 mb-8" : "lg:col-span-2 lg:col-start-1"
             } flex flex-col gap-6`}
         >
           {/* Token Header */}
@@ -662,6 +637,31 @@ export default function TokenSaleDetails() {
             {activeTab === TAB_HOLDERS && <TokenHolders token={token} />}
           </div>
         </div>
+
+        {/* Desktop Sidebar (Right Column) */}
+        {!isMobile && (
+          <div className="lg:col-span-1 lg:col-start-3 flex flex-col gap-6">
+            {!token?.sale_address ? (
+              <TokenSaleSidebarSkeleton boilerplate={isTokenPending} />
+            ) : (
+              <>
+                {showTradePanels && <TokenTradeCard token={token} />}
+                <TokenSummary
+                  token={token}
+                />
+                <TokenRanking token={token} />
+                {/* Quali.chat CTA - old design cards */}
+                <TokenChat
+                  token={{
+                    name: String(token.name || token.symbol || ''),
+                    address: String((token as any).sale_address || (token as any).address || (token as any).token_address || ''),
+                  }}
+                  mode="ctaOnly"
+                />
+              </>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Mobile Trading Modal */}

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -141,12 +141,12 @@ body {
   overflow-x: hidden;
   /* Better touch scrolling */
   -webkit-overflow-scrolling: touch;
-  /* Gen Z Ultra Dynamic Background */
+  /* Dark blue/black background (no red/green) */
   background:
-    radial-gradient(circle at 20% 80%, rgba(255, 107, 107, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(0, 255, 157, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 40% 40%, rgba(69, 183, 209, 0.1) 0%, transparent 50%),
-    linear-gradient(135deg, $background_color 0%, #0f0f23 50%, #1a1a2e 100%);
+    radial-gradient(circle at 20% 80%, rgba(7, 13, 32, 0.65) 0%, transparent 55%),
+    radial-gradient(circle at 80% 20%, rgba(8, 12, 26, 0.6) 0%, transparent 60%),
+    radial-gradient(circle at 40% 40%, rgba(13, 24, 48, 0.35) 0%, transparent 65%),
+    linear-gradient(135deg, #05060a 0%, #070b16 55%, #0b1224 100%);
     background-attachment: fixed;
 }
 
@@ -162,10 +162,10 @@ body::before {
   z-index: -1;
   pointer-events: none;
   background:
-    radial-gradient(circle at 20% 80%, rgba(255, 107, 107, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 80% 20%, rgba(0, 255, 157, 0.15) 0%, transparent 50%),
-    radial-gradient(circle at 40% 40%, rgba(69, 183, 209, 0.1) 0%, transparent 50%),
-    linear-gradient(135deg, $background_color 0%, #0f0f23 50%, #1a1a2e 100%);
+    radial-gradient(circle at 20% 80%, rgba(7, 13, 32, 0.65) 0%, transparent 55%),
+    radial-gradient(circle at 80% 20%, rgba(8, 12, 26, 0.6) 0%, transparent 60%),
+    radial-gradient(circle at 40% 40%, rgba(13, 24, 48, 0.35) 0%, transparent 65%),
+    linear-gradient(135deg, #05060a 0%, #070b16 55%, #0b1224 100%);
   will-change: transform;
   transform: translateZ(0); /* helps Safari keep it fixed */
 }

--- a/src/styles/mobile-optimizations.scss
+++ b/src/styles/mobile-optimizations.scss
@@ -11,6 +11,11 @@
     /* Navigation is now fixed, no padding needed */
     padding-top: 0;
   }
+
+  @media (min-width: 1024px) {
+    /* Offset for the fixed left navigation (matches lg breakpoint) */
+    padding-left: 16rem;
+  }
 }
 
 .app-routes-container {

--- a/src/utils/linkify.tsx
+++ b/src/utils/linkify.tsx
@@ -192,6 +192,7 @@ export function linkify(
             tag={tag}
             label={m}
             trendMentions={options?.trendMentions}
+            variant="inline"
             key={`hashtag-${tag}-${idx}-${off}`}
           />
         ) : (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly UI/layout changes, but they affect global navigation breakpoints, active-route highlighting, and page layout offsets, which could cause regressions in routing cues or content positioning across viewports.
> 
> **Overview**
> **Navigation layout is overhauled.** The desktop header is replaced with a fixed left sidebar (`WebAppHeader`) shown at `lg`+, while mobile headers/nav now hide at `lg` (was `md`) and compute the *active* item by longest matching path to avoid incorrect highlights.
> 
> **Nav configuration is simplified.** `navigationItems` removes nested `children` and flattens Trends/DeFi sub-links into top-level items so both mobile and desktop render from a single list.
> 
> **Feed visuals and hashtag linking are refreshed.** Multiple social feed items switch from full-bleed “card” styling to a unified bordered list-row style; `FeedList` adds a bordered/rounded container on desktop and stops hiding trends in `RightRail` for standalone mode. Hashtag rendering adds `PostHashtagLink` variants (pill vs inline) and `linkify`/activity/trade items now use the inline variant for in-text tags.
> 
> **Trending token details layout changes on desktop.** `TokenSaleDetails` moves the sidebar from the left to the right column.
> 
> **Global styling tweaks.** Background gradients are changed to a darker blue palette, and `.app-container` gains `lg` left padding to offset the new fixed sidebar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46f0d2384ca3ed80e0a4aaa78f15b25005f10fee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->