### PR TITLE
fix(safari): show list of trends correctly

### DIFF
--- a/src/features/trending/components/TokenListTable.tsx
+++ b/src/features/trending/components/TokenListTable.tsx
@@ -1,5 +1,6 @@
 import { TokenDto } from '@/api/generated/models/TokenDto';
 import { useIsMobile } from '@/hooks';
+import { IS_SAFARI } from '@/utils/constants';
 import {
   useLayoutEffect, useMemo, useRef, useState,
 } from 'react';
@@ -143,7 +144,8 @@ const TokenListTable = ({
   return (
     <div
       ref={tableContainerRef}
-      className="bctsl-token-list-container relative -mx-4 md:mx-0"
+      className="bctsl-token-list-container relative isolate -mx-4 md:mx-0"
+      data-safari={IS_SAFARI ? 'true' : undefined}
       data-compact={isCompactTable}
       data-container-md={isContainerMd}
       data-container-lg={isContainerLg}
@@ -153,6 +155,7 @@ const TokenListTable = ({
         '--token-list-sticky-top': isViewportMobile
           ? 'calc(var(--mobile-navigation-height) + env(safe-area-inset-top))'
           : '0px',
+        '--bctsl-table-v-spacing': isCompactTable ? '0px' : '6px',
       } as React.CSSProperties}
     >
       <table className="w-full bctsl-token-list-table">
@@ -264,11 +267,7 @@ const TokenListTable = ({
         {`
         .bctsl-token-list-table {
           border-collapse: separate;
-          border-spacing: 0 6px;
-        }
-
-        .bctsl-token-list-container[data-compact="true"] .bctsl-token-list-table {
-          border-spacing: 0;
+          border-spacing: 0 var(--bctsl-table-v-spacing, 6px);
         }
 
         .bctsl-token-list-table th {
@@ -285,13 +284,77 @@ const TokenListTable = ({
           width: auto;
         }
 
-        .cell-clickable-item {
-          color: inherit;
+        /* Desktop token rows — solid td backgrounds (no tr::after, no row transform): Safari scroll compositing */
+        .bctsl-token-list-table-row {
+          position: relative;
           cursor: pointer;
+          outline: none;
         }
 
-        .cell-clickable-item:hover {
-          text-decoration: underline;
+        .bctsl-token-list-table > tbody > tr.mobile-only-card {
+          cursor: pointer;
+          outline: none;
+        }
+
+        .bctsl-token-list-table-row td {
+          background-color: rgba(255, 255, 255, 0.035);
+          border-top: 1px solid rgba(255, 255, 255, 0.06);
+          border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+          transition: background-color 0.2s ease, border-color 0.2s ease;
+        }
+
+        .bctsl-token-list-table-row td.cell-fake {
+          background: transparent;
+          border: none;
+        }
+
+        .bctsl-token-list-table-row td.cell-rank {
+          border-left: 1px solid rgba(255, 255, 255, 0.06);
+          border-top-left-radius: 12px;
+          border-bottom-left-radius: 12px;
+        }
+
+        .bctsl-token-list-table-row td.cell-link {
+          border-right: 1px solid rgba(255, 255, 255, 0.06);
+          border-top-right-radius: 12px;
+          border-bottom-right-radius: 12px;
+        }
+
+        .bctsl-token-list-table-row:hover td:not(.cell-fake) {
+          background-color: rgba(17, 97, 254, 0.08);
+        }
+
+        .bctsl-token-list-table-row:hover td.cell-rank {
+          border-left-color: rgba(17, 97, 254, 0.22);
+        }
+
+        .bctsl-token-list-table-row:hover td.cell-link {
+          border-right-color: rgba(17, 97, 254, 0.22);
+        }
+
+        .bctsl-token-list-table-row:hover .token-name {
+          color: #93c5fd;
+        }
+
+        .bctsl-token-list-table-row:focus-visible td:not(.cell-fake) {
+          border-top-color: rgba(147, 197, 253, 0.55);
+          border-bottom-color: rgba(147, 197, 253, 0.55);
+        }
+
+        .bctsl-token-list-table-row:focus-visible td.cell-rank {
+          border-left-color: rgba(147, 197, 253, 0.55);
+        }
+
+        .bctsl-token-list-table-row:focus-visible td.cell-link {
+          border-right-color: rgba(147, 197, 253, 0.55);
+        }
+
+        .bctsl-token-list-table-row .token-name {
+          transition: color 0.2s ease;
+        }
+
+        .bctsl-token-list-table-row .cell-rank {
+          font-family: var(--heading-font-family);
         }
 
         /* --- Container-width-based column visibility --- */
@@ -338,19 +401,35 @@ const TokenListTable = ({
         .bctsl-token-list-container[data-container-xl="true"] .cell-volume { width: 115px; }
         .bctsl-token-list-container[data-container-xl="true"] .cell-supply { width: 115px; }
 
-        /* Sticky header — when container is ≥ 768px */
+        /* Sticky header — ≥768px container (Safari: opaque only — backdrop-filter washes table while scrolling) */
         .bctsl-token-list-container[data-container-md="true"] .bctsl-token-list-table > thead {
           position: sticky;
           top: 0;
           z-index: 20;
-          backdrop-filter: blur(16px);
-          -webkit-backdrop-filter: blur(16px);
+          background: rgba(var(--background-color-rgb), 0.97);
         }
 
         .bctsl-token-list-container[data-container-md="true"] .bctsl-token-list-table > thead th {
+          background: rgba(var(--background-color-rgb), 0.97);
           border-bottom: 1px solid rgba(255, 255, 255, 0.08);
           padding-top: 10px;
           padding-bottom: 10px;
+        }
+
+        /* Chrome / Firefox / etc.: restore frosted sticky header (not @supports(-webkit-touch-callout) — that matches Chrome too) */
+        .bctsl-token-list-container:not([data-safari="true"])[data-container-md="true"][data-compact="false"] .bctsl-token-list-table > thead {
+          backdrop-filter: blur(16px);
+          -webkit-backdrop-filter: blur(16px);
+          background: rgba(var(--background-color-rgb), 0.2);
+        }
+
+        .bctsl-token-list-container:not([data-safari="true"])[data-container-md="true"][data-compact="false"] .bctsl-token-list-table > thead th {
+          background: rgba(var(--background-color-rgb), 0.08);
+        }
+
+        /* Safari: sticky thead + border-spacing leaves a gap above the header (WebKit applies outer vertical spacing) */
+        .bctsl-token-list-container[data-safari="true"][data-container-md="true"][data-compact="false"] .bctsl-token-list-table > thead {
+          top: calc(-2 * var(--bctsl-table-v-spacing, 6px));
         }
 
         /* Narrower container: reduce font sizes */
@@ -374,19 +453,27 @@ const TokenListTable = ({
           position: sticky;
           top: var(--token-list-sticky-top);
           z-index: 20;
-          background: rgba(255, 255, 255, 0.05);
-          backdrop-filter: blur(20px);
-          -webkit-backdrop-filter: blur(20px);
+          background: rgba(var(--background-color-rgb), 0.97);
         }
 
         .bctsl-token-list-container[data-compact="true"] .bctsl-token-list-table > thead th {
           font-size: 11px;
           line-height: 1rem;
           white-space: nowrap;
-          background: rgba(255, 255, 255, 0.05);
+          background: rgba(var(--background-color-rgb), 0.97);
           padding-top: 8px;
           padding-bottom: 8px;
           border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .bctsl-token-list-container:not([data-safari="true"])[data-compact="true"] .bctsl-token-list-table > thead {
+          backdrop-filter: blur(20px);
+          -webkit-backdrop-filter: blur(20px);
+          background: rgba(var(--background-color-rgb), 0.24);
+        }
+
+        .bctsl-token-list-container:not([data-safari="true"])[data-compact="true"] .bctsl-token-list-table > thead th {
+          background: rgba(var(--background-color-rgb), 0.1);
         }
 
         .bctsl-token-list-container[data-compact="true"] .bctsl-token-list-table .cell-fake { width: 0; padding: 0; }

--- a/src/features/trending/components/TokenListTableRow.tsx
+++ b/src/features/trending/components/TokenListTableRow.tsx
@@ -1,7 +1,8 @@
 import { TokenDto } from '@/api/generated/models/TokenDto';
 import { PriceDataFormatter } from '@/features/shared/components';
 import { toAe } from '@/utils/bondingCurve';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Decimal } from '../../../libs/decimal';
 import { TokenLineChart } from './TokenLineChart';
 
@@ -41,6 +42,7 @@ const TokenListTableRow = ({
   useCollectionRank = false,
   rank,
 }: TokenListTableRowProps) => {
+  const navigate = useNavigate();
   const tokenAddress = useMemo(() => token.address, [token.address]);
   const collectionRank = useCollectionRank ? (token as any).collection_rank : rank;
   const saleAddress = useMemo(
@@ -54,11 +56,59 @@ const TokenListTableRow = ({
   const volume = perf30d?.volume ? Decimal.from(perf30d.volume) : null;
 
   const tokenHref = `/trending/tokens/${encodeURIComponent(token.name || token.address)}`;
+  const tokenLabel = token.name || token.symbol || token.address;
+
+  const handleRowClick = useCallback(
+    (event: React.MouseEvent<HTMLTableRowElement>) => {
+      if ((event.target as HTMLElement).closest('a, button')) return;
+      if (event.metaKey || event.ctrlKey) {
+        window.open(tokenHref, '_blank', 'noopener');
+      } else if (event.shiftKey) {
+        window.open(tokenHref);
+      } else {
+        navigate(tokenHref);
+      }
+    },
+    [navigate, tokenHref],
+  );
+
+  const handleRowAuxClick = useCallback(
+    (event: React.MouseEvent<HTMLTableRowElement>) => {
+      if (event.button === 1) {
+        event.preventDefault();
+        window.open(tokenHref, '_blank', 'noopener');
+      }
+    },
+    [tokenHref],
+  );
+
+  const handleRowKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTableRowElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        if (event.metaKey || event.ctrlKey) {
+          window.open(tokenHref, '_blank', 'noopener');
+        } else {
+          navigate(tokenHref);
+        }
+      }
+    },
+    [navigate, tokenHref],
+  );
 
   return (
     <>
       {/* Mobile compact card row — 4 columns: rank | name+MC | price+30d% | chart */}
-      <tr className="mobile-only-card relative">
+      <tr
+        className="mobile-only-card relative"
+        onClick={handleRowClick}
+        onAuxClick={handleRowAuxClick}
+        onKeyDown={handleRowKeyDown}
+        tabIndex={0}
+        role="link"
+        aria-label={`View ${tokenLabel}`}
+      >
+        {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
         <td className="cell-fake" />
 
         {/* Rank */}
@@ -106,16 +156,20 @@ const TokenListTableRow = ({
               <TokenLineChart saleAddress={saleAddress} height={40} width={64} interval="all-time" />
             </div>
           )}
-          <a
-            href={tokenHref}
-            className="link absolute inset-0 z-10"
-            aria-label={`View ${token.name || token.symbol}`}
-          />
         </td>
       </tr>
 
-      {/* Desktop table row */}
-      <tr className="bctsl-token-list-table-row rounded-xl relative overflow-hidden transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]">
+      {/* Desktop row: Safari-safe — no overlay links, no row transforms */}
+      <tr
+        className="bctsl-token-list-table-row"
+        onClick={handleRowClick}
+        onAuxClick={handleRowAuxClick}
+        onKeyDown={handleRowKeyDown}
+        tabIndex={0}
+        role="link"
+        aria-label={`View ${tokenLabel}`}
+      >
+        {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
         <td className="cell-fake" />
 
         {/* Rank */}
@@ -199,73 +253,7 @@ const TokenListTableRow = ({
           )}
         </td>
 
-        {/* Full-row link overlay */}
-        <td className="cell cell-link">
-          <a
-            href={tokenHref}
-            className="link absolute inset-0 z-10"
-            aria-label={`View ${token.name || token.symbol}`}
-          />
-        </td>
-
-        <style>
-          {`
-          .bctsl-token-list-table-row {
-            position: relative;
-            z-index: 1;
-            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-            transform: translate(0, 0);
-          }
-
-          .bctsl-token-list-table-row::after {
-            content: '';
-            position: absolute;
-            inset: 0;
-            border-radius: 12px;
-            background: rgba(255, 255, 255, 0.02);
-            border: 1px solid rgba(255, 255, 255, 0.05);
-            transition: all 0.3s ease;
-            pointer-events: none;
-          }
-
-          .bctsl-token-list-table-row:hover::after {
-            background: rgba(17, 97, 254, 0.06);
-            border-color: rgba(17, 97, 254, 0.2);
-          }
-
-          .bctsl-token-list-table-row:hover {
-            transform: translateY(-1px);
-          }
-
-          .bctsl-token-list-table-row:hover .token-name {
-            color: #93c5fd;
-          }
-
-          .token-name {
-            transition: color 0.2s ease;
-          }
-
-          .link {
-            position: absolute;
-            z-index: 10;
-            inset: 0;
-          }
-
-          .cell-rank {
-            font-family: var(--heading-font-family);
-          }
-
-          .mobile-label {
-            text-wrap: nowrap;
-          }
-
-          @media screen and (max-width: 767px) {
-            .mobile-market-cap .price {
-              display: none;
-            }
-          }
-          `}
-        </style>
+        <td className="cell cell-link" aria-hidden="true" />
       </tr>
     </>
   );

--- a/src/features/trending/components/__tests__/TokenListTableRow.test.tsx
+++ b/src/features/trending/components/__tests__/TokenListTableRow.test.tsx
@@ -1,0 +1,134 @@
+import {
+  fireEvent,
+  render,
+} from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import TokenListTableRow from '../TokenListTableRow';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('react-router-dom')>();
+  return { ...mod, useNavigate: () => mockNavigate };
+});
+
+vi.mock('@/features/shared/components', () => ({
+  PriceDataFormatter: () => <span data-testid="price-data-formatter">price</span>,
+}));
+
+vi.mock('../TokenLineChart', () => ({
+  TokenLineChart: () => <div data-testid="token-line-chart" />,
+}));
+
+const TOKEN = {
+  address: 'ct_test',
+  sale_address: 'ct_sale',
+  name: 'Alpha Token',
+  symbol: 'ALPHA',
+  total_supply: '1000000000000000000',
+  price_data: { usd: 1 },
+  market_cap_data: { usd: 10 },
+  performance: {},
+} as any;
+
+const EXPECTED_HREF = '/trending/tokens/Alpha%20Token';
+
+function renderRow() {
+  return render(
+    <MemoryRouter>
+      <table>
+        <tbody>
+          <TokenListTableRow token={TOKEN} rank={1} />
+        </tbody>
+      </table>
+    </MemoryRouter>,
+  );
+}
+
+describe('TokenListTableRow', () => {
+  it('renders accessible clickable rows', () => {
+    const { container } = renderRow();
+
+    const rows = container.querySelectorAll('tr[role="link"]');
+    expect(rows).toHaveLength(2);
+    rows.forEach((row) => {
+      expect(row).toHaveAttribute(
+        'aria-label',
+        'View Alpha Token',
+      );
+      expect(row).toHaveAttribute('tabindex', '0');
+    });
+  });
+
+  it('uses SPA navigation on plain click', () => {
+    const { container } = renderRow();
+
+    const desktopRow = container.querySelector(
+      'tr.bctsl-token-list-table-row',
+    )!;
+    fireEvent.click(desktopRow);
+    expect(mockNavigate).toHaveBeenCalledWith(EXPECTED_HREF);
+  });
+
+  it('opens new tab on Ctrl+click', () => {
+    const spy = vi.spyOn(window, 'open')
+      .mockImplementation(() => null);
+
+    const { container } = renderRow();
+    const desktopRow = container.querySelector(
+      'tr.bctsl-token-list-table-row',
+    )!;
+
+    fireEvent.click(desktopRow, { ctrlKey: true });
+    expect(spy).toHaveBeenCalledWith(
+      EXPECTED_HREF,
+      '_blank',
+      'noopener',
+    );
+    spy.mockRestore();
+  });
+
+  it('opens new tab on Meta+click (Cmd)', () => {
+    const spy = vi.spyOn(window, 'open')
+      .mockImplementation(() => null);
+
+    const { container } = renderRow();
+    const desktopRow = container.querySelector(
+      'tr.bctsl-token-list-table-row',
+    )!;
+
+    fireEvent.click(desktopRow, { metaKey: true });
+    expect(spy).toHaveBeenCalledWith(
+      EXPECTED_HREF,
+      '_blank',
+      'noopener',
+    );
+    spy.mockRestore();
+  });
+
+  it('opens new tab on middle-click', () => {
+    const spy = vi.spyOn(window, 'open')
+      .mockImplementation(() => null);
+
+    const { container } = renderRow();
+    const desktopRow = container.querySelector(
+      'tr.bctsl-token-list-table-row',
+    )!;
+
+    fireEvent(
+      desktopRow,
+      new MouseEvent('auxclick', { button: 1, bubbles: true }),
+    );
+    expect(spy).toHaveBeenCalledWith(
+      EXPECTED_HREF,
+      '_blank',
+      'noopener',
+    );
+    spy.mockRestore();
+  });
+});

--- a/src/features/trending/views/TokenList.tsx
+++ b/src/features/trending/views/TokenList.tsx
@@ -672,7 +672,7 @@ const TokenList = () => {
                     </div>
                     <div className="w-full sm:w-auto sm:flex-shrink-0">
                       <Select value={orderBy} onValueChange={updateOrderBy}>
-                        <SelectTrigger className="h-10 w-full rounded-lg border border-white/10 bg-white/[0.02] px-2 py-2 text-xs text-white backdrop-blur-[10px] transition-all duration-300 hover:bg-white/[0.05] focus:outline-none focus:border-[#1161FE] sm:min-w-[140px]">
+                        <SelectTrigger className="h-10 w-full rounded-lg border border-white/10 bg-white/[0.06] px-2 py-2 text-xs text-white transition-all duration-300 hover:bg-white/[0.08] focus:outline-none focus:border-[#1161FE] sm:min-w-[140px]">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent className="bg-gray-900 border-white/10">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes table row click/navigation behavior and conditional Safari-specific styling, which could affect link handling and keyboard/mouse interactions across browsers. Adds tests to reduce regressions but still touches core list UI/UX.
> 
> **Overview**
> Fixes Safari rendering issues in the trending token table by switching to Safari-safe row styling (solid `td` backgrounds, no `tr` transforms/overlays) and by making sticky headers opaque in Safari while keeping the frosted blur effect for non-Safari browsers.
> 
> Refactors `TokenListTableRow` to remove full-row `<a>` overlays and instead implement accessible, keyboard-focusable rows with SPA navigation plus modifier/middle-click behavior (`Ctrl/Cmd`/middle-click opens a new tab). Adds a Vitest suite covering these navigation interactions, and slightly adjusts the sort `SelectTrigger` styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb79752063fc6f8a13ca65f4aebe3275fb28873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->