### PR TITLE
fix: open correct existing token

### DIFF
--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -686,7 +686,7 @@ const CreateTokenView = () => {
                           size="md"
                           variant="success"
                           className="w-full"
-                          onClick={() => navigate(`/trends/tokens/${foundToken?.address || alreadyRegisteredAs}`)}
+                          onClick={() => navigate(`/trends/tokens/${foundToken?.name || alreadyRegisteredName}`)}
                         >
                           BUY TOKEN
                         </AeButton>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a one-line client-side navigation change that only affects the route parameter used when opening an already-existing token.
> 
> **Overview**
> When a user enters a token name that is already taken, the **“BUY TOKEN”** button in `CreateTokenView` now navigates to `/trends/tokens/:name` (using `foundToken.name` / `alreadyRegisteredName`) instead of using the token address, ensuring the CTA opens the correct existing token page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18f071f6bf3d703e065e9b702443a965301223b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->