### PR TITLE
Add search to home page

### DIFF
--- a/src/components/layout/FeedRailSearch.tsx
+++ b/src/components/layout/FeedRailSearch.tsx
@@ -1,6 +1,7 @@
 import AddressAvatar from '@/components/AddressAvatar';
 import Spinner from '@/components/Spinner';
 import { Input } from '@/components/ui/input';
+import type { TFunction } from 'i18next';
 import {
   EXPLORE_SEARCH_QUERY_KEY,
   FEED_RAIL_SEARCH_DEBOUNCE_MS,
@@ -19,11 +20,34 @@ import {
 } from 'lucide-react';
 import {
   useCallback, useEffect, useRef, useState,
-  type MouseEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
   type ReactNode,
 } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate, type NavigateFunction } from 'react-router-dom';
 import { formatAddress } from '@/utils/address';
+
+const FEED_RAIL_DROPDOWN_PANEL_CLASS = [
+  'absolute z-[60] left-0 right-0 mt-2 rounded-xl border border-white/10',
+  'bg-[#0f1118] shadow-lg max-h-[min(70vh,33rem)] overflow-y-auto overflow-x-hidden',
+].join(' ');
+
+function feedNavTrendToken(navigate: NavigateFunction, nameOrAddress: string) {
+  navigate(`/trends/tokens/${encodeURIComponent(nameOrAddress)}`);
+}
+
+function feedNavUser(navigate: NavigateFunction, address: string) {
+  navigate(`/users/${address}`);
+}
+
+function feedNavPost(navigate: NavigateFunction, slugOrId: string) {
+  navigate(`/post/${encodeURIComponent(slugOrId)}`);
+}
+
+function feedNavExploreWithQuery(navigate: NavigateFunction, q: string) {
+  navigate(`/trends/tokens?${EXPLORE_SEARCH_QUERY_KEY}=${encodeURIComponent(q)}`);
+}
 
 function feedRailRowKey(row: FeedRailSearchItem, index: number): string {
   if (row.type === 'token') return `t-${row.item.address}-${index}`;
@@ -38,24 +62,31 @@ function trendHashtag(token: { symbol?: string | null; name?: string | null }): 
   return cleaned ? `#${cleaned}` : '#—';
 }
 
-function postPreview(content: string | undefined, maxLen = 200): string {
+function postPreview(
+  content: string | undefined,
+  emptyLabel: string,
+  maxLen = 200,
+): string {
   const raw = (content || '').replace(/\s+/g, ' ').trim();
-  if (!raw) return 'Post';
+  if (!raw) return emptyLabel;
   return raw.length > maxLen ? `${raw.slice(0, maxLen)}…` : raw;
 }
 
-function recentRemoveAriaLabel(entry: FeedRailRecentEntry): string {
+function recentRemoveAriaLabel(
+  entry: FeedRailRecentEntry,
+  t: TFunction<'common'>,
+): string {
   switch (entry.kind) {
     case 'query':
-      return `Remove recent search "${entry.query}"`;
+      return t('feedRailSearch.aria.removeRecentQuery', { query: entry.query });
     case 'token':
-      return 'Remove this trend from recent searches';
+      return t('feedRailSearch.aria.removeRecentToken');
     case 'user':
-      return 'Remove this profile from recent searches';
+      return t('feedRailSearch.aria.removeRecentUser');
     case 'post':
-      return 'Remove this post from recent searches';
+      return t('feedRailSearch.aria.removeRecentPost');
     default:
-      return 'Remove from recent searches';
+      return t('feedRailSearch.aria.removeRecentDefault');
   }
 }
 
@@ -66,8 +97,9 @@ const FeedRailRecentRow = ({
 }: {
   entry: FeedRailRecentEntry;
   onActivate: () => void;
-  onRemoveClick: (e: MouseEvent) => void;
+  onRemoveClick: (e: ReactMouseEvent) => void;
 }) => {
+  const { t } = useTranslation('common');
   let main: ReactNode;
   switch (entry.kind) {
     case 'query':
@@ -79,7 +111,7 @@ const FeedRailRecentRow = ({
               {entry.query}
             </div>
             <div className="text-[10px] text-white/45 mt-0.5">
-              Search on Explore
+              {t('feedRailSearch.searchOnExplore')}
             </div>
           </div>
         </>
@@ -90,7 +122,7 @@ const FeedRailRecentRow = ({
       main = (
         <div className="min-w-0 flex-1 text-left w-full">
           <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
-            Trend
+            {t('feedRailSearch.trend')}
           </div>
           <div className="text-[15px] font-semibold text-white leading-tight">
             {trendHashtag({ symbol: entry.symbol, name: entry.name })}
@@ -114,7 +146,7 @@ const FeedRailRecentRow = ({
           />
           <div className="min-w-0 flex-1 text-left">
             <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
-              People
+              {t('feedRailSearch.people')}
             </div>
             <div className="text-[15px] font-semibold text-white truncate leading-tight">
               {title}
@@ -131,7 +163,7 @@ const FeedRailRecentRow = ({
       main = (
         <div className="min-w-0 flex-1 text-left w-full">
           <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
-            Post
+            {t('feedRailSearch.post')}
           </div>
           <p className="text-[13px] text-white/90 leading-snug line-clamp-4 m-0">
             {entry.preview}
@@ -157,7 +189,7 @@ const FeedRailRecentRow = ({
       <button
         type="button"
         className="flex items-center justify-center w-10 shrink-0 text-white/45 hover:text-white hover:bg-white/[0.08] border-none bg-transparent cursor-pointer"
-        aria-label={recentRemoveAriaLabel(entry)}
+        aria-label={recentRemoveAriaLabel(entry, t)}
         onClick={onRemoveClick}
       >
         <X className="w-4 h-4" aria-hidden />
@@ -167,6 +199,7 @@ const FeedRailRecentRow = ({
 };
 
 const FeedRailSearch = () => {
+  const { t } = useTranslation('common');
   const navigate = useNavigate();
   const [searchInput, setSearchInput] = useState('');
   const debounced = useDebouncedTrimmedSearch(searchInput, FEED_RAIL_SEARCH_DEBOUNCE_MS);
@@ -188,10 +221,17 @@ const FeedRailSearch = () => {
   const showRecentsPanel = open && trimmedInput.length === 0;
   const showSearchPanel = open && trimmedInput.length > 0;
 
-  const livePickTerm = (debounced || trimmedInput).trim();
-  if (livePickTerm) lastPickSearchRef.current = livePickTerm;
+  useEffect(() => {
+    const live = (debounced || trimmedInput).trim();
+    if (live) lastPickSearchRef.current = live;
+  }, [debounced, trimmedInput]);
 
-  const { data: items = [], isFetching, isError } = useQuery({
+  const {
+    data: items = [],
+    isFetching,
+    isError,
+    isPlaceholderData,
+  } = useQuery({
     queryKey: ['feed-rail-search', debounced],
     queryFn: () => fetchFeedRailSearchItems(debounced),
     enabled: hasQuery,
@@ -200,14 +240,20 @@ const FeedRailSearch = () => {
     placeholderData: (prev) => prev,
   });
 
+  /**
+   * `placeholderData` + `enabled: hasQuery` can surface the last fetch while debounce
+   * catches up (or the field is cleared); never treat that as live hits.
+   */
+  const hitsAreForActiveQuery = hasQuery && !isPlaceholderData;
+
   useEffect(() => {
-    const onDoc = (e: MouseEvent) => {
+    const onDoc = (e: PointerEvent) => {
       if (!rootRef.current?.contains(e.target as Node)) {
         setOpen(false);
       }
     };
-    document.addEventListener('mousedown', onDoc);
-    return () => document.removeEventListener('mousedown', onDoc);
+    document.addEventListener('pointerdown', onDoc);
+    return () => document.removeEventListener('pointerdown', onDoc);
   }, []);
 
   useEffect(() => {
@@ -225,56 +271,61 @@ const FeedRailSearch = () => {
 
   /** Capture phase so we still see the query before browser `type="search"` clear or blur races. */
   const capturePickSearchTerm = useCallback(() => {
-    const t = (debounced || searchInput.trim()).trim();
-    if (t) lastPickSearchRef.current = t;
+    const term = (debounced || searchInput.trim()).trim();
+    if (term) lastPickSearchRef.current = term;
   }, [debounced, searchInput]);
 
   const go = useCallback(
     (row: FeedRailSearchItem) => {
       const term = (debounced || searchInput.trim()).trim() || lastPickSearchRef.current;
-      if (row.type === 'token') {
-        const t = row.item;
-        pushRecent({
-          kind: 'token',
-          id: `t-${t.address}`,
-          query: term,
-          address: t.address,
-          name: t.name ?? '',
-          symbol: t.symbol ?? '',
-        });
-      } else if (row.type === 'user') {
-        const u = row.item;
-        pushRecent({
-          kind: 'user',
-          id: `u-${u.address}`,
-          query: term,
-          address: u.address,
-          chain_name: u.chain_name ?? null,
-        });
-      } else {
-        const p = row.item;
-        pushRecent({
-          kind: 'post',
-          id: `p-${p.id}`,
-          query: term,
-          postId: p.id,
-          slug: p.slug ?? null,
-          preview: postPreview(p.content),
-        });
-      }
-      if (row.type === 'token') {
-        const { name, address } = row.item;
-        navigate(`/trends/tokens/${encodeURIComponent(name || address)}`);
-      } else if (row.type === 'user') {
-        navigate(`/users/${row.item.address}`);
-      } else {
-        const p = row.item;
-        const slugOrId = (p.slug || p.id) as string;
-        navigate(`/post/${encodeURIComponent(slugOrId)}`);
+      switch (row.type) {
+        case 'token': {
+          const { address, name, symbol } = row.item;
+          pushRecent({
+            kind: 'token',
+            id: `t-${address}`,
+            query: term,
+            address,
+            name: name ?? '',
+            symbol: symbol ?? '',
+          });
+          feedNavTrendToken(navigate, name || address);
+          break;
+        }
+        case 'user': {
+          const user = row.item;
+          pushRecent({
+            kind: 'user',
+            id: `u-${user.address}`,
+            query: term,
+            address: user.address,
+            chain_name: user.chain_name ?? null,
+          });
+          feedNavUser(navigate, user.address);
+          break;
+        }
+        case 'post': {
+          const post = row.item;
+          pushRecent({
+            kind: 'post',
+            id: `p-${post.id}`,
+            query: term,
+            postId: post.id,
+            slug: post.slug ?? null,
+            preview: postPreview(
+              post.content,
+              t('feedRailSearch.postPreviewFallback'),
+            ),
+          });
+          feedNavPost(navigate, (post.slug || post.id) as string);
+          break;
+        }
+        default:
+          break;
       }
       clearSearchUi();
     },
-    [navigate, clearSearchUi, debounced, searchInput, pushRecent],
+    [navigate, clearSearchUi, debounced, searchInput, pushRecent, t],
   );
 
   const onPickRecent = useCallback(
@@ -286,16 +337,34 @@ const FeedRailSearch = () => {
         return;
       }
       if (entry.kind === 'token') {
-        navigate(`/trends/tokens/${encodeURIComponent(entry.name || entry.address)}`);
+        feedNavTrendToken(navigate, entry.name || entry.address);
       } else if (entry.kind === 'user') {
-        navigate(`/users/${entry.address}`);
+        feedNavUser(navigate, entry.address);
       } else {
-        const slugOrId = (entry.slug || entry.postId) as string;
-        navigate(`/post/${encodeURIComponent(slugOrId)}`);
+        feedNavPost(navigate, (entry.slug || entry.postId) as string);
       }
       clearSearchUi();
     },
     [pushRecent, navigate, clearSearchUi],
+  );
+
+  /** Same as choosing the Explore row: full Explore search with `q`, plus recent query. */
+  const submitSearchToExplore = useCallback(() => {
+    const q = activeSearchLabel.trim();
+    if (q) {
+      pushRecent({ kind: 'query', id: `q-${q.toLowerCase()}`, query: q });
+      feedNavExploreWithQuery(navigate, q);
+    }
+    clearSearchUi();
+  }, [activeSearchLabel, pushRecent, navigate, clearSearchUi]);
+
+  const onSearchKeyDown = useCallback(
+    (e: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== 'Enter') return;
+      e.preventDefault();
+      submitSearchToExplore();
+    },
+    [submitSearchToExplore],
   );
 
   return (
@@ -304,11 +373,12 @@ const FeedRailSearch = () => {
         <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/45 pointer-events-none" />
         <Input
           type="search"
-          aria-label="Search trends, users and posts"
+          aria-label={t('feedRailSearch.inputAria')}
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value)}
+          onKeyDown={onSearchKeyDown}
           onFocus={() => setOpen(true)}
-          placeholder="Search trends, users or posts"
+          placeholder={t('feedRailSearch.inputPlaceholder')}
           className="h-9 rounded-xl border-white/10 bg-white/[0.04] pl-9 pr-2.5 text-xs text-white placeholder:text-white/40 focus-visible:ring-[#1161FE]"
           autoComplete="off"
         />
@@ -316,25 +386,25 @@ const FeedRailSearch = () => {
 
       {showRecentsPanel ? (
         <div
-          className="absolute z-[60] left-0 right-0 mt-2 rounded-xl border border-white/10 bg-[#0f1118] shadow-lg max-h-[min(70vh,33rem)] overflow-y-auto overflow-x-hidden"
+          className={FEED_RAIL_DROPDOWN_PANEL_CLASS}
           role="region"
-          aria-label="Recent searches"
+          aria-label={t('feedRailSearch.recentRegionAria')}
         >
           {recentItems.length > 0 ? (
             <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-white/10">
-              <span className="text-[15px] font-bold text-white">Recent</span>
+              <span className="text-[15px] font-bold text-white">{t('feedRailSearch.recent')}</span>
               <button
                 type="button"
                 className="text-[13px] font-semibold text-[#1161FE] hover:text-[#3d7efe] bg-transparent border-none p-0 cursor-pointer shrink-0"
                 onClick={() => clearAll()}
               >
-                Clear all
+                {t('feedRailSearch.clearAll')}
               </button>
             </div>
           ) : null}
           {recentItems.length === 0 ? (
             <div className="px-3 py-6 text-[13px] text-white/50 text-center leading-snug">
-              Try searching for trends, people, posts
+              {t('feedRailSearch.recentsEmpty')}
             </div>
           ) : (
             recentItems.map((entry) => (
@@ -353,20 +423,20 @@ const FeedRailSearch = () => {
       ) : null}
 
       {showSearchPanel ? (
-        <div
-          className="absolute z-[60] left-0 right-0 mt-2 rounded-xl border border-white/10 bg-[#0f1118] shadow-lg max-h-[min(70vh,33rem)] overflow-y-auto overflow-x-hidden"
-        >
+        <div className={FEED_RAIL_DROPDOWN_PANEL_CLASS}>
           <Link
-            to={`/trends/tokens?${EXPLORE_SEARCH_QUERY_KEY}=${encodeURIComponent(activeSearchLabel)}`}
-            onClick={() => {
-              const q = activeSearchLabel.trim();
-              if (q) {
-                pushRecent({ kind: 'query', id: `q-${q.toLowerCase()}`, query: q });
-              }
-              clearSearchUi();
+            to={
+              activeSearchLabel.trim()
+                ? `/trends/tokens?${EXPLORE_SEARCH_QUERY_KEY}=${encodeURIComponent(activeSearchLabel.trim())}`
+                : '/trends/tokens'
+            }
+            onClick={(e) => {
+              if (e.ctrlKey || e.metaKey || e.shiftKey || e.altKey) return;
+              e.preventDefault();
+              submitSearchToExplore();
             }}
             className="flex items-center gap-2.5 px-3 py-2.5 border-b border-white/10 hover:bg-white/[0.06] transition-colors text-left no-underline w-full box-border"
-            aria-label={`Search "${activeSearchLabel}" on Explore`}
+            aria-label={t('feedRailSearch.exploreSearchAria', { query: activeSearchLabel })}
           >
             <SearchIcon className="w-4 h-4 text-[#8bc9ff] flex-shrink-0" aria-hidden />
             <div className="min-w-0 flex-1">
@@ -374,35 +444,35 @@ const FeedRailSearch = () => {
                 {activeSearchLabel}
               </div>
               <div className="text-[10px] text-white/45 mt-0.5">
-                Search on Explore
+                {t('feedRailSearch.searchOnExplore')}
               </div>
             </div>
           </Link>
 
-          {isFetching ? (
+          {hasQuery && isFetching ? (
             <div className="flex items-center justify-center gap-2 py-6 text-xs text-white/60">
               <Spinner className="w-4 h-4" />
-              <span>Searching…</span>
+              <span>{t('feedRailSearch.searching')}</span>
             </div>
           ) : null}
 
-          {!isFetching && isError ? (
+          {hasQuery && !isFetching && isError ? (
             <div className="px-3 py-4 text-xs text-white/60 text-center">
-              Search failed. Try again.
+              {t('feedRailSearch.searchFailed')}
             </div>
           ) : null}
 
-          {!isFetching && !isError && items.length === 0 ? (
+          {hitsAreForActiveQuery && !isFetching && !isError && items.length === 0 ? (
             <div className="px-3 py-4 text-xs text-white/60 text-center">
-              No results
+              {t('feedRailSearch.noResults')}
             </div>
           ) : null}
 
-          {!isFetching && !isError && items.length > 0
+          {hitsAreForActiveQuery && !isFetching && !isError && items.length > 0
             ? items.map((row, index) => {
               if (row.type === 'token') {
-                const t = row.item;
-                const addr = t.address ? formatAddress(t.address, 12, false) : '—';
+                const token = row.item;
+                const addr = token.address ? formatAddress(token.address, 12, false) : '—';
                 return (
                   <button
                     key={feedRailRowKey(row, index)}
@@ -412,10 +482,10 @@ const FeedRailSearch = () => {
                     onClick={() => go(row)}
                   >
                     <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
-                      Trend
+                      {t('feedRailSearch.trend')}
                     </div>
                     <div className="text-[15px] font-semibold text-white leading-tight">
-                      {trendHashtag(t)}
+                      {trendHashtag(token)}
                     </div>
                     <div className="text-[11px] text-white/45 font-mono tracking-tight mt-0.5 truncate">
                       {addr}
@@ -443,7 +513,7 @@ const FeedRailSearch = () => {
                     />
                     <div className="min-w-0 flex-1">
                       <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
-                        People
+                        {t('feedRailSearch.people')}
                       </div>
                       <div className="text-[15px] font-semibold text-white truncate leading-tight">
                         {title}
@@ -466,10 +536,10 @@ const FeedRailSearch = () => {
                   onClick={() => go(row)}
                 >
                   <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
-                    Post
+                    {t('feedRailSearch.post')}
                   </div>
                   <p className="text-[13px] text-white/90 leading-snug line-clamp-4 m-0">
-                    {postPreview(p.content)}
+                    {postPreview(p.content, t('feedRailSearch.postPreviewFallback'))}
                   </p>
                 </button>
               );

--- a/src/components/layout/FeedRailSearch.tsx
+++ b/src/components/layout/FeedRailSearch.tsx
@@ -1,0 +1,238 @@
+import AddressAvatar from '@/components/AddressAvatar';
+import Spinner from '@/components/Spinner';
+import { Input } from '@/components/ui/input';
+import {
+  EXPLORE_SEARCH_QUERY_KEY,
+  FEED_RAIL_SEARCH_DEBOUNCE_MS,
+  fetchFeedRailSearchItems,
+  type FeedRailSearchItem,
+} from '@/features/trending/api/trendsSearch';
+import { useDebouncedTrimmedSearch } from '@/hooks/useDebouncedValue';
+import { useQuery } from '@tanstack/react-query';
+import { Search as SearchIcon } from 'lucide-react';
+import {
+  useCallback, useEffect, useRef, useState,
+} from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { formatAddress } from '@/utils/address';
+
+function feedRailRowKey(row: FeedRailSearchItem, index: number): string {
+  if (row.type === 'token') return `t-${row.item.address}-${index}`;
+  if (row.type === 'user') return `u-${row.item.address}-${index}`;
+  return `p-${row.item.id}-${row.item.slug ?? ''}-${index}`;
+}
+
+/** Hashtag-style trend label: prefer symbol, then name (no leading # in source — we add it). */
+function trendHashtag(token: { symbol?: string | null; name?: string | null }): string {
+  const raw = (token.symbol || token.name || '').trim();
+  const cleaned = raw.replace(/^#+/, '');
+  return cleaned ? `#${cleaned}` : '#—';
+}
+
+function postPreview(content: string | undefined, maxLen = 200): string {
+  const raw = (content || '').replace(/\s+/g, ' ').trim();
+  if (!raw) return 'Post';
+  return raw.length > maxLen ? `${raw.slice(0, maxLen)}…` : raw;
+}
+
+const FeedRailSearch = () => {
+  const navigate = useNavigate();
+  const [searchInput, setSearchInput] = useState('');
+  const debounced = useDebouncedTrimmedSearch(searchInput, FEED_RAIL_SEARCH_DEBOUNCE_MS);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const hasQuery = debounced.length > 0;
+
+  useEffect(() => {
+    setOpen(hasQuery);
+  }, [hasQuery]);
+
+  const { data: items = [], isFetching, isError } = useQuery({
+    queryKey: ['feed-rail-search', debounced],
+    queryFn: () => fetchFeedRailSearchItems(debounced),
+    enabled: hasQuery,
+    staleTime: 30 * 1000,
+    retry: 1,
+    placeholderData: (prev) => prev,
+  });
+
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  const clearSearchUi = useCallback(() => {
+    setOpen(false);
+    setSearchInput('');
+  }, []);
+
+  const go = useCallback(
+    (row: FeedRailSearchItem) => {
+      if (row.type === 'token') {
+        const { name, address } = row.item;
+        navigate(`/trends/tokens/${encodeURIComponent(name || address)}`);
+      } else if (row.type === 'user') {
+        navigate(`/users/${row.item.address}`);
+      } else {
+        const p = row.item;
+        const slugOrId = (p.slug || p.id) as string;
+        navigate(`/post/${encodeURIComponent(slugOrId)}`);
+      }
+      clearSearchUi();
+    },
+    [navigate, clearSearchUi],
+  );
+
+  return (
+    <div ref={rootRef} className="relative w-full overflow-visible">
+      <div className="relative">
+        <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/45 pointer-events-none" />
+        <Input
+          type="search"
+          aria-label="Search trends, users and posts"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          onFocus={() => {
+            if (searchInput.trim()) setOpen(true);
+          }}
+          placeholder="Search trends, users or posts"
+          className="h-9 rounded-xl border-white/10 bg-white/[0.04] pl-9 pr-2.5 text-xs text-white placeholder:text-white/40 focus-visible:ring-[#1161FE]"
+          autoComplete="off"
+        />
+      </div>
+
+      {open && hasQuery ? (
+        <div
+          className="absolute z-[60] left-0 right-0 mt-2 rounded-xl border border-white/10 bg-[#0f1118] shadow-lg max-h-[min(70vh,33rem)] overflow-y-auto overflow-x-hidden"
+        >
+          <Link
+            to={`/trends/tokens?${EXPLORE_SEARCH_QUERY_KEY}=${encodeURIComponent(debounced)}`}
+            onClick={clearSearchUi}
+            className="flex items-center gap-2.5 px-3 py-2.5 border-b border-white/10 hover:bg-white/[0.06] transition-colors text-left no-underline w-full box-border"
+            aria-label={`Search “${debounced}” on Explore`}
+          >
+            <SearchIcon className="w-4 h-4 text-[#8bc9ff] flex-shrink-0" aria-hidden />
+            <div className="min-w-0 flex-1">
+              <div className="text-[13px] font-semibold text-white truncate">
+                {debounced}
+              </div>
+              <div className="text-[10px] text-white/45 mt-0.5">
+                Search on Explore
+              </div>
+            </div>
+          </Link>
+
+          {isFetching ? (
+            <div className="flex items-center justify-center gap-2 py-6 text-xs text-white/60">
+              <Spinner className="w-4 h-4" />
+              <span>Searching…</span>
+            </div>
+          ) : null}
+
+          {!isFetching && isError ? (
+            <div className="px-3 py-4 text-xs text-white/60 text-center">
+              Search failed. Try again.
+            </div>
+          ) : null}
+
+          {!isFetching && !isError && items.length === 0 ? (
+            <div className="px-3 py-4 text-xs text-white/60 text-center">
+              No results
+            </div>
+          ) : null}
+
+          {!isFetching && !isError && items.length > 0
+            ? items.map((row, index) => {
+              if (row.type === 'token') {
+                const t = row.item;
+                const addr = t.address ? formatAddress(t.address, 12, false) : '—';
+                return (
+                  <button
+                    key={feedRailRowKey(row, index)}
+                    type="button"
+                    className="w-full text-left px-3 py-2.5 border-b border-white/5 last:border-b-0 hover:bg-white/[0.06] transition-colors"
+                    onClick={() => go(row)}
+                  >
+                    <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
+                      Trend
+                    </div>
+                    <div className="text-[15px] font-semibold text-white leading-tight">
+                      {trendHashtag(t)}
+                    </div>
+                    <div className="text-[11px] text-white/45 font-mono tracking-tight mt-0.5 truncate">
+                      {addr}
+                    </div>
+                  </button>
+                );
+              }
+
+              if (row.type === 'user') {
+                const u = row.item;
+                const title = u.chain_name || formatAddress(u.address, 6);
+                return (
+                  <button
+                    key={feedRailRowKey(row, index)}
+                    type="button"
+                    className="w-full flex items-start gap-2.5 px-3 py-2.5 border-b border-white/5 last:border-b-0 hover:bg-white/[0.06] transition-colors text-left"
+                    onClick={() => go(row)}
+                  >
+                    <AddressAvatar
+                      address={u.address}
+                      size={36}
+                      borderRadius="50%"
+                      className="flex-shrink-0 mt-0.5"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
+                        People
+                      </div>
+                      <div className="text-[15px] font-semibold text-white truncate leading-tight">
+                        {title}
+                      </div>
+                      <div className="text-[11px] text-white/45 font-mono truncate mt-0.5">
+                        {formatAddress(u.address, 14, false)}
+                      </div>
+                    </div>
+                  </button>
+                );
+              }
+
+              const p = row.item;
+              return (
+                <button
+                  key={feedRailRowKey(row, index)}
+                  type="button"
+                  className="w-full text-left px-3 py-2.5 border-b border-white/5 last:border-b-0 hover:bg-white/[0.06] transition-colors"
+                  onClick={() => go(row)}
+                >
+                  <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
+                    Post
+                  </div>
+                  <p className="text-[13px] text-white/90 leading-snug line-clamp-4 m-0">
+                    {postPreview(p.content)}
+                  </p>
+                </button>
+              );
+            })
+            : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default FeedRailSearch;

--- a/src/components/layout/FeedRailSearch.tsx
+++ b/src/components/layout/FeedRailSearch.tsx
@@ -8,10 +8,19 @@ import {
   type FeedRailSearchItem,
 } from '@/features/trending/api/trendsSearch';
 import { useDebouncedTrimmedSearch } from '@/hooks/useDebouncedValue';
+import {
+  useFeedRailRecentSearches,
+  type FeedRailRecentEntry,
+} from '@/hooks/useFeedRailRecentSearches';
 import { useQuery } from '@tanstack/react-query';
-import { Search as SearchIcon } from 'lucide-react';
+import {
+  Search as SearchIcon,
+  X,
+} from 'lucide-react';
 import {
   useCallback, useEffect, useRef, useState,
+  type MouseEvent,
+  type ReactNode,
 } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { formatAddress } from '@/utils/address';
@@ -35,18 +44,152 @@ function postPreview(content: string | undefined, maxLen = 200): string {
   return raw.length > maxLen ? `${raw.slice(0, maxLen)}…` : raw;
 }
 
+function recentRemoveAriaLabel(entry: FeedRailRecentEntry): string {
+  switch (entry.kind) {
+    case 'query':
+      return `Remove recent search "${entry.query}"`;
+    case 'token':
+      return 'Remove this trend from recent searches';
+    case 'user':
+      return 'Remove this profile from recent searches';
+    case 'post':
+      return 'Remove this post from recent searches';
+    default:
+      return 'Remove from recent searches';
+  }
+}
+
+const FeedRailRecentRow = ({
+  entry,
+  onActivate,
+  onRemoveClick,
+}: {
+  entry: FeedRailRecentEntry;
+  onActivate: () => void;
+  onRemoveClick: (e: MouseEvent) => void;
+}) => {
+  let main: ReactNode;
+  switch (entry.kind) {
+    case 'query':
+      main = (
+        <>
+          <SearchIcon className="w-4 h-4 text-[#8bc9ff] flex-shrink-0 mt-0.5" aria-hidden />
+          <div className="min-w-0 flex-1 text-left">
+            <div className="text-[13px] font-semibold text-white truncate">
+              {entry.query}
+            </div>
+            <div className="text-[10px] text-white/45 mt-0.5">
+              Search on Explore
+            </div>
+          </div>
+        </>
+      );
+      break;
+    case 'token': {
+      const addr = entry.address ? formatAddress(entry.address, 12, false) : '—';
+      main = (
+        <div className="min-w-0 flex-1 text-left w-full">
+          <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
+            Trend
+          </div>
+          <div className="text-[15px] font-semibold text-white leading-tight">
+            {trendHashtag({ symbol: entry.symbol, name: entry.name })}
+          </div>
+          <div className="text-[11px] text-white/45 font-mono tracking-tight mt-0.5 truncate">
+            {addr}
+          </div>
+        </div>
+      );
+      break;
+    }
+    case 'user': {
+      const title = entry.chain_name || formatAddress(entry.address, 6);
+      main = (
+        <>
+          <AddressAvatar
+            address={entry.address}
+            size={36}
+            borderRadius="50%"
+            className="flex-shrink-0 mt-0.5"
+          />
+          <div className="min-w-0 flex-1 text-left">
+            <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
+              People
+            </div>
+            <div className="text-[15px] font-semibold text-white truncate leading-tight">
+              {title}
+            </div>
+            <div className="text-[11px] text-white/45 font-mono truncate mt-0.5">
+              {formatAddress(entry.address, 14, false)}
+            </div>
+          </div>
+        </>
+      );
+      break;
+    }
+    case 'post':
+      main = (
+        <div className="min-w-0 flex-1 text-left w-full">
+          <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
+            Post
+          </div>
+          <p className="text-[13px] text-white/90 leading-snug line-clamp-4 m-0">
+            {entry.preview}
+          </p>
+        </div>
+      );
+      break;
+    default:
+      main = null;
+  }
+
+  const rowFlex = entry.kind === 'user'
+    ? 'flex flex-1 min-w-0 items-start gap-2.5 px-3 py-2.5 text-left bg-transparent border-none cursor-pointer text-white w-full'
+    : 'flex flex-1 min-w-0 items-center gap-2.5 px-3 py-2.5 text-left bg-transparent border-none cursor-pointer text-white w-full';
+
+  return (
+    <div
+      className="flex items-stretch border-b border-white/5 last:border-b-0 hover:bg-white/[0.06] transition-colors"
+    >
+      <button type="button" className={rowFlex} onClick={onActivate}>
+        {main}
+      </button>
+      <button
+        type="button"
+        className="flex items-center justify-center w-10 shrink-0 text-white/45 hover:text-white hover:bg-white/[0.08] border-none bg-transparent cursor-pointer"
+        aria-label={recentRemoveAriaLabel(entry)}
+        onClick={onRemoveClick}
+      >
+        <X className="w-4 h-4" aria-hidden />
+      </button>
+    </div>
+  );
+};
+
 const FeedRailSearch = () => {
   const navigate = useNavigate();
   const [searchInput, setSearchInput] = useState('');
   const debounced = useDebouncedTrimmedSearch(searchInput, FEED_RAIL_SEARCH_DEBOUNCE_MS);
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+  /** Last non-empty search text (survives races where the field clears before `go` runs). */
+  const lastPickSearchRef = useRef('');
+  const {
+    items: recentItems,
+    pushRecent,
+    removeRecent,
+    clearAll,
+  } = useFeedRailRecentSearches();
 
+  const trimmedInput = searchInput.trim();
   const hasQuery = debounced.length > 0;
+  /** Query shown in the Explore row while debounce is catching up. */
+  const activeSearchLabel = debounced || trimmedInput;
+  const showRecentsPanel = open && trimmedInput.length === 0;
+  const showSearchPanel = open && trimmedInput.length > 0;
 
-  useEffect(() => {
-    setOpen(hasQuery);
-  }, [hasQuery]);
+  const livePickTerm = (debounced || trimmedInput).trim();
+  if (livePickTerm) lastPickSearchRef.current = livePickTerm;
 
   const { data: items = [], isFetching, isError } = useQuery({
     queryKey: ['feed-rail-search', debounced],
@@ -80,8 +223,45 @@ const FeedRailSearch = () => {
     setSearchInput('');
   }, []);
 
+  /** Capture phase so we still see the query before browser `type="search"` clear or blur races. */
+  const capturePickSearchTerm = useCallback(() => {
+    const t = (debounced || searchInput.trim()).trim();
+    if (t) lastPickSearchRef.current = t;
+  }, [debounced, searchInput]);
+
   const go = useCallback(
     (row: FeedRailSearchItem) => {
+      const term = (debounced || searchInput.trim()).trim() || lastPickSearchRef.current;
+      if (row.type === 'token') {
+        const t = row.item;
+        pushRecent({
+          kind: 'token',
+          id: `t-${t.address}`,
+          query: term,
+          address: t.address,
+          name: t.name ?? '',
+          symbol: t.symbol ?? '',
+        });
+      } else if (row.type === 'user') {
+        const u = row.item;
+        pushRecent({
+          kind: 'user',
+          id: `u-${u.address}`,
+          query: term,
+          address: u.address,
+          chain_name: u.chain_name ?? null,
+        });
+      } else {
+        const p = row.item;
+        pushRecent({
+          kind: 'post',
+          id: `p-${p.id}`,
+          query: term,
+          postId: p.id,
+          slug: p.slug ?? null,
+          preview: postPreview(p.content),
+        });
+      }
       if (row.type === 'token') {
         const { name, address } = row.item;
         navigate(`/trends/tokens/${encodeURIComponent(name || address)}`);
@@ -94,7 +274,28 @@ const FeedRailSearch = () => {
       }
       clearSearchUi();
     },
-    [navigate, clearSearchUi],
+    [navigate, clearSearchUi, debounced, searchInput, pushRecent],
+  );
+
+  const onPickRecent = useCallback(
+    (entry: FeedRailRecentEntry) => {
+      pushRecent(entry);
+      if (entry.kind === 'query') {
+        setSearchInput(entry.query);
+        setOpen(true);
+        return;
+      }
+      if (entry.kind === 'token') {
+        navigate(`/trends/tokens/${encodeURIComponent(entry.name || entry.address)}`);
+      } else if (entry.kind === 'user') {
+        navigate(`/users/${entry.address}`);
+      } else {
+        const slugOrId = (entry.slug || entry.postId) as string;
+        navigate(`/post/${encodeURIComponent(slugOrId)}`);
+      }
+      clearSearchUi();
+    },
+    [pushRecent, navigate, clearSearchUi],
   );
 
   return (
@@ -106,29 +307,71 @@ const FeedRailSearch = () => {
           aria-label="Search trends, users and posts"
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value)}
-          onFocus={() => {
-            if (searchInput.trim()) setOpen(true);
-          }}
+          onFocus={() => setOpen(true)}
           placeholder="Search trends, users or posts"
           className="h-9 rounded-xl border-white/10 bg-white/[0.04] pl-9 pr-2.5 text-xs text-white placeholder:text-white/40 focus-visible:ring-[#1161FE]"
           autoComplete="off"
         />
       </div>
 
-      {open && hasQuery ? (
+      {showRecentsPanel ? (
+        <div
+          className="absolute z-[60] left-0 right-0 mt-2 rounded-xl border border-white/10 bg-[#0f1118] shadow-lg max-h-[min(70vh,33rem)] overflow-y-auto overflow-x-hidden"
+          role="region"
+          aria-label="Recent searches"
+        >
+          {recentItems.length > 0 ? (
+            <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-white/10">
+              <span className="text-[15px] font-bold text-white">Recent</span>
+              <button
+                type="button"
+                className="text-[13px] font-semibold text-[#1161FE] hover:text-[#3d7efe] bg-transparent border-none p-0 cursor-pointer shrink-0"
+                onClick={() => clearAll()}
+              >
+                Clear all
+              </button>
+            </div>
+          ) : null}
+          {recentItems.length === 0 ? (
+            <div className="px-3 py-6 text-[13px] text-white/50 text-center leading-snug">
+              Try searching for trends, people, posts
+            </div>
+          ) : (
+            recentItems.map((entry) => (
+              <FeedRailRecentRow
+                key={entry.id}
+                entry={entry}
+                onActivate={() => onPickRecent(entry)}
+                onRemoveClick={(e) => {
+                  e.stopPropagation();
+                  removeRecent(entry.id);
+                }}
+              />
+            ))
+          )}
+        </div>
+      ) : null}
+
+      {showSearchPanel ? (
         <div
           className="absolute z-[60] left-0 right-0 mt-2 rounded-xl border border-white/10 bg-[#0f1118] shadow-lg max-h-[min(70vh,33rem)] overflow-y-auto overflow-x-hidden"
         >
           <Link
-            to={`/trends/tokens?${EXPLORE_SEARCH_QUERY_KEY}=${encodeURIComponent(debounced)}`}
-            onClick={clearSearchUi}
+            to={`/trends/tokens?${EXPLORE_SEARCH_QUERY_KEY}=${encodeURIComponent(activeSearchLabel)}`}
+            onClick={() => {
+              const q = activeSearchLabel.trim();
+              if (q) {
+                pushRecent({ kind: 'query', id: `q-${q.toLowerCase()}`, query: q });
+              }
+              clearSearchUi();
+            }}
             className="flex items-center gap-2.5 px-3 py-2.5 border-b border-white/10 hover:bg-white/[0.06] transition-colors text-left no-underline w-full box-border"
-            aria-label={`Search “${debounced}” on Explore`}
+            aria-label={`Search "${activeSearchLabel}" on Explore`}
           >
             <SearchIcon className="w-4 h-4 text-[#8bc9ff] flex-shrink-0" aria-hidden />
             <div className="min-w-0 flex-1">
               <div className="text-[13px] font-semibold text-white truncate">
-                {debounced}
+                {activeSearchLabel}
               </div>
               <div className="text-[10px] text-white/45 mt-0.5">
                 Search on Explore
@@ -165,6 +408,7 @@ const FeedRailSearch = () => {
                     key={feedRailRowKey(row, index)}
                     type="button"
                     className="w-full text-left px-3 py-2.5 border-b border-white/5 last:border-b-0 hover:bg-white/[0.06] transition-colors"
+                    onPointerDownCapture={capturePickSearchTerm}
                     onClick={() => go(row)}
                   >
                     <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">
@@ -188,6 +432,7 @@ const FeedRailSearch = () => {
                     key={feedRailRowKey(row, index)}
                     type="button"
                     className="w-full flex items-start gap-2.5 px-3 py-2.5 border-b border-white/5 last:border-b-0 hover:bg-white/[0.06] transition-colors text-left"
+                    onPointerDownCapture={capturePickSearchTerm}
                     onClick={() => go(row)}
                   >
                     <AddressAvatar
@@ -217,6 +462,7 @@ const FeedRailSearch = () => {
                   key={feedRailRowKey(row, index)}
                   type="button"
                   className="w-full text-left px-3 py-2.5 border-b border-white/5 last:border-b-0 hover:bg-white/[0.06] transition-colors"
+                  onPointerDownCapture={capturePickSearchTerm}
                   onClick={() => go(row)}
                 >
                   <div className="text-[11px] font-medium text-[#8bc9ff]/90 mb-1">

--- a/src/components/layout/RightRail.tsx
+++ b/src/components/layout/RightRail.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import WalletOverviewCard from '@/components/wallet/WalletOverviewCard';
+import FeedRailSearch from '@/components/layout/FeedRailSearch';
 import { useCurrencies } from '@/hooks/useCurrencies';
 import { useAccountBalances } from '../../hooks/useAccountBalances';
 import { useAeSdk } from '../../hooks/useAeSdk';
@@ -19,6 +20,9 @@ const RightRail = ({
   const navigate = useNavigate();
   const location = useLocation();
   const params = useParams();
+  const isSocialHomeFeed = location.pathname === '/';
+  /** Dedicated AE Price card: not on home feed (feed search uses its own panel). */
+  const showAePricePanel = !hidePriceSection && !isSocialHomeFeed;
   const { activeAccount } = useAeSdk();
   const { currentCurrencyCode, setCurrentCurrency, currencyRates } = useCurrencies();
 
@@ -74,10 +78,15 @@ const RightRail = ({
     'hover:scrollbar-thumb-via-[rgba(0,255,157,0.8)]',
     'hover:scrollbar-thumb-to-pink-500/80',
   ].join(' ');
-  const cardClassName = [
+  const walletRailCardClassName = [
     'bg-white/[0.03] border border-white/10 rounded-[20px] px-5 py-4',
     'shadow-none transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]',
     'relative overflow-hidden',
+  ].join(' ');
+  const feedSearchCardClassName = [
+    'bg-white/[0.03] border border-white/10 rounded-[20px] p-3',
+    'shadow-none transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]',
+    'relative overflow-visible',
   ].join(' ');
   const priceCardClassName = [
     'bg-white/[0.03] border border-white/10 rounded-[20px] p-4',
@@ -87,9 +96,15 @@ const RightRail = ({
 
   return (
     <div id="right-rail-root" className={railClassName}>
+      {isSocialHomeFeed ? (
+        <div className={feedSearchCardClassName}>
+          <FeedRailSearch />
+        </div>
+      ) : null}
+
       {/* Network & Wallet Overview - Hidden on own profile */}
       {!isOwnProfile && (
-        <div className={cardClassName}>
+        <div className={walletRailCardClassName}>
           <WalletOverviewCard
             key={activeAccount}
             selectedCurrency={selectedCurrency}
@@ -98,8 +113,9 @@ const RightRail = ({
         </div>
       )}
 
-      {/* Enhanced Price Section (hidden by default via hidePriceSection) */}
-      {!hidePriceSection && (
+      {/* Enhanced Price Section (via hidePriceSection;
+      omitted on home — feed search is its own panel) */}
+      {showAePricePanel && (
         <div className={priceCardClassName}>
           <div className="flex items-center gap-3 mb-4">
             <span className="text-xl drop-shadow-[0_2px_4px_rgba(0,0,0,0.3)]">
@@ -139,7 +155,7 @@ const RightRail = ({
                 </div>
               </div>
               <div className="flex-shrink-0">
-                {/* Sparkline removed: AE price is now globally polled via AePricePollingProvider */}
+                {/* Sparkline removed: price from AePricePollingProvider */}
               </div>
             </div>
 

--- a/src/features/trending/__tests__/trendsSearch.test.ts
+++ b/src/features/trending/__tests__/trendsSearch.test.ts
@@ -4,6 +4,9 @@ import {
 } from 'vitest';
 import { SuperheroApi } from '@/api/backend';
 import {
+  FEED_RAIL_SEARCH_LIMIT,
+  FEED_RAIL_SEARCH_TARGET_PER_CATEGORY,
+  fetchFeedRailSearchItems,
   fetchPopularPosts,
   fetchTopTraders,
   fetchTrendingTokens,
@@ -26,6 +29,194 @@ vi.mock('../api/leaderboard', () => ({
 }));
 
 describe('trendsSearch api helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchFeedRailSearchItems does not call APIs for empty or whitespace-only search', async () => {
+    await expect(fetchFeedRailSearchItems('')).resolves.toEqual([]);
+    await expect(fetchFeedRailSearchItems('  \t  ')).resolves.toEqual([]);
+    expect(SuperheroApi.listTokens).not.toHaveBeenCalled();
+    expect(SuperheroApi.fetchJson).not.toHaveBeenCalled();
+    expect(SuperheroApi.listPosts).not.toHaveBeenCalled();
+  });
+
+  it('fetchFeedRailSearchItems requests all three endpoints with rail limit and trimmed term', async () => {
+    vi.mocked(SuperheroApi.listTokens).mockResolvedValueOnce({ items: [], meta: { totalItems: 0, totalPages: 0, currentPage: 1 } } as any);
+    vi.mocked(SuperheroApi.fetchJson).mockResolvedValueOnce({ items: [], meta: { totalItems: 0, totalPages: 0, currentPage: 1 } } as any);
+    vi.mocked(SuperheroApi.listPosts).mockResolvedValueOnce({ items: [], meta: { totalItems: 0, totalPages: 0, currentPage: 1 } } as any);
+
+    await fetchFeedRailSearchItems('  hello  ');
+
+    const tokenArgs = { search: 'hello', limit: FEED_RAIL_SEARCH_LIMIT, page: 1, orderBy: 'market_cap', orderDirection: 'DESC' };
+    expect(SuperheroApi.listTokens).toHaveBeenCalledWith(tokenArgs);
+    expect(SuperheroApi.fetchJson).toHaveBeenCalledWith(`/api/accounts?limit=${FEED_RAIL_SEARCH_LIMIT}&search=hello`);
+    expect(SuperheroApi.listPosts).toHaveBeenCalledWith({
+      search: 'hello',
+      limit: FEED_RAIL_SEARCH_LIMIT,
+      page: 1,
+      orderBy: 'created_at',
+      orderDirection: 'DESC',
+    });
+  });
+
+  it('fetchFeedRailSearchItems orders trends, then users, then posts', async () => {
+    vi.mocked(SuperheroApi.listTokens).mockResolvedValueOnce({
+      items: [{ address: 'ct_1', sale_address: 'cs_1', name: 'T1' }],
+      meta: { totalItems: 1, totalPages: 1, currentPage: 1 },
+    } as any);
+    vi.mocked(SuperheroApi.fetchJson).mockResolvedValueOnce({
+      items: [{ address: 'ak_1', chain_name: 'u.chain' }],
+      meta: { totalItems: 1, totalPages: 1, currentPage: 1 },
+    } as any);
+    vi.mocked(SuperheroApi.listPosts).mockResolvedValueOnce({
+      items: [{
+        id: 'post_1',
+        sender_address: 'ak_x',
+        content: 'body',
+        media: [],
+        topics: [],
+        total_comments: 0,
+        tx_hash: '',
+        tx_args: [],
+        contract_address: '',
+        type: 'post',
+        created_at: '2026-01-01T00:00:00.000Z',
+      }],
+      meta: { totalItems: 1, totalPages: 1, currentPage: 1 },
+    } as any);
+
+    const result = await fetchFeedRailSearchItems('q');
+
+    expect(result.map((r) => r.type)).toEqual(['token', 'user', 'post']);
+  });
+
+  it('fetchFeedRailSearchItems groups trends then users then posts and backfills tokens when posts are thin', async () => {
+    const token = (i: number) => ({ address: `ct_${i}`, sale_address: `cs_${i}`, name: `T${i}` });
+    const user = (i: number) => ({ address: `ak_${i}`, chain_name: `u${i}.chain` });
+    vi.mocked(SuperheroApi.listTokens).mockResolvedValueOnce({
+      items: Array.from({ length: 6 }, (_, i) => token(i)),
+      meta: { totalItems: 6, totalPages: 1, currentPage: 1 },
+    } as any);
+    vi.mocked(SuperheroApi.fetchJson).mockResolvedValueOnce({
+      items: Array.from({ length: 6 }, (_, i) => user(i)),
+      meta: { totalItems: 6, totalPages: 1, currentPage: 1 },
+    } as any);
+    vi.mocked(SuperheroApi.listPosts).mockResolvedValueOnce({
+      items: [{ id: 'p1', sender_address: 'ak_x', content: 'c', media: [], topics: [], total_comments: 0, tx_hash: '', tx_args: [], contract_address: '', type: 'post', created_at: '2026-01-01' }],
+      meta: { totalItems: 1, totalPages: 1, currentPage: 1 },
+    } as any);
+
+    const result = await fetchFeedRailSearchItems('q');
+
+    expect(result).toHaveLength(FEED_RAIL_SEARCH_LIMIT);
+    expect(result.map((r) => r.type)).toEqual([
+      ...Array(6).fill('token'),
+      ...Array(3).fill('user'),
+      'post',
+    ]);
+  });
+
+  it('fetchFeedRailSearchItems takes up to target per category then one extra token when all buckets are full', async () => {
+    const token = (i: number) => ({ address: `ct_${i}`, sale_address: `cs_${i}`, name: `T${i}` });
+    const user = (i: number) => ({ address: `ak_${i}`, chain_name: `u${i}.chain` });
+    const post = (i: number) => ({
+      id: `post_${i}`,
+      sender_address: 'ak_x',
+      content: `c${i}`,
+      media: [],
+      topics: [],
+      total_comments: 0,
+      tx_hash: '',
+      tx_args: [],
+      contract_address: '',
+      type: 'post',
+      created_at: '2026-01-01',
+    });
+    vi.mocked(SuperheroApi.listTokens).mockResolvedValueOnce({
+      items: Array.from({ length: 10 }, (_, i) => token(i)),
+      meta: { totalItems: 10, totalPages: 1, currentPage: 1 },
+    } as any);
+    vi.mocked(SuperheroApi.fetchJson).mockResolvedValueOnce({
+      items: Array.from({ length: 10 }, (_, i) => user(i)),
+      meta: { totalItems: 10, totalPages: 1, currentPage: 1 },
+    } as any);
+    vi.mocked(SuperheroApi.listPosts).mockResolvedValueOnce({
+      items: Array.from({ length: 10 }, (_, i) => post(i)),
+      meta: { totalItems: 10, totalPages: 1, currentPage: 1 },
+    } as any);
+
+    const result = await fetchFeedRailSearchItems('q');
+
+    expect(result).toHaveLength(FEED_RAIL_SEARCH_LIMIT);
+    expect(result.map((r) => r.type)).toEqual([
+      ...Array(FEED_RAIL_SEARCH_TARGET_PER_CATEGORY + 1).fill('token'),
+      ...Array(FEED_RAIL_SEARCH_TARGET_PER_CATEGORY).fill('user'),
+      ...Array(FEED_RAIL_SEARCH_TARGET_PER_CATEGORY).fill('post'),
+    ]);
+  });
+
+  it('fetchFeedRailSearchItems still returns grouped users then posts when listTokens rejects', async () => {
+    vi.mocked(SuperheroApi.listTokens).mockRejectedValueOnce(new Error('network'));
+    const user = (i: number) => ({ address: `ak_${i}`, chain_name: `u${i}.chain` });
+    vi.mocked(SuperheroApi.fetchJson).mockResolvedValueOnce({
+      items: Array.from({ length: 10 }, (_, i) => user(i)),
+      meta: { totalItems: 10, totalPages: 1, currentPage: 1 },
+    } as any);
+    vi.mocked(SuperheroApi.listPosts).mockResolvedValueOnce({
+      items: [
+        {
+          id: 'p1',
+          sender_address: 'ak_x',
+          content: 'c',
+          media: [],
+          topics: [],
+          total_comments: 0,
+          tx_hash: '',
+          tx_args: [],
+          contract_address: '',
+          type: 'post',
+          created_at: '2026-01-01',
+        },
+        {
+          id: 'p2',
+          sender_address: 'ak_x',
+          content: 'd',
+          media: [],
+          topics: [],
+          total_comments: 0,
+          tx_hash: '',
+          tx_args: [],
+          contract_address: '',
+          type: 'post',
+          created_at: '2026-01-01',
+        },
+        {
+          id: 'p3',
+          sender_address: 'ak_x',
+          content: 'e',
+          media: [],
+          topics: [],
+          total_comments: 0,
+          tx_hash: '',
+          tx_args: [],
+          contract_address: '',
+          type: 'post',
+          created_at: '2026-01-01',
+        },
+      ],
+      meta: { totalItems: 3, totalPages: 1, currentPage: 1 },
+    } as any);
+
+    const result = await fetchFeedRailSearchItems('x');
+
+    expect(result).toHaveLength(FEED_RAIL_SEARCH_LIMIT);
+    expect(result.map((r) => r.type)).toEqual([
+      ...Array(7).fill('user'),
+      ...Array(3).fill('post'),
+    ]);
+  });
+
   it('loads preview results from all three search endpoints', async () => {
     vi.mocked(SuperheroApi.listTokens).mockResolvedValueOnce({
       items: [{ address: 'ct_token', sale_address: 'ct_sale', name: 'HELLO' }],

--- a/src/features/trending/api/trendsSearch.ts
+++ b/src/features/trending/api/trendsSearch.ts
@@ -108,21 +108,21 @@ function settledValue<T>(
   return result.status === 'fulfilled' ? result.value : undefined;
 }
 
-export async function fetchTrendSearchPreview(search: string) {
+async function fetchTrendSearchPreviewWithLimit(search: string, limit: number) {
   const term = search.trim();
 
   const [tokens, users, posts] = await Promise.allSettled([
     SuperheroApi.listTokens({
       search: term,
-      limit: SEARCH_PREVIEW_LIMIT,
+      limit,
       page: 1,
       orderBy: 'market_cap',
       orderDirection: 'DESC',
     }) as Promise<PaginatedApiResponse<TrendTokenItem>>,
-    fetchAccountSearch(SEARCH_PREVIEW_LIMIT, term),
+    fetchAccountSearch(limit, term),
     SuperheroApi.listPosts({
       search: term,
-      limit: SEARCH_PREVIEW_LIMIT,
+      limit,
       page: 1,
       orderBy: 'created_at',
       orderDirection: 'DESC',
@@ -134,6 +134,10 @@ export async function fetchTrendSearchPreview(search: string) {
     users: normalizeSection(settledValue(users)),
     posts: normalizeSection(settledValue(posts)),
   };
+}
+
+export async function fetchTrendSearchPreview(search: string) {
+  return fetchTrendSearchPreviewWithLimit(search, SEARCH_PREVIEW_LIMIT);
 }
 
 export async function fetchTrendSearchSection(tab: SearchTab, search: string) {
@@ -200,7 +204,8 @@ export const FEED_RAIL_SEARCH_TARGET_PER_CATEGORY = 3;
 
 /**
  * Delay before a rail search triggers one batched triple fetch (tokens + accounts + posts).
- * UI should debounce input by this amount so each keystroke burst does not call the trio repeatedly.
+ * UI should debounce input by this amount so each keystroke burst does not call the trio
+ * repeatedly.
  */
 export const FEED_RAIL_SEARCH_DEBOUNCE_MS = 400;
 
@@ -212,35 +217,6 @@ export type FeedRailSearchItem =
   | { type: 'user'; item: TrendUserItem }
   | { type: 'post'; item: TrendPostItem };
 
-async function fetchFeedRailSearchPreview(search: string) {
-  const term = search.trim();
-  const limit = FEED_RAIL_SEARCH_LIMIT;
-
-  const [tokens, users, posts] = await Promise.allSettled([
-    SuperheroApi.listTokens({
-      search: term,
-      limit,
-      page: 1,
-      orderBy: 'market_cap',
-      orderDirection: 'DESC',
-    }) as Promise<PaginatedApiResponse<TrendTokenItem>>,
-    fetchAccountSearch(limit, term),
-    SuperheroApi.listPosts({
-      search: term,
-      limit,
-      page: 1,
-      orderBy: 'created_at',
-      orderDirection: 'DESC',
-    }) as Promise<PaginatedApiResponse<TrendPostItem>>,
-  ]);
-
-  return {
-    tokens: normalizeSection(settledValue(tokens)),
-    users: normalizeSection(settledValue(users)),
-    posts: normalizeSection(settledValue(posts)),
-  };
-}
-
 /**
  * Take up to {@link FEED_RAIL_SEARCH_TARGET_PER_CATEGORY} from each bucket, then output
  * **all trends, then all users, then all posts** (grouped by type). Remaining slots up to
@@ -248,7 +224,7 @@ async function fetchFeedRailSearchPreview(search: string) {
  * to earlier types first.
  */
 function mergeFeedRailSearchGroupedWithBackfill(
-  preview: Awaited<ReturnType<typeof fetchFeedRailSearchPreview>>,
+  preview: Awaited<ReturnType<typeof fetchTrendSearchPreviewWithLimit>>,
   max: number,
 ): FeedRailSearchItem[] {
   const tokenItems: FeedRailSearchItem[] = preview.tokens.items.map((item) => ({
@@ -276,7 +252,7 @@ function mergeFeedRailSearchGroupedWithBackfill(
 
   while (total < max) {
     let added = false;
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 3; i += 1) {
       if (total >= max) break;
       if (counts[i] < buckets[i].length) {
         counts[i] += 1;
@@ -289,7 +265,7 @@ function mergeFeedRailSearchGroupedWithBackfill(
   }
 
   const out: FeedRailSearchItem[] = [];
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 3; i += 1) {
     out.push(...buckets[i].slice(0, counts[i]));
   }
   return out;
@@ -305,6 +281,6 @@ export async function fetchFeedRailSearchItems(search: string): Promise<FeedRail
   const term = search.trim();
   if (!term) return [];
 
-  const preview = await fetchFeedRailSearchPreview(term);
+  const preview = await fetchTrendSearchPreviewWithLimit(term, FEED_RAIL_SEARCH_LIMIT);
   return mergeFeedRailSearchGroupedWithBackfill(preview, FEED_RAIL_SEARCH_LIMIT);
 }

--- a/src/features/trending/api/trendsSearch.ts
+++ b/src/features/trending/api/trendsSearch.ts
@@ -191,3 +191,120 @@ export async function fetchTopTraders(limit: number = DEFAULT_TAB_LIMIT) {
     sortDir: 'DESC',
   }) as Promise<SearchSection<LeaderboardItem>>;
 }
+
+/** Max combined results for the home right-rail search dropdown (no fallback lists). */
+export const FEED_RAIL_SEARCH_LIMIT = 10;
+
+/** Try to show this many hits per category before redistributing spare slots. */
+export const FEED_RAIL_SEARCH_TARGET_PER_CATEGORY = 3;
+
+/**
+ * Delay before a rail search triggers one batched triple fetch (tokens + accounts + posts).
+ * UI should debounce input by this amount so each keystroke burst does not call the trio repeatedly.
+ */
+export const FEED_RAIL_SEARCH_DEBOUNCE_MS = 400;
+
+/** URL query param for prefilled Explore search (`/trends/tokens?q=…`). */
+export const EXPLORE_SEARCH_QUERY_KEY = 'q';
+
+export type FeedRailSearchItem =
+  | { type: 'token'; item: TrendTokenItem }
+  | { type: 'user'; item: TrendUserItem }
+  | { type: 'post'; item: TrendPostItem };
+
+async function fetchFeedRailSearchPreview(search: string) {
+  const term = search.trim();
+  const limit = FEED_RAIL_SEARCH_LIMIT;
+
+  const [tokens, users, posts] = await Promise.allSettled([
+    SuperheroApi.listTokens({
+      search: term,
+      limit,
+      page: 1,
+      orderBy: 'market_cap',
+      orderDirection: 'DESC',
+    }) as Promise<PaginatedApiResponse<TrendTokenItem>>,
+    fetchAccountSearch(limit, term),
+    SuperheroApi.listPosts({
+      search: term,
+      limit,
+      page: 1,
+      orderBy: 'created_at',
+      orderDirection: 'DESC',
+    }) as Promise<PaginatedApiResponse<TrendPostItem>>,
+  ]);
+
+  return {
+    tokens: normalizeSection(settledValue(tokens)),
+    users: normalizeSection(settledValue(users)),
+    posts: normalizeSection(settledValue(posts)),
+  };
+}
+
+/**
+ * Take up to {@link FEED_RAIL_SEARCH_TARGET_PER_CATEGORY} from each bucket, then output
+ * **all trends, then all users, then all posts** (grouped by type). Remaining slots up to
+ * `max` are filled in **trends → users → posts** order so empty buckets donate capacity
+ * to earlier types first.
+ */
+function mergeFeedRailSearchGroupedWithBackfill(
+  preview: Awaited<ReturnType<typeof fetchFeedRailSearchPreview>>,
+  max: number,
+): FeedRailSearchItem[] {
+  const tokenItems: FeedRailSearchItem[] = preview.tokens.items.map((item) => ({
+    type: 'token',
+    item,
+  }));
+  const userItems: FeedRailSearchItem[] = preview.users.items.map((item) => ({
+    type: 'user',
+    item,
+  }));
+  const postItems: FeedRailSearchItem[] = preview.posts.items.map((item) => ({
+    type: 'post',
+    item,
+  }));
+
+  const buckets = [tokenItems, userItems, postItems];
+  const t = FEED_RAIL_SEARCH_TARGET_PER_CATEGORY;
+  const counts = [
+    Math.min(t, buckets[0].length),
+    Math.min(t, buckets[1].length),
+    Math.min(t, buckets[2].length),
+  ];
+
+  let total = counts[0] + counts[1] + counts[2];
+
+  while (total < max) {
+    let added = false;
+    for (let i = 0; i < 3; i++) {
+      if (total >= max) break;
+      if (counts[i] < buckets[i].length) {
+        counts[i] += 1;
+        total += 1;
+        added = true;
+        break;
+      }
+    }
+    if (!added) break;
+  }
+
+  const out: FeedRailSearchItem[] = [];
+  for (let i = 0; i < 3; i++) {
+    out.push(...buckets[i].slice(0, counts[i]));
+  }
+  return out;
+}
+
+/**
+ * Search tokens, users, and posts (same APIs as Explore). Up to
+ * {@link FEED_RAIL_SEARCH_TARGET_PER_CATEGORY} per category when available, grouped as
+ * trends → users → posts; spare slots (when a category is short or empty) backfill in that
+ * same type order. Capped at {@link FEED_RAIL_SEARCH_LIMIT}. No trending/leaderboard fallbacks.
+ */
+export async function fetchFeedRailSearchItems(search: string): Promise<FeedRailSearchItem[]> {
+  const term = search.trim();
+  if (!term) return [];
+
+  const preview = await fetchFeedRailSearchPreview(term);
+  return mergeFeedRailSearchGroupedWithBackfill(preview, FEED_RAIL_SEARCH_LIMIT);
+}

--- a/src/features/trending/components/TrendSearchExploreResultLists.tsx
+++ b/src/features/trending/components/TrendSearchExploreResultLists.tsx
@@ -1,4 +1,6 @@
 import AddressAvatar from '@/components/AddressAvatar';
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { formatAddress } from '@/utils/address';
 import { formatCompactNumber } from '@/utils/number';
@@ -18,19 +20,22 @@ const UserStatsCell = ({ label, value }: { label: string; value: string }) => (
   </div>
 );
 
-function getUserStats(item: TrendUserItem | LeaderboardItem) {
+function getUserStats(
+  item: TrendUserItem | LeaderboardItem,
+  t: TFunction<'trending'>,
+) {
   if (isLeaderboardItem(item)) {
     return [
-      { label: 'PnL', value: `$${formatCompactNumber(item.pnl_usd, 2, 1)}` },
-      { label: 'ROI', value: `${formatCompactNumber(item.roi_pct, 2, 1)}%` },
-      { label: 'AUM', value: `$${formatCompactNumber(item.aum_usd, 2, 1)}` },
+      { label: t('exploreSearch.userStats.pnl'), value: `$${formatCompactNumber(item.pnl_usd, 2, 1)}` },
+      { label: t('exploreSearch.userStats.roi'), value: `${formatCompactNumber(item.roi_pct, 2, 1)}%` },
+      { label: t('exploreSearch.userStats.aum'), value: `$${formatCompactNumber(item.aum_usd, 2, 1)}` },
     ];
   }
 
   return [
-    { label: 'Volume', value: `${formatCompactNumber(item.total_volume, 2, 1)} AE` },
-    { label: 'Txs', value: formatCompactNumber(item.total_tx_count, 0, 1) },
-    { label: 'Created', value: formatCompactNumber(item.total_created_tokens, 0, 1) },
+    { label: t('exploreSearch.userStats.volume'), value: `${formatCompactNumber(item.total_volume, 2, 1)} AE` },
+    { label: t('exploreSearch.userStats.txs'), value: formatCompactNumber(item.total_tx_count, 0, 1) },
+    { label: t('exploreSearch.userStats.created'), value: formatCompactNumber(item.total_created_tokens, 0, 1) },
   ];
 }
 
@@ -44,38 +49,41 @@ export const TokenResultsList = ({ items }: { items: TrendTokenItem[] }) => (
   />
 );
 
-export const UserResultsList = ({ items }: { items: Array<TrendUserItem | LeaderboardItem> }) => (
-  <>
-    {items.map((item) => {
-      const { address } = item;
-      const title = item.chain_name || formatAddress(address, 6);
-      const stats = getUserStats(item);
+export const UserResultsList = ({ items }: { items: Array<TrendUserItem | LeaderboardItem> }) => {
+  const { t } = useTranslation('trending');
+  return (
+    <>
+      {items.map((item) => {
+        const { address } = item;
+        const title = item.chain_name || formatAddress(address, 6);
+        const stats = getUserStats(item, t);
 
-      return (
-        <Link
-          key={address}
-          to={`/users/${address}`}
-          className="flex flex-col gap-3 px-1 py-4 text-white transition-colors hover:bg-white/[0.03] hover:text-white rounded-xl sm:flex-row sm:items-center sm:justify-between"
-        >
-          <div className="flex items-center gap-3 min-w-0">
-            <AddressAvatar address={address} size={40} borderRadius="50%" />
-            <div className="min-w-0">
-              <div className="text-[15px] font-semibold text-white truncate">{title}</div>
-              <div className="text-[10px] text-white/60 font-mono truncate">
-                {formatAddress(address, 10, false)}
+        return (
+          <Link
+            key={address}
+            to={`/users/${address}`}
+            className="flex flex-col gap-3 px-1 py-4 text-white transition-colors hover:bg-white/[0.03] hover:text-white rounded-xl sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="flex items-center gap-3 min-w-0">
+              <AddressAvatar address={address} size={40} borderRadius="50%" />
+              <div className="min-w-0">
+                <div className="text-[15px] font-semibold text-white truncate">{title}</div>
+                <div className="text-[10px] text-white/60 font-mono truncate">
+                  {formatAddress(address, 10, false)}
+                </div>
               </div>
             </div>
-          </div>
-          <div className="grid grid-cols-2 gap-3 text-xs sm:grid-cols-3 sm:text-right sm:min-w-[340px]">
-            {stats.map((s) => (
-              <UserStatsCell key={s.label} label={s.label} value={s.value} />
-            ))}
-          </div>
-        </Link>
-      );
-    })}
-  </>
-);
+            <div className="grid grid-cols-2 gap-3 text-xs sm:grid-cols-3 sm:text-right sm:min-w-[340px]">
+              {stats.map((s) => (
+                <UserStatsCell key={s.label} label={s.label} value={s.value} />
+              ))}
+            </div>
+          </Link>
+        );
+      })}
+    </>
+  );
+};
 
 export const PostResultsList = ({
   items,

--- a/src/features/trending/components/TrendSearchExploreResultLists.tsx
+++ b/src/features/trending/components/TrendSearchExploreResultLists.tsx
@@ -1,0 +1,98 @@
+import AddressAvatar from '@/components/AddressAvatar';
+import { Link } from 'react-router-dom';
+import { formatAddress } from '@/utils/address';
+import { formatCompactNumber } from '@/utils/number';
+import type { LeaderboardItem } from '../api/leaderboard';
+import type { TrendPostItem, TrendTokenItem, TrendUserItem } from '../api/trendsSearch';
+import ReplyToFeedItem from '../../social/components/ReplyToFeedItem';
+import TokenListTable from './TokenListTable';
+
+function isLeaderboardItem(item: TrendUserItem | LeaderboardItem): item is LeaderboardItem {
+  return 'pnl_usd' in item || 'aum_usd' in item || 'roi_pct' in item || 'mdd_pct' in item;
+}
+
+const UserStatsCell = ({ label, value }: { label: string; value: string }) => (
+  <div>
+    <div className="text-white/50">{label}</div>
+    <div className="text-white">{value}</div>
+  </div>
+);
+
+function getUserStats(item: TrendUserItem | LeaderboardItem) {
+  if (isLeaderboardItem(item)) {
+    return [
+      { label: 'PnL', value: `$${formatCompactNumber(item.pnl_usd, 2, 1)}` },
+      { label: 'ROI', value: `${formatCompactNumber(item.roi_pct, 2, 1)}%` },
+      { label: 'AUM', value: `$${formatCompactNumber(item.aum_usd, 2, 1)}` },
+    ];
+  }
+
+  return [
+    { label: 'Volume', value: `${formatCompactNumber(item.total_volume, 2, 1)} AE` },
+    { label: 'Txs', value: formatCompactNumber(item.total_tx_count, 0, 1) },
+    { label: 'Created', value: formatCompactNumber(item.total_created_tokens, 0, 1) },
+  ];
+}
+
+export const TokenResultsList = ({ items }: { items: TrendTokenItem[] }) => (
+  <TokenListTable
+    pages={[{ items }]}
+    loading={false}
+    orderBy="market_cap"
+    orderDirection="DESC"
+    onSort={() => {}}
+  />
+);
+
+export const UserResultsList = ({ items }: { items: Array<TrendUserItem | LeaderboardItem> }) => (
+  <>
+    {items.map((item) => {
+      const { address } = item;
+      const title = item.chain_name || formatAddress(address, 6);
+      const stats = getUserStats(item);
+
+      return (
+        <Link
+          key={address}
+          to={`/users/${address}`}
+          className="flex flex-col gap-3 px-1 py-4 text-white transition-colors hover:bg-white/[0.03] hover:text-white rounded-xl sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="flex items-center gap-3 min-w-0">
+            <AddressAvatar address={address} size={40} borderRadius="50%" />
+            <div className="min-w-0">
+              <div className="text-[15px] font-semibold text-white truncate">{title}</div>
+              <div className="text-[10px] text-white/60 font-mono truncate">
+                {formatAddress(address, 10, false)}
+              </div>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3 text-xs sm:grid-cols-3 sm:text-right sm:min-w-[340px]">
+            {stats.map((s) => (
+              <UserStatsCell key={s.label} label={s.label} value={s.value} />
+            ))}
+          </div>
+        </Link>
+      );
+    })}
+  </>
+);
+
+export const PostResultsList = ({
+  items,
+  onOpenPost,
+}: {
+  items: TrendPostItem[];
+  onOpenPost: (slugOrId: string) => void;
+}) => (
+  <>
+    {items.map((post) => (
+      <ReplyToFeedItem
+        key={post.id}
+        item={post}
+        commentCount={post.total_comments ?? 0}
+        allowInlineRepliesToggle={false}
+        onOpenPost={onOpenPost}
+      />
+    ))}
+  </>
+);

--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/features/transaction-notification';
 import { useLocation, useNavigate } from 'react-router-dom';
 import AppSelect, { Item as AppSelectItem } from '@/components/inputs/AppSelect';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { createCommunity } from '../libs/createCommunity';
 import Spinner from '../../../components/Spinner';
 import VerifiedIcon from '../../../svg/verifiedUrl.svg?react';
@@ -31,23 +32,6 @@ import type {
   IAllowedNameChars,
   ICollectionData,
 } from '../../../utils/types';
-
-// Debounce hook
-function useDebounce<T>(value: T, delay: number): T {
-  const [debouncedValue, setDebouncedValue] = useState<T>(value);
-
-  useEffect(() => {
-    const handler = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delay);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [value, delay]);
-
-  return debouncedValue;
-}
 
 interface TokenMetaInfo {
   collection: string;
@@ -112,9 +96,9 @@ const CreateTokenView = () => {
   // Factory and collections state
   const [loading, setLoading] = useState(true);
 
-  const initialBuyVolumeDebounced = useDebounce(initialBuyVolume, 300);
-  const aeAmountDebounced = useDebounce(aeAmount, 300);
-  const tokenNameDebounced = useDebounce(tokenName, 400);
+  const initialBuyVolumeDebounced = useDebouncedValue(initialBuyVolume, 300);
+  const aeAmountDebounced = useDebouncedValue(aeAmount, 300);
+  const tokenNameDebounced = useDebouncedValue(tokenName, 400);
 
   // Computed values - use from the hook
   const activeFactoryCollectionsArr = useMemo(

--- a/src/features/trending/views/TokenList.tsx
+++ b/src/features/trending/views/TokenList.tsx
@@ -140,11 +140,10 @@ const TokenList = () => {
     return t('tokenList.fallbackPosts');
   }, [t]);
 
+  /** Sync input and search term with `?q=`, including when `q` is dropped from the URL. */
   useEffect(() => {
-    if (qFromUrl) {
-      setSearchInput(qFromUrl);
-      setSearchTerm(qFromUrl);
-    }
+    setSearchInput(qFromUrl);
+    setSearchTerm(qFromUrl);
   }, [qFromUrl]);
 
   useEffect(() => {
@@ -314,7 +313,7 @@ const TokenList = () => {
   const searchOrder = useMemo(() => {
     const preview = searchPreviewQuery.data;
     if (!preview) {
-      return [activeTab, ...SEARCH_TABS.filter((t) => t !== activeTab)];
+      return [activeTab, ...SEARCH_TABS.filter((tab) => tab !== activeTab)];
     }
 
     const counts: Record<SearchTab, number> = {
@@ -330,7 +329,7 @@ const TokenList = () => {
       );
     const hasExactTokenMatch = isAddress
       && preview.tokens.items.some(
-        (t) => (t as any).address?.toLowerCase() === searchTerm.toLowerCase(),
+        (token) => (token as any).address?.toLowerCase() === searchTerm.toLowerCase(),
       );
 
     const score = (tab: SearchTab): number => {

--- a/src/features/trending/views/TokenList.tsx
+++ b/src/features/trending/views/TokenList.tsx
@@ -6,6 +6,7 @@ import { Search as SearchIcon } from 'lucide-react';
 import {
   useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { TokensService } from '../../../api/generated';
 import LatestTransactionsCarousel from '../../../components/Trendminer/LatestTransactionsCarousel';
@@ -58,35 +59,7 @@ const SORT = {
 
 const SEARCH_TABS: SearchTab[] = ['tokens', 'users', 'posts'];
 
-const TAB_LABELS: Record<SearchTab, string> = {
-  tokens: 'Tokens',
-  users: 'Users',
-  posts: 'Posts',
-};
-
 type OrderByOption = typeof SORT[keyof typeof SORT];
-
-const ORDER_BY_OPTIONS: SelectOptions<OrderByOption> = [
-  { title: 'Market Cap', value: SORT.marketCap },
-  { title: 'Trending', value: SORT.trendingScore },
-  { title: 'Price', value: SORT.price },
-  { title: 'Name', value: SORT.name },
-  { title: 'Newest', value: SORT.newest },
-  { title: 'Oldest', value: SORT.oldest },
-  { title: 'Holders Count', value: SORT.holdersCount },
-];
-
-function getFallbackSubtitle(tab: SearchTab) {
-  if (tab === 'tokens') {
-    return 'No matching tokens found. Showing trending tokens instead.';
-  }
-
-  if (tab === 'users') {
-    return 'No matching users found. Showing top traders instead.';
-  }
-
-  return 'No matching posts found. Showing popular posts instead.';
-}
 
 const SearchSectionShell = ({
   title,
@@ -121,7 +94,7 @@ const EmptyPanel = ({ message }: { message: string }) => (
   </div>
 );
 
-const InlineLoading = ({ label = 'Loading...' }: { label?: string }) => (
+const InlineLoading = ({ label }: { label: string }) => (
   <div className="flex items-center justify-center gap-2 py-8 text-sm text-white/70">
     <Spinner className="w-4 h-4" />
     <span>{label}</span>
@@ -129,6 +102,7 @@ const InlineLoading = ({ label = 'Loading...' }: { label?: string }) => (
 );
 
 const TokenList = () => {
+  const { t } = useTranslation('trending');
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const qFromUrl = searchParams.get(EXPLORE_SEARCH_QUERY_KEY)?.trim() ?? '';
@@ -143,6 +117,28 @@ const TokenList = () => {
     posts: false,
   });
   const loadMoreBtn = useRef<HTMLButtonElement>(null);
+
+  const tabLabels = useMemo((): Record<SearchTab, string> => ({
+    tokens: t('tokenList.tabTokens'),
+    users: t('tokenList.tabUsers'),
+    posts: t('tokenList.tabPosts'),
+  }), [t]);
+
+  const orderByOptions = useMemo((): SelectOptions<OrderByOption> => [
+    { title: t('tokenList.sortMarketCap'), value: SORT.marketCap },
+    { title: t('tokenList.sortTrending'), value: SORT.trendingScore },
+    { title: t('tokenList.sortPrice'), value: SORT.price },
+    { title: t('tokenList.sortName'), value: SORT.name },
+    { title: t('tokenList.sortNewest'), value: SORT.newest },
+    { title: t('tokenList.sortOldest'), value: SORT.oldest },
+    { title: t('tokenList.sortHoldersCount'), value: SORT.holdersCount },
+  ], [t]);
+
+  const getFallbackSubtitle = useCallback((tab: SearchTab) => {
+    if (tab === 'tokens') return t('tokenList.fallbackTokens');
+    if (tab === 'users') return t('tokenList.fallbackUsers');
+    return t('tokenList.fallbackPosts');
+  }, [t]);
 
   useEffect(() => {
     if (qFromUrl) {
@@ -452,14 +448,14 @@ const TokenList = () => {
 
   const showSearchLoading = hasSearch && searchPreviewQuery.isLoading;
   const searchError = hasSearch && searchPreviewQuery.isError
-    ? 'Unable to load search results right now. Please try again.'
+    ? t('tokenList.searchError')
     : null;
 
   return (
     <div className="max-w-[min(1536px,100%)] mx-auto min-h-screen text-white px-4">
       <Head
-        title="Superhero.com – Search Trends, Users and Posts"
-        description="Search tokenized trends, creators, traders, and posts across Superhero."
+        title={t('tokenList.pageTitle')}
+        description={t('tokenList.pageDescription')}
         canonicalPath="/trends/tokens"
       />
 
@@ -471,10 +467,10 @@ const TokenList = () => {
                 <SearchIcon className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-white/45 pointer-events-none" />
                 <Input
                   id="trend-search"
-                  aria-label="Search tokens, users and posts"
+                  aria-label={t('tokenList.inputAria')}
                   value={searchInput}
                   onChange={(event) => setSearchInput(event.target.value)}
-                  placeholder="Search trends, users or posts"
+                  placeholder={t('tokenList.searchPlaceholder')}
                   className="h-12 rounded-2xl border-white/10 bg-white/[0.03] pl-11 pr-4 text-sm text-white placeholder:text-white/45 focus-visible:ring-[#1161FE]"
                 />
               </div>
@@ -494,7 +490,7 @@ const TokenList = () => {
                         isActive ? 'text-white' : 'text-white/55 hover:text-white/80'
                       }`}
                     >
-                      {TAB_LABELS[tab]}
+                      {tabLabels[tab]}
                       {isActive ? (
                         <span className="absolute inset-x-0 -bottom-px h-0.5 rounded-full bg-[#1161FE]" />
                       ) : null}
@@ -507,7 +503,7 @@ const TokenList = () => {
 
           {searchError ? <EmptyPanel message={searchError} /> : null}
 
-          {showSearchLoading ? <InlineLoading label="Searching trends..." /> : null}
+          {showSearchLoading ? <InlineLoading label={t('tokenList.searchingTrends')} /> : null}
 
           {hasSearch && !showSearchLoading && !searchError ? (
             <div className="flex flex-col gap-4">
@@ -526,9 +522,11 @@ const TokenList = () => {
                 );
 
                 const subtitle = state.hasResults
-                  ? `${state.totalItems} result${state.totalItems === 1 ? '' : 's'}`
+                  ? t('tokenList.resultsCount', { count: state.totalItems })
                   : getFallbackSubtitle(tab);
-                const footerLabel = expanded && !state.usesFallback ? 'Show less' : 'View all';
+                const footerLabel = expanded && !state.usesFallback
+                  ? t('tokenList.showLess')
+                  : t('tokenList.viewAll');
 
                 let sectionBody: React.ReactNode = null;
                 if (tab === 'tokens') {
@@ -551,7 +549,7 @@ const TokenList = () => {
                 return (
                   <SearchSectionShell
                     key={tab}
-                    title={TAB_LABELS[tab]}
+                    title={tabLabels[tab]}
                     subtitle={subtitle}
                     contentClassName={tab === 'posts' ? 'divide-y-0' : undefined}
                     footer={state.canExpand || state.usesFallback ? (
@@ -572,7 +570,9 @@ const TokenList = () => {
                     ) : null}
                   >
                     {sectionBody}
-                    {expanded && isLoadingExpanded ? <InlineLoading label="Loading more results..." /> : null}
+                    {expanded && isLoadingExpanded ? (
+                      <InlineLoading label={t('tokenList.loadingMore')} />
+                    ) : null}
                   </SearchSectionShell>
                 );
               })}
@@ -589,7 +589,7 @@ const TokenList = () => {
                 <div className="flex w-full flex-wrap items-center justify-between gap-3">
                   <div className="flex min-w-0 flex-wrap items-center gap-3 sm:gap-4">
                     <div className="text-xl font-bold text-white sm:text-2xl">
-                      Tokenized Trends
+                      {t('tokenList.tokenizedTrends')}
                     </div>
                     <div className="w-full sm:w-auto sm:flex-shrink-0">
                       <Select value={orderBy} onValueChange={updateOrderBy}>
@@ -597,7 +597,7 @@ const TokenList = () => {
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent className="bg-gray-900 border-white/10">
-                          {ORDER_BY_OPTIONS.map((option) => (
+                          {orderByOptions.map((option) => (
                             <SelectItem key={option.value} value={option.value} className="text-white hover:bg-white/10 text-xs">
                               {option.title}
                             </SelectItem>
@@ -610,14 +610,14 @@ const TokenList = () => {
                     to="/trends/create"
                     className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/[0.03] px-4 py-2 text-sm font-semibold text-white transition-all duration-200 hover:bg-white/[0.08] hover:border-white/25 hover:shadow-[0_0_12px_rgba(255,255,255,0.06)] active:scale-[0.97] cursor-pointer"
                   >
-                    Tokenize Trend
+                    {t('tokenList.tokenizeTrend')}
                   </Link>
                 </div>
               </div>
 
               {(!tokenPages?.pages?.length || !tokenPages.pages[0].items.length)
               && !isFetchingTokens ? (
-                <EmptyPanel message="No token sales are available right now." />
+                <EmptyPanel message={t('tokenList.noTokenSales')} />
                 ) : null}
 
               <TokenListTable
@@ -644,9 +644,9 @@ const TokenList = () => {
                     {isFetchingTokens ? (
                       <div className="flex items-center justify-center gap-2">
                         <Spinner className="w-4 h-4" />
-                        Loading...
+                        {t('tokenList.loadingEllipsis')}
                       </div>
-                    ) : 'Load More'}
+                    ) : t('tokenList.loadMore')}
                   </button>
                 </div>
               ) : null}
@@ -654,20 +654,26 @@ const TokenList = () => {
           ) : null}
 
           {!hasSearch && activeTab === 'users' ? (
-            <SearchSectionShell title="Top Traders" subtitle="The most active traders on Superhero right now.">
-              {usersTabQuery.isLoading ? <InlineLoading /> : null}
+            <SearchSectionShell
+              title={t('tokenList.topTradersTitle')}
+              subtitle={t('tokenList.topTradersSubtitle')}
+            >
+              {usersTabQuery.isLoading ? <InlineLoading label={t('tokenList.loading')} /> : null}
               {!usersTabQuery.isLoading && usersTabQuery.data?.items.length ? (
                 <UserResultsList items={usersTabQuery.data.items} />
               ) : null}
               {!usersTabQuery.isLoading && !usersTabQuery.data?.items.length ? (
-                <div className="py-6 text-sm text-white/60">No leaderboard data is available right now.</div>
+                <div className="py-6 text-sm text-white/60">{t('tokenList.noLeaderboard')}</div>
               ) : null}
             </SearchSectionShell>
           ) : null}
 
           {!hasSearch && activeTab === 'posts' ? (
-            <SearchSectionShell title="Popular Posts" subtitle="What the community is talking about the most.">
-              {postsTabQuery.isLoading ? <InlineLoading /> : null}
+            <SearchSectionShell
+              title={t('tokenList.popularPostsTitle')}
+              subtitle={t('tokenList.popularPostsSubtitle')}
+            >
+              {postsTabQuery.isLoading ? <InlineLoading label={t('tokenList.loading')} /> : null}
               {!postsTabQuery.isLoading && postsTabQuery.data?.items.length ? (
                 <PostResultsList
                   items={postsTabQuery.data.items}
@@ -675,7 +681,7 @@ const TokenList = () => {
                 />
               ) : null}
               {!postsTabQuery.isLoading && !postsTabQuery.data?.items.length ? (
-                <div className="py-6 text-sm text-white/60">No popular posts are available right now.</div>
+                <div className="py-6 text-sm text-white/60">{t('tokenList.noPopularPosts')}</div>
               ) : null}
             </SearchSectionShell>
           ) : null}

--- a/src/features/trending/views/TokenList.tsx
+++ b/src/features/trending/views/TokenList.tsx
@@ -1,13 +1,12 @@
 import { Encoding, isEncoded } from '@aeternity/aepp-sdk';
 import Spinner from '@/components/Spinner';
-import AddressAvatar from '@/components/AddressAvatar';
 import { Input } from '@/components/ui/input';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { Search as SearchIcon } from 'lucide-react';
 import {
   useCallback, useEffect, useMemo, useRef, useState,
 } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { TokensService } from '../../../api/generated';
 import LatestTransactionsCarousel from '../../../components/Trendminer/LatestTransactionsCarousel';
 import {
@@ -18,10 +17,9 @@ import {
   SelectValue,
 } from '../../../components/ui/select';
 import { Head } from '../../../seo/Head';
-import { formatAddress } from '../../../utils/address';
-import { formatCompactNumber } from '../../../utils/number';
 import {
   DEFAULT_TAB_LIMIT,
+  EXPLORE_SEARCH_QUERY_KEY,
   FALLBACK_LIMIT,
   SEARCH_PREVIEW_LIMIT,
   fetchPopularPosts,
@@ -37,7 +35,11 @@ import {
 } from '../api/trendsSearch';
 import type { LeaderboardItem } from '../api/leaderboard';
 import TokenListTable from '../components/TokenListTable';
-import ReplyToFeedItem from '../../social/components/ReplyToFeedItem';
+import {
+  PostResultsList,
+  TokenResultsList,
+  UserResultsList,
+} from '../components/TrendSearchExploreResultLists';
 
 type SelectOptions<T> = Array<{
   title: string;
@@ -73,10 +75,6 @@ const ORDER_BY_OPTIONS: SelectOptions<OrderByOption> = [
   { title: 'Oldest', value: SORT.oldest },
   { title: 'Holders Count', value: SORT.holdersCount },
 ];
-
-function isLeaderboardItem(item: TrendUserItem | LeaderboardItem): item is LeaderboardItem {
-  return 'pnl_usd' in item || 'aum_usd' in item || 'roi_pct' in item || 'mdd_pct' in item;
-}
 
 function getFallbackSubtitle(tab: SearchTab) {
   if (tab === 'tokens') {
@@ -130,105 +128,28 @@ const InlineLoading = ({ label = 'Loading...' }: { label?: string }) => (
   </div>
 );
 
-const TokenResultsList = ({ items }: { items: TrendTokenItem[] }) => (
-  <TokenListTable
-    pages={[{ items }]}
-    loading={false}
-    orderBy="market_cap"
-    orderDirection="DESC"
-    onSort={() => {}}
-  />
-);
-
-const UserStatsCell = ({ label, value }: { label: string; value: string }) => (
-  <div>
-    <div className="text-white/50">{label}</div>
-    <div className="text-white">{value}</div>
-  </div>
-);
-
-function getUserStats(item: TrendUserItem | LeaderboardItem) {
-  if (isLeaderboardItem(item)) {
-    return [
-      { label: 'PnL', value: `$${formatCompactNumber(item.pnl_usd, 2, 1)}` },
-      { label: 'ROI', value: `${formatCompactNumber(item.roi_pct, 2, 1)}%` },
-      { label: 'AUM', value: `$${formatCompactNumber(item.aum_usd, 2, 1)}` },
-    ];
-  }
-
-  return [
-    { label: 'Volume', value: `${formatCompactNumber(item.total_volume, 2, 1)} AE` },
-    { label: 'Txs', value: formatCompactNumber(item.total_tx_count, 0, 1) },
-    { label: 'Created', value: formatCompactNumber(item.total_created_tokens, 0, 1) },
-  ];
-}
-
-const UserResultsList = ({ items }: { items: Array<TrendUserItem | LeaderboardItem> }) => (
-  <>
-    {items.map((item) => {
-      const { address } = item;
-      const title = item.chain_name || formatAddress(address, 6);
-      const stats = getUserStats(item);
-
-      return (
-        <Link
-          key={address}
-          to={`/users/${address}`}
-          className="flex flex-col gap-3 px-1 py-4 text-white transition-colors hover:bg-white/[0.03] hover:text-white rounded-xl sm:flex-row sm:items-center sm:justify-between"
-        >
-          <div className="flex items-center gap-3 min-w-0">
-            <AddressAvatar address={address} size={40} borderRadius="50%" />
-            <div className="min-w-0">
-              <div className="text-[15px] font-semibold text-white truncate">{title}</div>
-              <div className="text-[10px] text-white/60 font-mono truncate">
-                {formatAddress(address, 10, false)}
-              </div>
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-3 text-xs sm:grid-cols-3 sm:text-right sm:min-w-[340px]">
-            {stats.map((s) => (
-              <UserStatsCell key={s.label} label={s.label} value={s.value} />
-            ))}
-          </div>
-        </Link>
-      );
-    })}
-  </>
-);
-
-const PostResultsList = ({
-  items,
-  onOpenPost,
-}: {
-  items: TrendPostItem[];
-  onOpenPost: (slugOrId: string) => void;
-}) => (
-  <>
-    {items.map((post) => (
-      <ReplyToFeedItem
-        key={post.id}
-        item={post}
-        commentCount={post.total_comments ?? 0}
-        allowInlineRepliesToggle={false}
-        onOpenPost={onOpenPost}
-      />
-    ))}
-  </>
-);
-
 const TokenList = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const qFromUrl = searchParams.get(EXPLORE_SEARCH_QUERY_KEY)?.trim() ?? '';
   const [orderBy, setOrderBy] = useState<OrderByOption>(SORT.trendingScore);
   const [orderDirection, setOrderDirection] = useState<'ASC' | 'DESC'>('DESC');
   const [activeTab, setActiveTab] = useState<SearchTab>('tokens');
-  const [searchInput, setSearchInput] = useState('');
-  const [searchTerm, setSearchTerm] = useState('');
+  const [searchInput, setSearchInput] = useState(qFromUrl);
+  const [searchTerm, setSearchTerm] = useState(qFromUrl);
   const [expandedSections, setExpandedSections] = useState<Record<SearchTab, boolean>>({
     tokens: false,
     users: false,
     posts: false,
   });
   const loadMoreBtn = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (qFromUrl) {
+      setSearchInput(qFromUrl);
+      setSearchTerm(qFromUrl);
+    }
+  }, [qFromUrl]);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {

--- a/src/hooks/__tests__/useDebouncedValue.test.ts
+++ b/src/hooks/__tests__/useDebouncedValue.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+  describe, expect, it, vi, beforeEach, afterEach,
+} from 'vitest';
+import { useDebouncedValue, useDebouncedTrimmedSearch } from '../useDebouncedValue';
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('updates only after delay when value stabilizes', () => {
+    const { result, rerender } = renderHook(
+      ({ v, d }: { v: string; d: number }) => useDebouncedValue(v, d),
+      { initialProps: { v: 'a', d: 300 } },
+    );
+
+    expect(result.current).toBe('a');
+
+    rerender({ v: 'ab', d: 300 });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('ab');
+  });
+
+  it('resets timer when value changes again before delay elapses', () => {
+    const { result, rerender } = renderHook(
+      ({ v }: { v: string }) => useDebouncedValue(v, 200),
+      { initialProps: { v: 'x' } },
+    );
+
+    rerender({ v: 'y' });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    rerender({ v: 'z' });
+    act(() => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(result.current).toBe('x');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('z');
+  });
+});
+
+describe('useDebouncedTrimmedSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('debounces non-empty trimmed input', () => {
+    const { result, rerender } = renderHook(
+      ({ input }: { input: string }) => useDebouncedTrimmedSearch(input, 250),
+      { initialProps: { input: '' } },
+    );
+
+    expect(result.current).toBe('');
+
+    rerender({ input: '  hello  ' });
+    expect(result.current).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(result.current).toBe('hello');
+  });
+
+  it('clears immediately when input becomes empty or whitespace-only', () => {
+    const { result, rerender } = renderHook(
+      ({ input }: { input: string }) => useDebouncedTrimmedSearch(input, 400),
+      { initialProps: { input: 'typed' } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(result.current).toBe('typed');
+
+    rerender({ input: '' });
+    expect(result.current).toBe('');
+
+    rerender({ input: '   ' });
+    expect(result.current).toBe('');
+  });
+});

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns `value` only after it has stayed unchanged for `delayMs`.
+ * Cancels pending updates when `value` changes again (standard debounce).
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(id);
+  }, [value, delayMs]);
+
+  return debounced;
+}
+
+/**
+ * Debounced **trimmed** search string. Non-empty queries wait `delayMs` after typing stops;
+ * clearing the field resets immediately so callers do not keep fetching or show stale results.
+ */
+export function useDebouncedTrimmedSearch(input: string, delayMs: number): string {
+  const [q, setQ] = useState('');
+
+  useEffect(() => {
+    const t = input.trim();
+    if (!t) {
+      setQ('');
+      return undefined;
+    }
+    const id = window.setTimeout(() => setQ(t), delayMs);
+    return () => window.clearTimeout(id);
+  }, [input, delayMs]);
+
+  return q;
+}

--- a/src/hooks/useFeedRailRecentSearches.ts
+++ b/src/hooks/useFeedRailRecentSearches.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 const STORAGE_KEY = 'superhero:feedRailRecentSearches';
 const MAX_ITEMS = 10;
@@ -115,10 +115,6 @@ function normalizeList(
  */
 export function useFeedRailRecentSearches() {
   const [items, setItems] = useState<FeedRailRecentEntry[]>(() => readStored());
-
-  useEffect(() => {
-    setItems(readStored());
-  }, []);
 
   /**
    * Persist before `setState` so a same-tick `navigate()` unmount does not skip the updater

--- a/src/hooks/useFeedRailRecentSearches.ts
+++ b/src/hooks/useFeedRailRecentSearches.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'superhero:feedRailRecentSearches';
+const MAX_ITEMS = 10;
+
+export type FeedRailRecentEntry =
+  | { kind: 'query'; id: string; query: string }
+  | {
+      kind: 'token';
+      id: string;
+      /** Search term used when this hit was chosen (for analytics / future use). */
+      query: string;
+      address: string;
+      name: string;
+      symbol: string;
+    }
+  | {
+      kind: 'user';
+      id: string;
+      query: string;
+      address: string;
+      chain_name: string | null;
+    }
+  | {
+      kind: 'post';
+      id: string;
+      query: string;
+      postId: string;
+      slug: string | null;
+      preview: string;
+    };
+
+function entryDedupeKey(e: FeedRailRecentEntry): string {
+  switch (e.kind) {
+    case 'query':
+      return `q:${e.query.trim().toLowerCase()}`;
+    case 'token':
+      return `t:${e.address}`;
+    case 'user':
+      return `u:${e.address}`;
+    case 'post':
+      return `p:${e.postId}`;
+    default:
+      return '';
+  }
+}
+
+function isFeedRailRecentEntry(x: unknown): x is FeedRailRecentEntry {
+  if (!x || typeof x !== 'object') return false;
+  const k = (x as { kind?: string }).kind;
+  if (k === 'query') {
+    const q = (x as { query?: unknown }).query;
+    return typeof q === 'string' && typeof (x as { id?: unknown }).id === 'string';
+  }
+  if (k === 'token') {
+    const o = x as Record<string, unknown>;
+    return typeof o.id === 'string' && typeof o.query === 'string' && typeof o.address === 'string'
+      && typeof o.name === 'string' && typeof o.symbol === 'string';
+  }
+  if (k === 'user') {
+    const o = x as Record<string, unknown>;
+    return typeof o.id === 'string' && typeof o.query === 'string' && typeof o.address === 'string'
+      && (o.chain_name === null || typeof o.chain_name === 'string');
+  }
+  if (k === 'post') {
+    const o = x as Record<string, unknown>;
+    const idsOk = typeof o.id === 'string' && typeof o.query === 'string' && typeof o.postId === 'string';
+    const slugOk = o.slug == null || typeof o.slug === 'string';
+    return idsOk && slugOk && typeof o.preview === 'string';
+  }
+  return false;
+}
+
+function readStored(): FeedRailRecentEntry[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.reduce<FeedRailRecentEntry[]>((acc, el) => {
+      if (typeof el === 'string') {
+        const q = el.trim();
+        if (q) acc.push({ kind: 'query', id: `q-${q.toLowerCase()}`, query: q });
+        return acc;
+      }
+      if (isFeedRailRecentEntry(el)) acc.push(el);
+      return acc;
+    }, []);
+  } catch {
+    return [];
+  }
+}
+
+function writeStored(items: FeedRailRecentEntry[]) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // ignore quota / private mode
+  }
+}
+
+function normalizeList(
+  next: FeedRailRecentEntry,
+  prev: FeedRailRecentEntry[],
+): FeedRailRecentEntry[] {
+  const key = entryDedupeKey(next);
+  const without = prev.filter((e) => entryDedupeKey(e) !== key);
+  return [next, ...without].slice(0, MAX_ITEMS);
+}
+
+/**
+ * Persisted recent feed-rail interactions: typed Explore queries and concrete
+ * token / user / post picks (stored so the list can mirror dropdown presentation).
+ */
+export function useFeedRailRecentSearches() {
+  const [items, setItems] = useState<FeedRailRecentEntry[]>(() => readStored());
+
+  useEffect(() => {
+    setItems(readStored());
+  }, []);
+
+  /**
+   * Persist before `setState` so a same-tick `navigate()` unmount does not skip the updater
+   * and drop localStorage writes.
+   */
+  const pushRecent = useCallback((entry: FeedRailRecentEntry) => {
+    const prev = readStored();
+    const next = normalizeList(entry, prev);
+    writeStored(next);
+    setItems(next);
+  }, []);
+
+  const removeRecent = useCallback((id: string) => {
+    const prev = readStored();
+    const next = prev.filter((e) => e.id !== id);
+    writeStored(next);
+    setItems(next);
+  }, []);
+
+  const clearAll = useCallback(() => {
+    writeStored([]);
+    setItems([]);
+  }, []);
+
+  return {
+    items,
+    pushRecent,
+    removeRecent,
+    clearAll,
+  };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -169,6 +169,30 @@
       "categorySecurity": "Security",
       "categoryTrading": "Trading",
       "categoryInvestment": "Investment"
+    },
+    "feedRailSearch": {
+      "searchOnExplore": "Search on Explore",
+      "trend": "Trend",
+      "people": "People",
+      "post": "Post",
+      "postPreviewFallback": "Post",
+      "recent": "Recent",
+      "clearAll": "Clear all",
+      "recentsEmpty": "Try searching for trends, people, posts",
+      "recentRegionAria": "Recent searches",
+      "inputAria": "Search trends, users and posts",
+      "inputPlaceholder": "Search trends, users or posts",
+      "searching": "Searching…",
+      "searchFailed": "Search failed. Try again.",
+      "noResults": "No results",
+      "exploreSearchAria": "Search \"{{query}}\" on Explore",
+      "aria": {
+        "removeRecentQuery": "Remove recent search \"{{query}}\"",
+        "removeRecentToken": "Remove this trend from recent searches",
+        "removeRecentUser": "Remove this profile from recent searches",
+        "removeRecentPost": "Remove this post from recent searches",
+        "removeRecentDefault": "Remove from recent searches"
+      }
     }
   },
   "dex": {
@@ -564,7 +588,55 @@
     "retry": "Retry",
     "noTopTraders": "No top traders for this view yet",
     "leaderboardHighlights": "The leaderboard highlights wallets with strong on-chain trading performance over the selected timeframe.",
-    "tryDifferentTimeframe": "Try a different timeframe or metric, then come back as your on-chain activity grows."
+    "tryDifferentTimeframe": "Try a different timeframe or metric, then come back as your on-chain activity grows.",
+    "exploreSearch": {
+      "userStats": {
+        "pnl": "PnL",
+        "roi": "ROI",
+        "aum": "AUM",
+        "volume": "Volume",
+        "txs": "Txs",
+        "created": "Created"
+      }
+    },
+    "tokenList": {
+      "tabTokens": "Tokens",
+      "tabUsers": "Users",
+      "tabPosts": "Posts",
+      "sortMarketCap": "Market Cap",
+      "sortTrending": "Trending",
+      "sortPrice": "Price",
+      "sortName": "Name",
+      "sortNewest": "Newest",
+      "sortOldest": "Oldest",
+      "sortHoldersCount": "Holders Count",
+      "fallbackTokens": "No matching tokens found. Showing trending tokens instead.",
+      "fallbackUsers": "No matching users found. Showing top traders instead.",
+      "fallbackPosts": "No matching posts found. Showing popular posts instead.",
+      "loading": "Loading...",
+      "searchingTrends": "Searching trends...",
+      "loadingMore": "Loading more results...",
+      "searchError": "Unable to load search results right now. Please try again.",
+      "inputAria": "Search tokens, users and posts",
+      "searchPlaceholder": "Search trends, users or posts",
+      "resultsCount_one": "{{count}} result",
+      "resultsCount_other": "{{count}} results",
+      "showLess": "Show less",
+      "viewAll": "View all",
+      "pageTitle": "Superhero.com – Search Trends, Users and Posts",
+      "pageDescription": "Search tokenized trends, creators, traders, and posts across Superhero.",
+      "tokenizedTrends": "Tokenized Trends",
+      "tokenizeTrend": "Tokenize Trend",
+      "noTokenSales": "No token sales are available right now.",
+      "loadMore": "Load More",
+      "loadingEllipsis": "Loading...",
+      "topTradersTitle": "Top Traders",
+      "topTradersSubtitle": "The most active traders on Superhero right now.",
+      "noLeaderboard": "No leaderboard data is available right now.",
+      "popularPostsTitle": "Popular Posts",
+      "popularPostsSubtitle": "What the community is talking about the most.",
+      "noPopularPosts": "No popular posts are available right now."
+    }
   },
   "errors": {
     "userRejected": "Transaction was rejected in your wallet.",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -3,6 +3,7 @@ import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 // Provide a default CONFIG for tests unless overridden
 import { CONFIG } from './src/config';
+import './src/i18n';
 
 (global as any).CONFIG = CONFIG;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new debounced, multi-endpoint search dropdown on the home right rail with localStorage-backed recents and new API merging logic; main risk is UX/navigation edge cases and increased search traffic/load on backend endpoints.
> 
> **Overview**
> **Adds a new home right-rail search experience.** The `/` right rail now shows `FeedRailSearch`, a debounced dropdown that searches tokens, users, and posts, supports keyboard submit to Explore, and persists/remove/clear *recent searches* via `localStorage`.
> 
> **Extends trending search APIs for the rail.** `trendsSearch` now exposes `fetchFeedRailSearchItems` plus constants, reuses the preview fetch with a configurable limit, and merges results into a grouped list (tokens → users → posts) with backfill when categories are sparse; accompanying unit tests cover ordering, trimming/empty queries, backfill, and partial endpoint failure.
> 
> **Cleans up and internationalizes Explore search.** `TokenList` is refactored to share result list components, read/write initial search state from `?q=`, and move UI strings to i18n; `CreateTokenView` switches to the shared `useDebouncedValue` hook, and new debounce hooks/tests plus locale keys and test i18n setup are added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5e904431325a3de23153e665ae93173320c2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->