### PR TITLE
fix(TokenSaleDetails): increase retry limit for token fetching

### DIFF
--- a/src/features/trending/views/TokenSaleDetails.tsx
+++ b/src/features/trending/views/TokenSaleDetails.tsx
@@ -201,10 +201,10 @@ const TokenSaleDetails = () => {
       }
     },
     retry: (failureCount) => {
-      if (failureCount > 3) {
+      if (failureCount > 10) {
         setPendingLastsLong(true);
       }
-      return isTokenNewlyCreated ? true : failureCount <= 3;
+      return isTokenNewlyCreated ? true : failureCount <= 10;
     },
     retryDelay: 10000,
     staleTime: 60000,


### PR DESCRIPTION
- Updated the retry limit from 3 to 10 attempts for fetching token data, allowing for more retries before marking the process as failed. This change aims to improve the robustness of the token fetching mechanism and enhance user experience during data loading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/data-loading behavior change limited to retry timing/count; main risk is longer wait before showing an error if a token truly doesn’t exist.
> 
> **Overview**
> Increases the `react-query` retry threshold for `TokensService.findByAddress` in `TokenSaleDetails` from 3 to 10 attempts.
> 
> The “pending lasts long” UI flag is now triggered after 10 failures (instead of 3), and non-newly-created tokens will keep retrying up to 10 times before surfacing “not found.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a55e1393c24d754cf3658d272ffbd5f75fb76364. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->