### PR TITLE
fix: do not call non-existent endpoints

### DIFF
--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -346,8 +346,8 @@ export const SuperheroApi = {
     const qp = new URLSearchParams();
     if (includeOnChain != null) qp.set('includeOnChain', String(includeOnChain));
     const query = qp.toString();
-    // TOOD: uncomment this when the backend is ready
-    return null
+    // TODO: uncomment this when the backend is ready
+    return Promise.resolve(null);
     return this.fetchJson(`/api/profile/${encodeURIComponent(address)}${query ? `?${query}` : ''}`) as Promise<ProfileAggregate>;
   },
   getProfilesByAddresses(addresses: string[], includeOnChain?: boolean) {
@@ -360,7 +360,9 @@ export const SuperheroApi = {
     const qp = new URLSearchParams();
     qp.set('limit', String(limit));
     qp.set('offset', String(offset));
-    return this.fetchJson(`/api/profile/feed?${qp.toString()}`) as Promise<ProfileFeedResponse>;
+    return Promise.resolve({ items: [], data: [] } as ProfileFeedResponse);
+    // TODO: uncomment this when the backend is ready
+    // return this.fetchJson(`/api/profile/feed?${qp.toString()}`) as Promise<ProfileFeedResponse>;
   },
   createXAttestation(address: string, accessToken: string) {
     return this.fetchJson('/api/profile/x/attestation', {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small client-side behavior change that only affects profile/profile-feed data fetching; main risk is UI screens now consistently receiving `null`/empty results where they previously attempted network calls.
> 
> **Overview**
> Stops calling not-yet-available profile endpoints in `SuperheroApi`.
> 
> `getProfile` now consistently returns a resolved promise (`null`) instead of a raw `null`, and `getProfileFeed` is temporarily stubbed to return an empty feed payload, with the real `fetchJson` calls left commented for later re-enable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e211884dfe2c6c6adc880f10a3d2e89cb25d425a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->