### PR TITLE
feat: be able to customize popular feed

### DIFF
--- a/src/api/__tests__/backend.listPopularPosts.test.ts
+++ b/src/api/__tests__/backend.listPopularPosts.test.ts
@@ -1,0 +1,119 @@
+import {
+  beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import { SuperheroApi } from '../backend';
+
+describe('SuperheroApi.listPopularPosts', () => {
+  const jsonBody = JSON.stringify({ items: [], meta: { currentPage: 1, totalPages: 1, totalItems: 0 } });
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (name: string) => {
+          if (name === 'content-type') return 'application/json';
+          if (name === 'content-length') return String(jsonBody.length);
+          return null;
+        },
+      },
+      text: () => Promise.resolve(jsonBody),
+    }));
+  });
+
+  const getCalledUrl = (): string => {
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    return call[0] as string;
+  };
+
+  it('builds URL with window, page, and limit', async () => {
+    await SuperheroApi.listPopularPosts({ window: '7d', page: 2, limit: 20 });
+    const url = getCalledUrl();
+    expect(url).toContain('window=7d');
+    expect(url).toContain('page=2');
+    expect(url).toContain('limit=20');
+  });
+
+  it('builds URL without weights when none provided', async () => {
+    await SuperheroApi.listPopularPosts({ window: '24h', page: 1, limit: 10 });
+    const url = getCalledUrl();
+    expect(url).toContain('window=24h');
+    expect(url).not.toContain('comments');
+    expect(url).not.toContain('reads');
+  });
+
+  it('appends weight params to URL', async () => {
+    await SuperheroApi.listPopularPosts({
+      window: '24h',
+      page: 1,
+      limit: 10,
+      weights: { comments: 'high', reads: 'low' },
+    });
+    const url = getCalledUrl();
+    expect(url).toContain('comments=high');
+    expect(url).toContain('reads=low');
+  });
+
+  it('appends all weight keys when provided', async () => {
+    await SuperheroApi.listPopularPosts({
+      window: 'all',
+      page: 1,
+      limit: 10,
+      weights: {
+        comments: 'high',
+        tipsAmountAE: 'low',
+        tipsCount: 'med',
+        uniqueTippers: 'high',
+        trendingBoost: 'low',
+        contentQuality: 'med',
+        reads: 'high',
+        interactionsPerHour: 'low',
+      },
+    });
+    const url = getCalledUrl();
+    expect(url).toContain('comments=high');
+    expect(url).toContain('tipsAmountAE=low');
+    expect(url).toContain('tipsCount=med');
+    expect(url).toContain('uniqueTippers=high');
+    expect(url).toContain('trendingBoost=low');
+    expect(url).toContain('contentQuality=med');
+    expect(url).toContain('reads=high');
+    expect(url).toContain('interactionsPerHour=low');
+  });
+
+  it('skips undefined weight values', async () => {
+    await SuperheroApi.listPopularPosts({
+      window: '24h',
+      page: 1,
+      limit: 10,
+      weights: { comments: 'high' },
+    });
+    const url = getCalledUrl();
+    expect(url).toContain('comments=high');
+    expect(url).not.toContain('reads=');
+    expect(url).not.toContain('tipsCount=');
+  });
+
+  it('does not append weights when weights is undefined', async () => {
+    await SuperheroApi.listPopularPosts({
+      window: '24h',
+      page: 1,
+      limit: 10,
+      weights: undefined,
+    });
+    const url = getCalledUrl();
+    const params = new URL(url).searchParams;
+    expect([...params.keys()]).toEqual(['window', 'page', 'limit']);
+  });
+
+  it('does not append weights when weights is empty object', async () => {
+    await SuperheroApi.listPopularPosts({
+      window: '24h',
+      page: 1,
+      limit: 10,
+      weights: {},
+    });
+    const url = getCalledUrl();
+    const params = new URL(url).searchParams;
+    expect([...params.keys()]).toEqual(['window', 'page', 'limit']);
+  });
+});

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -157,12 +157,24 @@ export const SuperheroApi = {
       throw err;
     }
   },
-  // GET /api/posts/popular?window=all&page=1&limit=50
-  listPopularPosts(params: { window?: '24h'|'7d'|'all'; page?: number; limit?: number } = {}) {
+  listPopularPosts(params: {
+    window?: '24h'|'7d'|'all';
+    page?: number;
+    limit?: number;
+    weights?: Partial<Record<
+      'comments'|'tipsAmountAE'|'tipsCount'|'uniqueTippers'|'trendingBoost'|'contentQuality'|'reads'|'interactionsPerHour',
+      'low'|'med'|'high'
+    >>;
+  } = {}) {
     const qp = new URLSearchParams();
     if (params.window) qp.set('window', params.window);
     if (params.page != null) qp.set('page', String(params.page));
     if (params.limit != null) qp.set('limit', String(params.limit));
+    if (params.weights) {
+      Object.entries(params.weights).forEach(([key, value]) => {
+        if (value) qp.set(key, value);
+      });
+    }
     const query = qp.toString();
     return this.fetchJson(`/api/posts/popular${query ? `?${query}` : ''}`);
   },

--- a/src/features/social/components/SortControls.tsx
+++ b/src/features/social/components/SortControls.tsx
@@ -1,13 +1,51 @@
-import React, { memo } from 'react';
+import React, {
+  memo, useEffect, useRef, useState,
+} from 'react';
+import { Link } from 'react-router-dom';
 import { cn } from '@/lib/utils';
-import { ChevronDown } from 'lucide-react';
+import {
+  ChevronDown, SlidersHorizontal, RotateCcw, Rocket, X,
+} from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { AeButton } from '../../../components/ui/ae-button';
+
+export type WeightKey =
+  | 'comments'
+  | 'tipsAmountAE'
+  | 'tipsCount'
+  | 'uniqueTippers'
+  | 'trendingBoost'
+  | 'contentQuality'
+  | 'reads'
+  | 'interactionsPerHour';
+
+export type WeightValue = 'low' | 'med' | 'high';
+
+export type PopularWeights = Partial<Record<WeightKey, WeightValue>>;
+
+const WEIGHT_LABELS: Record<WeightKey, string> = {
+  comments: 'Comments',
+  tipsAmountAE: 'Tip Amount',
+  tipsCount: 'Tip Count',
+  uniqueTippers: 'Unique Tippers',
+  trendingBoost: 'Trending Boost',
+  contentQuality: 'Content Quality',
+  reads: 'Reads',
+  interactionsPerHour: 'Activity Rate',
+};
+
+const WEIGHT_KEYS = Object.keys(WEIGHT_LABELS) as WeightKey[];
+const WEIGHT_VALUES: WeightValue[] = ['low', 'med', 'high'];
 
 interface SortControlsProps {
   sortBy: string;
@@ -16,13 +54,77 @@ interface SortControlsProps {
   popularWindow?: '24h' | '7d' | 'all';
   onPopularWindowChange?: (value: '24h' | '7d' | 'all') => void;
   popularFeedEnabled?: boolean;
+  popularWeights?: PopularWeights;
+  onPopularWeightsChange?: (weights: PopularWeights) => void;
 }
 
 // Component: Sort Controls
 const SortControls = memo(
   ({
-    sortBy, onSortChange, className = '', popularWindow = 'all', onPopularWindowChange, popularFeedEnabled = true,
+    sortBy, onSortChange, className = '', popularWindow = '24h', onPopularWindowChange, popularFeedEnabled = true,
+    popularWeights = {}, onPopularWeightsChange,
   }: SortControlsProps) => {
+    const mobileSortRef = useRef<HTMLDivElement>(null);
+    const [customizeOpen, setCustomizeOpen] = useState(false);
+    const [mobileSortOpen, setMobileSortOpen] = useState(false);
+    const [mobileCustomizeOpen, setMobileCustomizeOpen] = useState(false);
+
+    const hasCustomWeights = Object.keys(popularWeights).length > 0;
+
+    const getEffectiveWeight = (key: WeightKey): WeightValue => popularWeights[key] ?? 'med';
+
+    const handleWindowChange = (value: '24h' | '7d' | 'all') => {
+      if (onPopularWindowChange) onPopularWindowChange(value);
+    };
+
+    const handleWeightChange = (key: WeightKey, value: WeightValue) => {
+      if (!onPopularWeightsChange) return;
+      const next = { ...popularWeights };
+      const effective = getEffectiveWeight(key);
+      if (effective === value) return;
+      if (value === 'med') {
+        delete next[key];
+      } else {
+        next[key] = value;
+      }
+      onPopularWeightsChange(next);
+    };
+
+    const handleResetWeights = () => {
+      if (onPopularWeightsChange) onPopularWeightsChange({});
+    };
+
+    const handleResetCustomSettings = () => {
+      handleResetWeights();
+      handleWindowChange('24h');
+    };
+
+    useEffect(() => {
+      if (!mobileSortOpen) return undefined;
+
+      const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+        if (!mobileSortRef.current?.contains(event.target as Node)) {
+          setMobileSortOpen(false);
+        }
+      };
+
+      document.addEventListener('mousedown', handlePointerDown);
+      document.addEventListener('touchstart', handlePointerDown);
+
+      return () => {
+        document.removeEventListener('mousedown', handlePointerDown);
+        document.removeEventListener('touchstart', handlePointerDown);
+      };
+    }, [mobileSortOpen]);
+
+    useEffect(() => {
+      setMobileSortOpen(false);
+      if (sortBy !== 'hot') {
+        setMobileCustomizeOpen(false);
+        setCustomizeOpen(false);
+      }
+    }, [sortBy, popularWindow]);
+
     // Show "Latest Feed" title if popular feed is disabled
     if (!popularFeedEnabled) {
       return (
@@ -52,115 +154,257 @@ const SortControls = memo(
       return `Popular ${timeLabel.toLowerCase()}`;
     };
 
-    // Helper function to handle dropdown selection
-    const handleMobileOptionSelect = (option: string) => {
-      if (option === 'latest') {
-        onSortChange('latest');
-      } else if (option === 'this-week') {
-        onSortChange('hot');
-        if (onPopularWindowChange) {
-          onPopularWindowChange('7d');
-        }
-      } else if (option === 'all-time') {
-        onSortChange('hot');
-        if (onPopularWindowChange) {
-          onPopularWindowChange('all');
-        }
-      } else if (option === 'today') {
-        onSortChange('hot');
-        if (onPopularWindowChange) {
-          onPopularWindowChange('24h');
-        }
-      }
+    const handleMobileSortToggle = (newSort: 'hot' | 'latest') => {
+      setMobileSortOpen(false);
+      onSortChange(newSort);
     };
+
+    const hasNonDefaultWindow = popularWindow !== '24h';
+    const hasCustomSettings = hasCustomWeights || hasNonDefaultWindow;
+
+    const renderCustomizeControls = (isMobile = false) => (
+      <>
+        {!isMobile && (
+          <div className="px-4 pt-3 pb-2 flex items-center justify-between border-b border-white/10">
+            <span className="text-xs font-semibold text-white/90 uppercase tracking-wider">Customize Feed</span>
+            {hasCustomSettings && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleResetCustomSettings();
+                }}
+                className="flex items-center gap-1 text-[11px] text-white/50 hover:text-white/80 transition-colors"
+              >
+                <RotateCcw className="h-3 w-3" />
+                Reset
+              </button>
+            )}
+          </div>
+        )}
+        <div className="px-4 pt-3 pb-2">
+          <span className="text-[10px] font-semibold text-white/50 uppercase tracking-wider">Time Window</span>
+          <div className="mt-1.5 inline-flex items-center gap-0.5 bg-white/5 rounded-full p-0.5 border border-white/10">
+            {(['24h', '7d', 'all'] as const).map((tf) => {
+              const isActive = popularWindow === tf;
+              const label = getPopularLabel(tf);
+              return (
+                <button
+                  type="button"
+                  key={tf}
+                  onClick={(e) => {
+                    if (!isMobile) {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }
+                    handleWindowChange(tf);
+                  }}
+                  className={cn(
+                    'px-3 py-1.5 text-[11px] rounded-full border transition-all duration-200',
+                    isActive
+                      ? 'bg-[#1161FE] text-white border-transparent shadow-sm'
+                      : 'bg-transparent text-white/70 border-transparent hover:text-white/90 hover:bg-white/10',
+                  )}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <div className="px-4 pt-2 pb-1">
+          <span className="text-[10px] font-semibold text-white/50 uppercase tracking-wider">Weights</span>
+        </div>
+        <div className="px-3 pb-3 flex flex-col gap-2">
+          {WEIGHT_KEYS.map((key) => (
+            <div key={key} className="flex items-center justify-between gap-3 px-1">
+              <span className="text-xs text-white/70 min-w-[90px]">{WEIGHT_LABELS[key]}</span>
+              <div className="inline-flex items-center gap-0.5 bg-white/5 rounded-full p-0.5 border border-white/10">
+                {WEIGHT_VALUES.map((val) => {
+                  const isActive = getEffectiveWeight(key) === val;
+                  return (
+                    <button
+                      type="button"
+                      key={val}
+                      onClick={(e) => {
+                        if (!isMobile) {
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }
+                        handleWeightChange(key, val);
+                      }}
+                      className={cn(
+                        'px-2.5 py-1 text-[10px] rounded-full border transition-all duration-200 capitalize',
+                        isActive
+                          ? 'bg-[#1161FE] text-white border-transparent shadow-sm'
+                          : 'bg-transparent text-white/60 border-transparent hover:text-white/90 hover:bg-white/10',
+                      )}
+                    >
+                      {val}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </>
+    );
+
+    const renderCustomizeDropdownContent = (minWidth: string) => (
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        className={cn('bg-[#0d0d0d] border-white/15 text-white p-0 rounded-xl shadow-2xl', minWidth)}
+        style={{
+          background: 'radial-gradient(600px 300px at 50% -20%, rgba(17,97,254,0.08), transparent 60%), #0d0d0d',
+        }}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        {renderCustomizeControls()}
+      </DropdownMenuContent>
+    );
 
     return (
       <div className={cn('w-full mb-0 md:mb-3', className)}>
         {/* Mobile: title with dropdown */}
         <div className="md:hidden">
           <div className="flex items-center justify-between border-b border-white/15 w-screen -mx-[calc((100vw-100%)/2)] px-4 pt-3 pb-3">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
+            <div className="flex items-center gap-2 min-w-0">
+              <div ref={mobileSortRef} className="relative min-w-0">
+                {mobileSortOpen && (
+                  <div
+                    className="absolute left-0 top-[calc(100%+8px)] z-[1200] min-w-[180px] rounded-2xl border border-white/15 bg-[#0d0d0d] p-1 text-white shadow-2xl"
+                    style={{
+                      background: 'radial-gradient(600px 300px at 50% -20%, rgba(17,97,254,0.08), transparent 60%), #0d0d0d',
+                    }}
+                    role="menu"
+                    aria-label="Feed sort options"
+                  >
+                    {sortBy === 'hot' ? (
+                      <button
+                        type="button"
+                        onClick={() => handleMobileSortToggle('latest')}
+                        className="flex min-h-[44px] w-full items-center rounded-xl px-4 py-2.5 text-left text-sm text-white transition-colors hover:bg-white/10"
+                        role="menuitem"
+                      >
+                        Latest
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => handleMobileSortToggle('hot')}
+                        className="flex min-h-[44px] w-full items-center rounded-xl px-4 py-2.5 text-left text-sm text-white transition-colors hover:bg-white/10"
+                        role="menuitem"
+                      >
+                        Popular
+                      </button>
+                    )}
+                  </div>
+                )}
+
                 <button
                   type="button"
                   className="flex items-center gap-2 text-base font-bold text-white tracking-tight [text-shadow:none] [background:none] [-webkit-text-fill-color:white] hover:opacity-80 transition-opacity focus:outline-none"
+                  aria-haspopup="menu"
+                  aria-expanded={mobileSortOpen}
+                  onClick={() => {
+                    setMobileCustomizeOpen(false);
+                    setMobileSortOpen((open) => !open);
+                  }}
                 >
                   <span>{getMobileTitle()}</span>
-                  <ChevronDown className="h-4 w-4 text-white/70" />
+                  <ChevronDown className={cn('h-4 w-4 text-white/70 shrink-0 transition-transform', mobileSortOpen && 'rotate-180')} />
                 </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent
-                align="start"
-                sideOffset={8}
-                className="bg-white/5 backdrop-blur-xl border-white/20 text-white min-w-[240px] py-2 rounded-xl shadow-2xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-4 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-top"
-                style={{
-                  background: 'radial-gradient(1200px 400px at -20% -40%, rgba(255,255,255,0.06), transparent 40%), rgba(255, 255, 255, 0.03)',
-                  backdropFilter: 'blur(16px)',
-                  WebkitBackdropFilter: 'blur(16px)',
-                }}
-              >
-                {sortBy === 'hot' ? (
-                  <>
-                    {popularWindow !== '24h' && (
-                    <DropdownMenuItem
-                      onClick={() => handleMobileOptionSelect('today')}
-                      className="cursor-pointer focus:bg-white/10 focus:text-white px-4 py-2.5 text-sm"
-                    >
-                      Today
-                    </DropdownMenuItem>
+              </div>
+              {sortBy === 'hot' && (
+                <Dialog open={mobileCustomizeOpen} onOpenChange={setMobileCustomizeOpen}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMobileSortOpen(false);
+                      setMobileCustomizeOpen(true);
+                    }}
+                    className={cn(
+                      'relative overflow-visible p-2.5 rounded-full transition-all duration-200 shrink-0',
+                      hasCustomSettings
+                        ? 'text-[#1161FE]'
+                        : 'text-white/50 hover:text-white/80',
                     )}
-                    {popularWindow !== '7d' && (
-                    <DropdownMenuItem
-                      onClick={() => handleMobileOptionSelect('this-week')}
-                      className="cursor-pointer focus:bg-white/10 focus:text-white px-4 py-2.5 text-sm"
-                    >
-                      This week
-                    </DropdownMenuItem>
+                    title="Customize popular feed"
+                  >
+                    <SlidersHorizontal className="h-5 w-5" />
+                    {hasCustomSettings && (
+                      <span className="absolute top-0.5 right-0.5 w-2 h-2 bg-[#1161FE] rounded-full ring-2 ring-[#0d0d0d]" />
                     )}
-                    {popularWindow !== 'all' && (
-                    <DropdownMenuItem
-                      onClick={() => handleMobileOptionSelect('all-time')}
-                      className="cursor-pointer focus:bg-white/10 focus:text-white px-4 py-2.5 text-sm"
-                    >
-                      All time
-                    </DropdownMenuItem>
-                    )}
-                    <DropdownMenuItem
-                      onClick={() => handleMobileOptionSelect('latest')}
-                      className="cursor-pointer focus:bg-white/10 focus:text-white px-4 py-2.5 text-sm"
-                    >
-                      Latest
-                    </DropdownMenuItem>
-                  </>
-                ) : (
-                  <>
-                    <DropdownMenuItem
-                      onClick={() => handleMobileOptionSelect('today')}
-                      className="cursor-pointer focus:bg-white/10 focus:text-white px-4 py-2.5 text-sm"
-                    >
-                      Popular today
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => handleMobileOptionSelect('this-week')}
-                      className="cursor-pointer focus:bg-white/10 focus:text-white px-4 py-2.5 text-sm"
-                    >
-                      Popular this week
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => handleMobileOptionSelect('all-time')}
-                      className="cursor-pointer focus:bg-white/10 focus:text-white px-4 py-2.5 text-sm"
-                    >
-                      Popular all time
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
+                  </button>
+                  <DialogContent
+                    hideClose
+                    className="!left-0 !right-0 !top-auto !bottom-0 !z-[1200] !w-full !max-w-none !translate-x-0 !translate-y-0 gap-0 rounded-t-[28px] rounded-b-none border-white/15 bg-[#0d0d0d] p-0 text-white shadow-2xl data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-left-0 data-[state=open]:slide-in-from-left-0 data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100 sm:!max-w-none"
+                  >
+                    <div className="mx-auto mt-3 h-1.5 w-12 rounded-full bg-white/15" />
+                    <div className="max-h-[85vh] overflow-y-auto pb-[calc(env(safe-area-inset-bottom)+16px)]">
+                      <div className="flex items-start justify-between gap-4 border-b border-white/10 px-4 pt-3 pb-3">
+                        <div>
+                          <DialogTitle className="text-base font-semibold text-white">
+                            Customize Feed
+                          </DialogTitle>
+                          <DialogDescription className="mt-1 text-sm text-white/60">
+                            Tune the popular feed ranking and time window.
+                          </DialogDescription>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setMobileCustomizeOpen(false)}
+                          className="rounded-full p-2 text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+                          aria-label="Close customization panel"
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      </div>
+                      <div className="px-4 pt-3 pb-2 flex items-center justify-between">
+                        <span className="text-xs font-semibold text-white/50 uppercase tracking-wider">
+                          Popular Feed Settings
+                        </span>
+                        {hasCustomSettings && (
+                          <button
+                            type="button"
+                            onClick={handleResetCustomSettings}
+                            className="flex items-center gap-1 text-[11px] text-white/50 transition-colors hover:text-white/80"
+                          >
+                            <RotateCcw className="h-3 w-3" />
+                            Reset
+                          </button>
+                        )}
+                      </div>
+                      {renderCustomizeControls(true)}
+                      <div className="px-4 pt-2">
+                        <button
+                          type="button"
+                          onClick={() => setMobileCustomizeOpen(false)}
+                          className="flex min-h-[44px] w-full items-center justify-center rounded-2xl bg-[#1161FE] px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#0e50d8]"
+                        >
+                          Done
+                        </button>
+                      </div>
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              )}
+            </div>
+            <Link
+              to="/trends/create"
+              className="inline-flex items-center gap-1.5 rounded-full bg-[#1161FE] px-3 py-1.5 text-xs font-semibold text-white transition-all duration-200 hover:bg-[#0e50d8] active:scale-[0.97] shrink-0"
+            >
+              <Rocket className="h-3 w-3" />
+              Tokenize Trend
+            </Link>
           </div>
         </div>
 
-        {/* Desktop: keep existing pill style */}
-        <div className="hidden md:flex w-full items-center justify-between gap-2">
+        {/* Desktop */}
+        <div className="hidden md:flex w-full items-center gap-2 pr-1">
           <div className="inline-flex items-center gap-1.5 bg-white/5 rounded-full p-0.5 border border-white/10 md:w-auto">
             <AeButton
               onClick={() => onSortChange('hot')}
@@ -192,32 +436,34 @@ const SortControls = memo(
             </AeButton>
           </div>
           {sortBy === 'hot' && (
-          <div className="inline-flex items-center gap-1 bg-white/5 rounded-full p-0.5 border border-white/10 ml-auto">
-            {(['24h', '7d', 'all'] as const).map((tf) => {
-              const isActive = popularWindow === tf;
-              const label = getPopularLabel(tf);
-              return (
+            <DropdownMenu open={customizeOpen} onOpenChange={setCustomizeOpen} modal={false}>
+              <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  key={tf}
-                  onClick={() => {
-                    if (onPopularWindowChange) {
-                      onPopularWindowChange(tf);
-                    }
-                  }}
                   className={cn(
-                    'px-3 py-1.5 text-[11px] rounded-full border transition-all duration-300',
-                    isActive
-                      ? 'bg-[#1161FE] text-white border-transparent shadow-sm'
-                      : 'bg-transparent text-white/80 border-white/10 hover:bg-white/10',
+                    'relative overflow-visible p-2.5 rounded-full border transition-all duration-200',
+                    hasCustomSettings
+                      ? 'bg-[#1161FE]/20 border-[#1161FE]/50 text-[#1161FE]'
+                      : 'bg-white/5 border-white/10 text-white/70 hover:text-white hover:bg-white/10',
                   )}
+                  title="Customize popular feed"
                 >
-                  {label}
+                  <SlidersHorizontal className="h-5 w-5" />
+                  {hasCustomSettings && (
+                    <span className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-[#1161FE] rounded-full ring-2 ring-[#0d0d0d]" />
+                  )}
                 </button>
-              );
-            })}
-          </div>
+              </DropdownMenuTrigger>
+              {renderCustomizeDropdownContent('min-w-[300px]')}
+            </DropdownMenu>
           )}
+          <Link
+            to="/trends/create"
+            className="inline-flex items-center gap-1.5 rounded-full bg-[#1161FE] px-3.5 py-1.5 text-xs font-semibold text-white transition-all duration-200 hover:bg-[#0e50d8] active:scale-[0.97] ml-auto"
+          >
+            <Rocket className="h-3 w-3" />
+            Tokenize Trend
+          </Link>
         </div>
       </div>
     );

--- a/src/features/social/components/__tests__/SortControls.test.tsx
+++ b/src/features/social/components/__tests__/SortControls.test.tsx
@@ -1,0 +1,243 @@
+import React from 'react';
+import {
+  fireEvent, render, screen,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  beforeEach, describe, expect, it, vi,
+} from 'vitest';
+
+import SortControls, { type PopularWeights } from '../SortControls';
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: any[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('lucide-react', () => ({
+  ChevronDown: (props: any) => <span data-testid="chevron-down" {...props} />,
+  SlidersHorizontal: (props: any) => <span data-testid="sliders-icon" {...props} />,
+  RotateCcw: (props: any) => <span data-testid="rotate-ccw" {...props} />,
+  Rocket: (props: any) => <span data-testid="rocket-icon" {...props} />,
+  X: (props: any) => <span data-testid="x-icon" {...props} />,
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children, ...props }: any) => <div data-testid="dropdown-menu" {...props}>{children}</div>,
+  DropdownMenuContent: ({ children, ...props }: any) => <div data-testid="dropdown-content" {...props}>{children}</div>,
+  DropdownMenuItem: ({ children, onClick, ...props }: any) => (
+    <button type="button" data-testid="dropdown-item" onClick={onClick} {...props}>{children}</button>
+  ),
+  DropdownMenuTrigger: ({ children }: any) => children,
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: any) => <div data-testid="dialog-root">{children}</div>,
+  DialogContent: ({ children, ...props }: any) => <div data-testid="dialog-content" {...props}>{children}</div>,
+  DialogDescription: ({ children, ...props }: any) => <div data-testid="dialog-description" {...props}>{children}</div>,
+  DialogTitle: ({ children, ...props }: any) => <div data-testid="dialog-title" {...props}>{children}</div>,
+}));
+
+vi.mock('../../../../components/ui/ae-button', () => ({
+  AeButton: ({ children, onClick, ...props }: any) => (
+    <button type="button" onClick={onClick} {...props}>{children}</button>
+  ),
+}));
+
+describe('SortControls', () => {
+  let onSortChange: ReturnType<typeof vi.fn>;
+  let onPopularWindowChange: ReturnType<typeof vi.fn>;
+  let onPopularWeightsChange: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onSortChange = vi.fn();
+    onPopularWindowChange = vi.fn();
+    onPopularWeightsChange = vi.fn();
+  });
+
+  const renderControls = (overrides: Record<string, any> = {}) => render(
+    <MemoryRouter>
+      <SortControls
+        sortBy="hot"
+        onSortChange={onSortChange}
+        popularWindow="24h"
+        onPopularWindowChange={onPopularWindowChange}
+        onPopularWeightsChange={onPopularWeightsChange}
+        {...overrides}
+      />
+    </MemoryRouter>,
+  );
+
+  describe('when popular feed is disabled', () => {
+    it('renders "Latest Feed" heading', () => {
+      renderControls({ popularFeedEnabled: false });
+      expect(screen.getByText('Latest Feed')).toBeInTheDocument();
+    });
+
+    it('does not render the customize button', () => {
+      renderControls({ popularFeedEnabled: false });
+      expect(screen.queryByTitle('Customize popular feed')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('sort tabs', () => {
+    it('renders Popular and Latest buttons', () => {
+      renderControls();
+      expect(screen.getAllByText('Popular').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('Latest').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('calls onSortChange when clicking a Latest button', () => {
+      renderControls();
+      const latestButtons = screen.getAllByText('Latest');
+      fireEvent.click(latestButtons[latestButtons.length - 1]);
+      expect(onSortChange).toHaveBeenCalledWith('latest');
+    });
+
+    it('calls onSortChange when clicking a Popular button', () => {
+      renderControls({ sortBy: 'latest' });
+      const popularButtons = screen.getAllByText('Popular');
+      fireEvent.click(popularButtons[popularButtons.length - 1]);
+      expect(onSortChange).toHaveBeenCalledWith('hot');
+    });
+  });
+
+  describe('tokenize trend button', () => {
+    it('renders Tokenize Trend link', () => {
+      renderControls();
+      const links = screen.getAllByText('Tokenize Trend');
+      expect(links.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('links to /trends/create', () => {
+      renderControls();
+      const links = screen.getAllByText('Tokenize Trend');
+      const linkEl = links[0].closest('a');
+      expect(linkEl).toHaveAttribute('href', '/trends/create');
+    });
+
+    it('renders Tokenize Trend even when sortBy is latest', () => {
+      renderControls({ sortBy: 'latest' });
+      const links = screen.getAllByText('Tokenize Trend');
+      expect(links.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('customize button', () => {
+    it('renders the customize button when sortBy is hot', () => {
+      renderControls();
+      expect(screen.getAllByTitle('Customize popular feed').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not render the customize button when sortBy is latest', () => {
+      renderControls({ sortBy: 'latest' });
+      expect(screen.queryByTitle('Customize popular feed')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('customize dropdown content', () => {
+    it('contains time window buttons (Today, This week, All time)', () => {
+      renderControls();
+      expect(screen.getAllByText('Today').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('This week').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('All time').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('calls onPopularWindowChange when clicking a time window', () => {
+      renderControls();
+      const weekButtons = screen.getAllByText('This week');
+      fireEvent.click(weekButtons[0]);
+      expect(onPopularWindowChange).toHaveBeenCalledWith('7d');
+    });
+
+    it('renders all 8 weight labels', () => {
+      renderControls();
+      const expectedLabels = [
+        'Comments', 'Tip Amount', 'Tip Count', 'Unique Tippers',
+        'Trending Boost', 'Content Quality', 'Reads', 'Activity Rate',
+      ];
+      expectedLabels.forEach((label) => {
+        expect(screen.getAllByText(label).length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('renders low/med/high toggles for each weight', () => {
+      renderControls();
+      expect(screen.getAllByText('low').length).toBeGreaterThanOrEqual(8);
+      expect(screen.getAllByText('med').length).toBeGreaterThanOrEqual(8);
+      expect(screen.getAllByText('high').length).toBeGreaterThanOrEqual(8);
+    });
+
+    it('calls onPopularWeightsChange when clicking a weight value', () => {
+      renderControls();
+      const highButtons = screen.getAllByText('high');
+      fireEvent.click(highButtons[0]);
+      expect(onPopularWeightsChange).toHaveBeenCalledWith({ comments: 'high' });
+    });
+
+    it('does not fire when clicking the already-effective value (med default)', () => {
+      renderControls();
+      const medButtons = screen.getAllByText('med');
+      fireEvent.click(medButtons[0]);
+      expect(onPopularWeightsChange).not.toHaveBeenCalled();
+    });
+
+    it('removes a key when selecting med (reverts to default)', () => {
+      renderControls({ popularWeights: { comments: 'high' } });
+      const medButtons = screen.getAllByText('med');
+      fireEvent.click(medButtons[0]);
+      expect(onPopularWeightsChange).toHaveBeenCalledWith({});
+    });
+  });
+
+  describe('reset button', () => {
+    it('renders Reset when custom weights exist', () => {
+      renderControls({ popularWeights: { comments: 'high' } });
+      const resetButtons = screen.getAllByText('Reset');
+      expect(resetButtons.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders Reset when non-default window is set', () => {
+      renderControls({ popularWindow: '7d' });
+      const resetButtons = screen.getAllByText('Reset');
+      expect(resetButtons.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not render Reset when defaults are active', () => {
+      renderControls({ popularWeights: {}, popularWindow: '24h' });
+      expect(screen.queryByText('Reset')).not.toBeInTheDocument();
+    });
+
+    it('resets both weights and window on click', () => {
+      renderControls({ popularWeights: { comments: 'high' }, popularWindow: '7d' });
+      const resetButtons = screen.getAllByText('Reset');
+      fireEvent.click(resetButtons[0]);
+      expect(onPopularWeightsChange).toHaveBeenCalledWith({});
+      expect(onPopularWindowChange).toHaveBeenCalledWith('24h');
+    });
+  });
+
+  describe('weight change logic edge cases', () => {
+    it('sets a non-default value correctly', () => {
+      renderControls({ popularWeights: {} });
+      const lowButtons = screen.getAllByText('low');
+      fireEvent.click(lowButtons[0]);
+      expect(onPopularWeightsChange).toHaveBeenCalledWith({ comments: 'low' });
+    });
+
+    it('switches from one non-default to another non-default', () => {
+      renderControls({ popularWeights: { comments: 'low' } });
+      const highButtons = screen.getAllByText('high');
+      fireEvent.click(highButtons[0]);
+      expect(onPopularWeightsChange).toHaveBeenCalledWith({ comments: 'high' });
+    });
+
+    it('preserves other weights when changing one', () => {
+      const weights: PopularWeights = { comments: 'high', reads: 'low' };
+      renderControls({ popularWeights: weights });
+      const lowButtons = screen.getAllByText('low');
+      fireEvent.click(lowButtons[0]);
+      expect(onPopularWeightsChange).toHaveBeenCalledWith({ comments: 'low', reads: 'low' });
+    });
+  });
+});

--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -13,7 +13,7 @@ import HeroBannerCarousel from '../../../components/hero-banner/HeroBannerCarous
 import Shell from '../../../components/layout/Shell';
 import RightRail from '../../../components/layout/RightRail';
 import CreatePost, { CreatePostRef } from '../components/CreatePost';
-import SortControls from '../components/SortControls';
+import SortControls, { type PopularWeights } from '../components/SortControls';
 import EmptyState from '../components/EmptyState';
 import PostSkeleton from '../components/PostSkeleton';
 import ReplyToFeedItem from '../components/ReplyToFeedItem';
@@ -117,6 +117,7 @@ const FeedList = ({
   }, [sortBy]);
 
   const [popularWindow, setPopularWindow] = useState<'24h' | '7d' | 'all'>(initialWindow);
+  const [popularWeights, setPopularWeights] = useState<PopularWeights>({});
   const trendingInsertSeed = useRef<number>(Math.floor(Math.random() * 0x100000000));
 
   // Keep popularWindow in sync with URL (e.g., browser back/forward or direct URL edits)
@@ -411,12 +412,13 @@ const FeedList = ({
     refetch: refetchPopular,
   } = useInfiniteQuery({
     enabled: sortBy === 'hot',
-    queryKey: ['popular-posts', { limit: 10, window: popularWindow }],
+    queryKey: ['popular-posts', { limit: 10, window: popularWindow, weights: popularWeights }],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await SuperheroApi.listPopularPosts({
         window: popularWindow,
         page: pageParam as number,
         limit: 10,
+        weights: Object.keys(popularWeights).length > 0 ? popularWeights : undefined,
       });
       return response as PostApiResponse;
     },
@@ -801,10 +803,14 @@ const FeedList = ({
     setPopularWindow(w);
     if (sortBy === 'hot') {
       navigate(`/?sortBy=hot&window=${w}`);
-      // Reset pages for new window
       queryClient.removeQueries({ queryKey: ['popular-posts'], exact: false });
     }
   }, [navigate, sortBy, queryClient]);
+
+  const handlePopularWeightsChange = useCallback((weights: PopularWeights) => {
+    setPopularWeights(weights);
+    queryClient.removeQueries({ queryKey: ['popular-posts'], exact: false });
+  }, [queryClient]);
 
   const handleItemClick = useCallback(
     (idOrSlug: string) => {
@@ -1259,6 +1265,8 @@ const FeedList = ({
             popularWindow={popularWindow}
             onPopularWindowChange={handlePopularWindowChange}
             popularFeedEnabled={popularFeedEnabled}
+            popularWeights={popularWeights}
+            onPopularWeightsChange={handlePopularWeightsChange}
           />
         </div>
         <div className="hidden md:block">
@@ -1268,6 +1276,8 @@ const FeedList = ({
             popularWindow={popularWindow}
             onPopularWindowChange={handlePopularWindowChange}
             popularFeedEnabled={popularFeedEnabled}
+            popularWeights={popularWeights}
+            onPopularWeightsChange={handlePopularWeightsChange}
           />
         </div>
       </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the popular-feed ranking inputs and query caching keys, which can alter what content users see and may increase API/query churn if not handled carefully.
> 
> **Overview**
> Adds **popular feed customization** by letting users adjust the popular time window and per-signal ranking weights (low/med/high) via new desktop dropdown and mobile bottom-sheet controls in `SortControls`.
> 
> Plumbs the selected weights through `FeedList` into the popular posts query (updated `react-query` `queryKey`, cache resets, and `SuperheroApi.listPopularPosts` call), and extends `listPopularPosts` to serialize optional `weights` into query params. Includes new unit tests covering URL construction and the SortControls customization/reset behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be2d83fa77697cbb8bf14fec2fad5fbf87663be5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->