### PR TITLE
fix: show account modal correctly

### DIFF
--- a/src/components/layout/app-header/HeaderWalletButton.tsx
+++ b/src/components/layout/app-header/HeaderWalletButton.tsx
@@ -48,10 +48,10 @@ export default function HeaderWalletButton() {
 
   // If connected, show user info with clickable avatar and separate menu button
   return (
-    <div className="inline-flex items-center gap-3">
+    <div className="inline-flex items-center gap-3 max-w-full">
       <button
         onClick={handleProfileClick}
-        className="cursor-pointer hover:opacity-80 transition-opacity rounded-lg px-1 py-0.5 hover:bg-white/5"
+        className="cursor-pointer hover:opacity-80 transition-opacity rounded-lg px-1 py-0.5 hover:bg-white/5 max-w-[210px] overflow-hidden"
         aria-label="View profile"
       >
         <AddressAvatarWithChainName
@@ -60,12 +60,12 @@ export default function HeaderWalletButton() {
           address={activeAccount}
           size={36}
           overlaySize={18}
-          showBalance={true}
+          showBalance={false}
           showAddressAndChainName={false}
           showPrimaryOnly={true}
           hideFallbackName={true}
-          contentClassName="px-2 pb-0"
-          className="w-auto"
+          contentClassName="px-2 pb-0 max-w-[160px] overflow-hidden"
+          className="w-full max-w-[210px]"
         />
       </button>
 
@@ -80,7 +80,12 @@ export default function HeaderWalletButton() {
           </button>
         </DropdownMenuTrigger>
 
-        <DropdownMenuContent className="min-w-[560px] p-4" align="end">
+        <DropdownMenuContent
+          className="min-w-[320px] max-w-[360px] p-4 z-[1101]"
+          align="center"
+          side="top"
+          sideOffset={8}
+        >
           <AddressAvatarWithChainName
             key={activeAccount}
             isHoverEnabled={false}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only layout and menu positioning tweaks; no changes to wallet connection, auth, or data handling logic.
> 
> **Overview**
> **Fixes header wallet/account UI sizing and dropdown positioning.** The connected-wallet button now constrains width and hides overflow to prevent layout issues, and it stops rendering the inline balance.
> 
> The account dropdown is resized and repositioned (smaller width, centered, opens above with offset, higher z-index) to improve modal/menu display behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea8f5e1c94429b1487c3f5caa6a6744995d0899a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->