### PR TITLE
Release

### DIFF
--- a/src/components/layout/RightRail.tsx
+++ b/src/components/layout/RightRail.tsx
@@ -6,8 +6,7 @@ import FeedRailSearch from '@/components/layout/FeedRailSearch';
 import { useCurrencies } from '@/hooks/useCurrencies';
 import { useAccountBalances } from '../../hooks/useAccountBalances';
 import { useAeSdk } from '../../hooks/useAeSdk';
-import { BuyAeWidget } from '../../features/ae-eth-buy';
-
+// import { BuyAeWidget } from '../../features/ae-eth-buy';
 import { useWallet } from '../../hooks';
 import { useAddressByChainName } from '../../hooks/useChainName';
 
@@ -183,10 +182,11 @@ const RightRail = ({
 
       {/* Enhanced Trending Section removed for now. */}
 
-      {/* Buy AE with ETH widget (compact) */}
+      {/* Buy AE with ETH (disabled): uncomment BuyAeWidget import above, then the block below.
       <div className="bg-white/[0.03] border border-white/10 rounded-[20px] p-4 shadow-none">
         <BuyAeWidget embedded />
       </div>
+      */}
 
       {/* Trading Leaderboard promo */}
       <div className="bg-white/[0.03] border border-white/10 rounded-[20px] p-4 shadow-none mb-4">
@@ -250,6 +250,16 @@ const RightRail = ({
           >
             📦 Wrap AE
           </button>
+          <a
+            href="https://quali.chat"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-gradient-to-r from-purple-500 to-purple-600 text-white border-none rounded-xl py-3.5 px-3.5 text-xs font-semibold cursor-pointer transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(147,51,234,0.35)] no-underline text-center flex items-center justify-center gap-1.5 relative overflow-hidden after:content-[''] after:absolute after:top-0 after:-left-full after:w-full after:h-full after:bg-gradient-to-r after:from-transparent after:via-white/30 after:to-transparent after:transition-all after:duration-600 hover:after:left-full"
+            title={t('titles.openChat')}
+          >
+            💬 Chat
+          </a>
+          {/* Buy AE with ETH quick action (disabled)
           <button
             type="button"
             className="bg-gradient-to-r from-indigo-500 to-blue-600 text-white border-none rounded-xl py-3.5 px-3.5 text-xs font-semibold cursor-pointer transition-all duration-200 hover:-translate-y-0.5 relative overflow-hidden after:content-[''] after:absolute after:top-0 after:-left-full after:w-full after:h-full after:bg-gradient-to-r after:from-transparent after:via-white/30 after:to-transparent after:transition-all after:duration-600 hover:after:left-full"
@@ -258,6 +268,7 @@ const RightRail = ({
           >
             🌉 Buy AE with ETH
           </button>
+          */}
           <button
             type="button"
             className="bg-gradient-to-r from-amber-500 to-orange-600 text-white border-none rounded-xl py-3.5 px-3.5 text-xs font-semibold cursor-pointer transition-all duration-200 hover:-translate-y-0.5 relative overflow-hidden after:content-[''] after:absolute after:top-0 after:-left-full after:w-full after:h-full after:bg-gradient-to-r after:from-transparent after:via-white/30 after:to-transparent after:transition-all after:duration-600 hover:after:left-full"
@@ -266,15 +277,6 @@ const RightRail = ({
           >
             💧 Provide Liquidity
           </button>
-          <a
-            href="https://quali.chat"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="col-span-2 bg-gradient-to-r from-purple-500 to-purple-600 text-white border-none rounded-xl py-3.5 px-3.5 text-xs font-semibold cursor-pointer transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(147,51,234,0.35)] no-underline text-center flex items-center justify-center gap-1.5 relative overflow-hidden after:content-[''] after:absolute after:top-0 after:-left-full after:w-full after:h-full after:bg-gradient-to-r after:from-transparent after:via-white/30 after:to-transparent after:transition-all after:duration-600 hover:after:left-full"
-            title={t('titles.openChat')}
-          >
-            💬 Chat
-          </a>
         </div>
       </div>
     </div>

--- a/src/features/dex/layouts/DexLayout.tsx
+++ b/src/features/dex/layouts/DexLayout.tsx
@@ -4,8 +4,8 @@ import {
   ArrowLeftRight,
   Droplet,
   Package,
-  Network,
-  Gem,
+  // Network,
+  // Gem,
   Coins,
   Waves,
   ClipboardList,
@@ -45,20 +45,20 @@ const navigationItems: NavigationItem[] = [
     path: '/defi/wrap',
     description: 'Convert AE ↔ WAE',
   },
-  {
-    id: 'bridge',
-    label: 'BRIDGE',
-    icon: Network,
-    path: '/defi/bridge',
-    description: 'Bridge tokens between Ethereum and æternity',
-  },
-  {
-    id: 'buy-ae',
-    label: 'BUY AE',
-    icon: Gem,
-    path: '/defi/buy-ae-with-eth',
-    description: 'Buy AE with ETH',
-  },
+  // {
+  //   id: 'bridge',
+  //   label: 'BRIDGE',
+  //   icon: Network,
+  //   path: '/defi/bridge',
+  //   description: 'Bridge tokens between Ethereum and æternity',
+  // },
+  // {
+  //   id: 'buy-ae',
+  //   label: 'BUY AE',
+  //   icon: Gem,
+  //   path: '/defi/buy-ae-with-eth',
+  //   description: 'Buy AE with ETH',
+  // },
 ];
 
 const exploreItems: NavigationItem[] = [

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -41,7 +41,7 @@ const TxQueue = lazy(() => import('./views/TxQueue'));
 const DexLayout = lazy(() => import('./features/dex/layouts/DexLayout'));
 const DexSwap = lazy(() => import('./features/dex/views/DexSwap'));
 const DexWrap = lazy(() => import('./features/dex/views/DexWrap'));
-const DexBridge = lazy(() => import('./features/dex/views/DexBridge'));
+// const DexBridge = lazy(() => import('./features/dex/views/DexBridge'));
 const Pool = lazy(() => import('./features/dex/views/Pool'));
 const DexExploreTokens = lazy(
   () => import('./features/dex/views/DexExploreTokens'),
@@ -52,7 +52,7 @@ const DexExplorePools = lazy(
 const DexExploreTransactions = lazy(
   () => import('./features/dex/views/DexExploreTransactions'),
 );
-const Bridge = lazy(() => import('./features/ae-eth-bridge/views/Bridge'));
+// const Bridge = lazy(() => import('./features/ae-eth-bridge/views/Bridge'));
 
 // Legacy DEX components (for backward compatibility)
 const Explore = lazy(() => import('./views/Explore'));
@@ -171,19 +171,23 @@ export const routes: RouteObject[] = [
   },
   {
     path: '/defi/buy-ae-with-eth',
-    element: (
-      <DexLayout>
-        <DexBridge />
-      </DexLayout>
-    ),
+    // Re-enable: uncomment DexBridge lazy import above, then swap `element` for the block below.
+    element: <Navigate to="/defi/swap" replace />,
+    // element: (
+    //   <DexLayout>
+    //     <DexBridge />
+    //   </DexLayout>
+    // ),
   },
   {
     path: '/defi/bridge',
-    element: (
-      <DexLayout>
-        <Bridge />
-      </DexLayout>
-    ),
+    // Re-enable: uncomment Bridge lazy import above, then swap `element` for the block below.
+    element: <Navigate to="/defi/swap" replace />,
+    // element: (
+    //   <DexLayout>
+    //     <Bridge />
+    //   </DexLayout>
+    // ),
   },
   {
     path: '/defi/pool',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes DEX navigation and routing by disabling `bridge`/`buy-ae-with-eth` and redirecting those paths to `swap`, which may break existing deep links or user flows. Otherwise the diff is UI-only and low complexity.
> 
> **Overview**
> Temporarily disables the AE↔ETH bridge / buy-AE flows across the app: the DEX nav no longer shows `BRIDGE`/`BUY AE`, the right-rail `BuyAeWidget` and quick-action button are commented out, and routes for `/defi/bridge` and `/defi/buy-ae-with-eth` now redirect to `/defi/swap` (with inline instructions to re-enable).
> 
> Reorders the right-rail quick actions and adds a persistent external `Chat` link to `https://quali.chat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9f32edb7d7d882509efbfd119ee5418b0189c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->