### PR TITLE
fix(posts): show correct token performance direction

### DIFF
--- a/src/components/social/PostHashtagLink.tsx
+++ b/src/components/social/PostHashtagLink.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { SuperheroApi } from '@/api/backend';
 import { cn } from '@/lib/utils';
+import { toOptionalFiniteNumber } from '@/utils/number';
 
 type TokenLike = {
   name?: string;
@@ -11,16 +12,20 @@ type TokenLike = {
 };
 
 type TrendPerformanceWindow = {
-  current_change_percent?: number;
+  current_change_percent?: number | string;
 };
 
 export type TrendMention = {
   name?: string;
+  symbol?: string;
   sale_address?: string;
   address?: string;
   performance?: {
+    current_change_percent?: number | string;
     past_24h?: TrendPerformanceWindow;
     past_7d?: TrendPerformanceWindow;
+    past_30d?: TrendPerformanceWindow;
+    all_time?: TrendPerformanceWindow;
   };
 };
 
@@ -47,6 +52,20 @@ async function fetchTokenForTag(tag: string): Promise<TokenLike | null> {
   return match || items[0] || null;
 }
 
+function resolveChangePercent(performanceData: any): number | null {
+  if (!performanceData) return null;
+  const candidates: unknown[] = [
+    performanceData?.current_change_percent,
+    performanceData?.past_24h?.current_change_percent,
+    performanceData?.past_7d?.current_change_percent,
+    performanceData?.past_30d?.current_change_percent,
+    performanceData?.all_time?.current_change_percent,
+  ];
+  return candidates
+    .map((candidate) => toOptionalFiniteNumber(candidate))
+    .find((parsed): parsed is number => parsed !== null) ?? null;
+}
+
 const PostHashtagLink = ({
   tag,
   label,
@@ -59,7 +78,8 @@ const PostHashtagLink = ({
   const matchedMention = Array.isArray(trendMentions)
     ? trendMentions.find((mention) => {
       const name = normalizeTag(mention?.name || '');
-      return name === normalized;
+      const symbol = normalizeTag(mention?.symbol || '');
+      return name === normalized || symbol === normalized;
     })
     : undefined;
   const hasMentionAddress = Boolean(matchedMention?.sale_address || matchedMention?.address);
@@ -84,11 +104,10 @@ const PostHashtagLink = ({
 
   // TODO: We should use 24h performance, but it is not present for most of the tokens.
   const performanceData = matchedMention?.performance || (performance as any);
-  const changeRaw = (performanceData as any)?.past_7d?.current_change_percent;
-  const hasChange = (typeof changeRaw === 'number' && changeRaw !== 0);
-  const changePercent = hasChange ? changeRaw : 0;
-  const isPositive = changePercent >= 0;
-  const changeText = hasChange ? `${Math.abs(changePercent).toFixed(2)}%` : null;
+  const changePercent = resolveChangePercent(performanceData);
+  const hasChange = changePercent !== null && changePercent !== 0;
+  const isPositive = (changePercent ?? 0) > 0;
+  const changeText = hasChange ? `${Math.abs(changePercent ?? 0).toFixed(2)}%` : null;
 
   return (
     <Link

--- a/src/features/trending/components/tabs/TokenTradeTab.tsx
+++ b/src/features/trending/components/tabs/TokenTradeTab.tsx
@@ -5,6 +5,7 @@ import TokenCandlestickChart from '@/components/charts/TokenCandlestickChart';
 import PriceDataFormatter from '@/features/shared/components/PriceDataFormatter';
 import { ArrowDown, ArrowUpRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { toOptionalFiniteNumber } from '@/utils/number';
 import TokenCandlestickChartSkeleton from '../Skeletons/TokenCandlestickChartSkeleton';
 
 type TokenTradeTabProps = {
@@ -17,11 +18,19 @@ type TokenTradeTabProps = {
 };
 
 const ChangePill = ({ tokenPerformance }: { tokenPerformance?: TokenPriceMovementDto | null }) => {
-  const pct = tokenPerformance?.past_24h?.current_change_percent ?? 0;
-  const isPositive = pct >= 0;
+  const pct = toOptionalFiniteNumber(tokenPerformance?.past_24h?.current_change_percent) ?? 0;
+  const isPositive = pct > 0;
+  const isNegative = pct < 0;
   return (
-    <span className={cn('inline-flex items-center gap-1 text-xs font-semibold tabular-nums', isPositive ? 'text-green-400' : 'text-red-400')}>
-      {isPositive ? <ArrowUpRight className="h-3.5 w-3.5" /> : <ArrowDown className="h-3.5 w-3.5" />}
+    <span className={cn(
+      'inline-flex items-center gap-1 text-xs font-semibold tabular-nums',
+      isPositive ? 'text-green-400' : '',
+      isNegative ? 'text-red-400' : '',
+      !isPositive && !isNegative ? 'text-white/60' : '',
+    )}
+    >
+      {isPositive ? <ArrowUpRight className="h-3.5 w-3.5" /> : null}
+      {isNegative ? <ArrowDown className="h-3.5 w-3.5" /> : null}
       {Math.abs(pct).toFixed(2)}
       %
     </span>
@@ -44,10 +53,11 @@ export const TokenTradeTab = ({
   ].map((range) => {
     const p = tokenPerformance?.[range.id];
     const direction = String(p?.current_change_direction || '');
-    const isUp = direction === 'up' || direction === 'positive';
-    const isDown = direction === 'down' || direction === 'negative';
-    const changePercent = typeof p?.current_change_percent === 'number'
-      ? `${p.current_change_percent.toFixed(2)}%`
+    const pct = toOptionalFiniteNumber(p?.current_change_percent);
+    const isUp = pct !== null ? pct > 0 : (direction === 'up' || direction === 'positive');
+    const isDown = pct !== null ? pct < 0 : (direction === 'down' || direction === 'negative');
+    const changePercent = pct !== null
+      ? `${pct.toFixed(2)}%`
       : '--';
     return {
       ...range,

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -53,3 +53,17 @@ export function formatCompactNumber(
 
   return negative ? `-${formatted}` : formatted;
 }
+
+// Parse numeric API values while treating missing/empty as null.
+export function toOptionalFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI logic change that only affects how token performance percentages are parsed and displayed. Main risk is minor regressions in edge cases (0/empty/string percent values) across post hashtag links and the trade tab.
> 
> **Overview**
> Fixes token performance percent/direction display in posts and the token trade view by parsing `current_change_percent` values that may arrive as strings and by treating `0` as *neutral* rather than positive/negative.
> 
> `PostHashtagLink` now matches mentions by *name or symbol* and derives the shown change from the first available window (`current`, `24h`, `7d`, `30d`, `all_time`) via a new `resolveChangePercent` helper, backed by a new `toOptionalFiniteNumber` utility in `src/utils/number.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ccd6728d5b9edade5cd1cef45d9dff10de38080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->