### PR TITLE
fix: submit transaction via deeplink if the original page was closed

### DIFF
--- a/src/context/AeSdkProvider.tsx
+++ b/src/context/AeSdkProvider.tsx
@@ -6,22 +6,17 @@ import { useAtom } from 'jotai';
 import {
   createContext,
   useCallback,
-  useEffect, useMemo, useRef, useState,
+  useEffect, useMemo, useRef, useState, type SetStateAction,
 } from 'react';
 import { activeAccountAtom } from '../atoms/accountAtoms';
-import { transactionsQueueAtom } from '../atoms/txQueueAtoms';
+import { transactionsQueueAtom, type TxQueueEntry } from '../atoms/txQueueAtoms';
 import { walletInfoAtom } from '../atoms/walletAtoms';
 import { CONFIG } from '../config';
 import { useModal } from '../hooks/useModal';
 import { CURRENT_NETWORK } from '../utils/constants';
 import { INetwork } from '../utils/types';
 import { createDeepLinkUrl, openDeepLink } from '../utils/url';
-
-type TxQueueEntry = {
-  status: string;
-  tx: Encoded.Transaction;
-  signUrl: string;
-};
+import { consumeNextTxQueueCallback } from '../utils/txQueueCallback';
 
 export const AeSdkContext = createContext<{
   aeSdk: AeSdkAepp,
@@ -36,7 +31,7 @@ export const AeSdkContext = createContext<{
   getCurrentGeneration: () => void,
   addStaticAccount: (account: string) => void,
   setActiveNetwork: (network: INetwork) => void,
-  setTransactionsQueue: (queue: Record<string, TxQueueEntry>) => void,
+  setTransactionsQueue: (queue: SetStateAction<Record<string, TxQueueEntry>>) => void,
   initSdk: () => void,
   scanForAccounts: () => void,
   nodes: { instance: Node; name: string }[],
@@ -50,17 +45,18 @@ const nodes: { instance: Node; name: string }[] = [
 ];
 
 export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
+  type ContractInitializeOptions = Parameters<typeof Contract.initialize>[0];
   type LegacyInitializableSdk = {
-    getContext: () => Record<string, unknown>;
+    getContext: () => Partial<ContractInitializeOptions>;
     initializeContract?: (
-      options: Record<string, unknown>,
+      options: ContractInitializeOptions,
     ) => ReturnType<typeof Contract.initialize>;
   };
 
   const ensureLegacyInitializeContract = useCallback((sdkInstance: LegacyInitializableSdk) => {
     if (typeof sdkInstance.initializeContract === 'function') return;
     // eslint-disable-next-line no-param-reassign -- intentional patch for legacy SDK
-    sdkInstance.initializeContract = (options: Record<string, unknown>) => Contract.initialize({
+    sdkInstance.initializeContract = (options: ContractInitializeOptions) => Contract.initialize({
       ...sdkInstance.getContext(),
       ...options,
     });
@@ -134,16 +130,32 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
           currentUrl.searchParams.delete('status');
 
           const currentDomain = currentUrl.origin;
+          const returnUrl = currentUrl.href;
+          const callbackState = consumeNextTxQueueCallback();
 
           // append transaction parameter for success case
           // const successUrl = new URL(currentUrl.href);
           const successUrl = new URL(`${currentDomain}/tx-queue/${uniqueId}`);
           successUrl.searchParams.set('transaction', '{transaction}');
           successUrl.searchParams.set('status', 'completed');
+          successUrl.searchParams.set('returnUrl', returnUrl);
+          if (callbackState?.successAction) {
+            successUrl.searchParams.set('successAction', callbackState.successAction);
+          }
+          if (callbackState?.successUrl) {
+            successUrl.searchParams.set('successUrl', callbackState.successUrl);
+          }
+          if (callbackState?.accountAddress) {
+            successUrl.searchParams.set('accountAddress', callbackState.accountAddress);
+          }
+          if (callbackState?.content) {
+            successUrl.searchParams.set('content', callbackState.content);
+          }
 
           // append transaction parameter for failed case
           const cancelUrl = new URL(`${currentDomain}/tx-queue/${uniqueId}`);
           cancelUrl.searchParams.set('status', 'cancelled');
+          cancelUrl.searchParams.set('returnUrl', returnUrl);
 
           const signUrl: any = createDeepLinkUrl({
             type: 'sign-transaction',

--- a/src/features/social/components/PostForm.tsx
+++ b/src/features/social/components/PostForm.tsx
@@ -17,6 +17,7 @@ import { CONFIG } from '../../../config';
 import { useAccount } from '../../../hooks/useAccount';
 import { useAeSdk } from '../../../hooks/useAeSdk';
 import { initializeContractTyped } from '../../../libs/initializeContractTyped';
+import { clearNextTxQueueCallback, setNextTxQueueCallback } from '../../../utils/txQueueCallback';
 import { GifSelectorDialog } from './GifSelectorDialog';
 
 type TippingV3ContractApi = ContractMethodsBase & {
@@ -355,11 +356,12 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
     const trimmed = text.trim();
     if (!trimmed) return;
     if (!activeAccount) return;
+    if (!isPost && !postId) return;
 
     setIsSubmitting(true);
 
     const txPayload = isPost
-      ? { type: TxPayloadType.CreatePost, content: trimmed } as const
+      ? { type: TxPayloadType.CreatePost, content: trimmed, accountAddress: activeAccount } as const
       : { type: TxPayloadType.CreateComment, postId: postId! } as const;
 
     notifySubmitted(txPayload);
@@ -377,6 +379,14 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
         postMedia = [...mediaUrls];
       } else if (postId) {
         postMedia = [`comment:${postId}`, ...mediaUrls];
+      }
+
+      if (isPost) {
+        setNextTxQueueCallback({
+          successAction: 'redirect-post-by-tx',
+          accountAddress: activeAccount,
+          content: trimmed,
+        });
       }
 
       const { decodedResult } = await contract.post_without_tip(
@@ -870,15 +880,19 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
       }
 
       // Reset after success
-      setText(initialText || '');
-      setMediaUrls([]);
+      if (isMountedRef.current) {
+        setText(initialText || '');
+        setMediaUrls([]);
+      }
 
       // Call onPostCreated callback if this is a new post (for tab switching, etc.)
-      if (isPost) {
+      if (isMountedRef.current && isPost) {
         onPostCreated?.(newPostId ?? postId);
       }
 
-      onSuccess?.(newPostId ?? postId);
+      if (isMountedRef.current) {
+        onSuccess?.(newPostId ?? postId);
+      }
       // Also refetch any topic feeds related to this hashtag so other viewers update quickly
       try {
         if (requiredHashtag) {
@@ -891,7 +905,12 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
       // TODO: add sentry capture
       notifyError(error?.message || (isPost ? 'Failed to publish post' : 'Failed to publish reply'));
     } finally {
-      setIsSubmitting(false);
+      if (isPost) {
+        clearNextTxQueueCallback();
+      }
+      if (isMountedRef.current) {
+        setIsSubmitting(false);
+      }
     }
   };
 

--- a/src/features/transaction-notification/TransactionNotificationBanner.tsx
+++ b/src/features/transaction-notification/TransactionNotificationBanner.tsx
@@ -3,7 +3,9 @@ import Spinner from '@/components/Spinner';
 import { Decimal } from '@/libs/decimal';
 import { useAtomValue } from 'jotai';
 import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import SuperheroIcon from '@/svg/favicon.svg?react';
+import { PostsService } from '@/api/generated';
 import type { TxPayload } from './transaction-notification.context';
 import { TxPayloadType, useTransactionNotification } from './transaction-notification.context';
 
@@ -301,15 +303,85 @@ const NotificationConfirmed = ({
   );
 };
 
+const delay = (ms: number, signal?: AbortSignal) => new Promise<void>((resolve) => {
+  if (signal?.aborted) {
+    resolve();
+    return;
+  }
+
+  const timer = window.setTimeout(resolve, ms);
+  signal?.addEventListener('abort', () => {
+    window.clearTimeout(timer);
+    resolve();
+  }, { once: true });
+});
+
+async function findPostPathByTxHash(
+  txHash: string,
+  accountAddress?: string,
+  signal?: AbortSignal,
+  attempt = 0,
+): Promise<string | undefined> {
+  if (attempt >= 20 || signal?.aborted) return undefined;
+
+  try {
+    const request = PostsService.listAll({
+      accountAddress,
+      limit: 20,
+      page: 1,
+      orderBy: 'created_at',
+      orderDirection: 'DESC',
+    });
+    signal?.addEventListener('abort', () => request.cancel(), { once: true });
+
+    const response: any = await request;
+    const post = (Array.isArray(response?.items) ? response.items : [])
+      .find((item: any) => item?.tx_hash === txHash);
+
+    if (post?.id) {
+      return `/post/${encodeURIComponent(String(post.id))}`;
+    }
+  } catch (error: any) {
+    if (signal?.aborted || error?.isCancelled) return undefined;
+    // Backend indexing can lag right after broadcast; keep polling briefly.
+  }
+
+  await delay(3000, signal);
+  return findPostPathByTxHash(txHash, accountAddress, signal, attempt + 1);
+}
+
 // ─── Main banner ─────────────────────────────────────────────────────────────
 
 export const TransactionNotificationBanner = () => {
   const { notificationState, dismissNotification } = useTransactionNotification();
   const activeAccount = useAtomValue(activeAccountAtom);
+  const navigate = useNavigate();
   const [visible, setVisible] = useState(false);
   const bannerRef = useRef<HTMLDivElement>(null);
+  const redirectedTxRef = useRef<string | null>(null);
+  const postRedirectPollTxRef = useRef<string | null>(null);
+  const postRedirectAbortRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
+  const postRedirectGenerationRef = useRef(0);
 
   const isActive = notificationState.status !== 'idle';
+  const postRedirectTxHash = (
+    (notificationState.status === 'pending' || notificationState.status === 'confirmed')
+    && notificationState.payload.type === TxPayloadType.CreatePost
+  ) ? notificationState.txHash : undefined;
+  const postRedirectAccountAddress = (
+    (notificationState.status === 'pending' || notificationState.status === 'confirmed')
+    && notificationState.payload.type === TxPayloadType.CreatePost
+  ) ? notificationState.payload.accountAddress : undefined;
+  const activeNotificationTxHash = (
+    notificationState.status === 'pending' || notificationState.status === 'confirmed'
+  ) ? notificationState.txHash : undefined;
+
+  const abortPostRedirectPoll = () => {
+    postRedirectAbortRef.current?.abort();
+    postRedirectAbortRef.current = null;
+    postRedirectPollTxRef.current = null;
+  };
 
   useEffect(() => {
     if (isActive) {
@@ -318,6 +390,66 @@ export const TransactionNotificationBanner = () => {
       setVisible(false);
     }
   }, [isActive]);
+
+  useEffect(() => () => {
+    isMountedRef.current = false;
+    postRedirectAbortRef.current?.abort();
+  }, []);
+
+  useEffect(() => {
+    if (!postRedirectTxHash) {
+      if (
+        activeNotificationTxHash
+        && activeNotificationTxHash !== postRedirectPollTxRef.current
+      ) {
+        postRedirectGenerationRef.current += 1;
+        abortPostRedirectPoll();
+      }
+      return undefined;
+    }
+    const txHash = postRedirectTxHash;
+    if (redirectedTxRef.current === txHash || postRedirectPollTxRef.current === txHash) {
+      return undefined;
+    }
+
+    const generation = postRedirectGenerationRef.current + 1;
+    postRedirectGenerationRef.current = generation;
+    postRedirectPollTxRef.current = txHash;
+    postRedirectAbortRef.current?.abort();
+    const abortController = new AbortController();
+    postRedirectAbortRef.current = abortController;
+    findPostPathByTxHash(
+      txHash,
+      postRedirectAccountAddress || activeAccount,
+      abortController.signal,
+    ).then((postPath) => {
+      if (postRedirectAbortRef.current === abortController) {
+        postRedirectAbortRef.current = null;
+        postRedirectPollTxRef.current = null;
+      }
+      if (
+        abortController.signal.aborted
+        || !isMountedRef.current
+        || postRedirectGenerationRef.current !== generation
+        || !postPath
+        || redirectedTxRef.current === txHash
+      ) return;
+      redirectedTxRef.current = txHash;
+      navigate(postPath);
+    });
+
+    return () => {
+      if (!isMountedRef.current && postRedirectAbortRef.current === abortController) {
+        abortPostRedirectPoll();
+      }
+    };
+  }, [
+    activeAccount,
+    activeNotificationTxHash,
+    navigate,
+    postRedirectAccountAddress,
+    postRedirectTxHash,
+  ]);
 
   if (!isActive && !visible) return null;
 

--- a/src/features/transaction-notification/transaction-notification.context.tsx
+++ b/src/features/transaction-notification/transaction-notification.context.tsx
@@ -24,7 +24,7 @@ export type TxPayload =
   | { type: typeof TxPayloadType.SellToken; tokenName: string; tokenSymbol: string; tokenAmount: string; estimatedCoin: string; saleAddress?: string }
   | { type: typeof TxPayloadType.ApproveAllowance; tokenName: string; tokenSymbol: string; amount: string; stepNumber: number; totalSteps: number }
   | { type: typeof TxPayloadType.CreateToken; tokenName: string }
-  | { type: typeof TxPayloadType.CreatePost; content: string }
+  | { type: typeof TxPayloadType.CreatePost; content: string; accountAddress?: string }
   | { type: typeof TxPayloadType.CreateComment; postId: string }
   | { type: typeof TxPayloadType.SwapToken; tokenInSymbol: string; tokenOutSymbol: string; amountIn: string; amountOut: string }
   | { type: typeof TxPayloadType.WrapToken; amount: string }
@@ -38,7 +38,7 @@ export type NotificationState =
   | { status: 'idle' }
   | { status: 'submitted'; payload: TxPayload }
   | { status: 'pending'; payload: TxPayload; txHash: string }
-  | { status: 'confirmed'; payload: TxPayload }
+  | { status: 'confirmed'; payload: TxPayload; txHash?: string }
   | { status: 'error'; message: string };
 
 type TransactionNotificationContextValue = {
@@ -143,7 +143,7 @@ export const TransactionNotificationProvider: React.FC<{
         if (gen !== pollGeneration.current) return;
         if (mined) {
           clearPollInterval();
-          setNotificationState({ status: 'confirmed', payload });
+          setNotificationState({ status: 'confirmed', payload, txHash });
           scheduleAutoDismiss(payload, AUTO_DISMISS_MS);
         }
       };

--- a/src/utils/txQueueCallback.ts
+++ b/src/utils/txQueueCallback.ts
@@ -1,0 +1,40 @@
+const TX_QUEUE_CALLBACK_KEY = 'txQueue:nextCallback';
+const TX_QUEUE_CALLBACK_TTL_MS = 5 * 60 * 1000;
+const ALLOWED_SUCCESS_ACTIONS = new Set(['redirect-post-by-tx']);
+export type TxQueueCallbackState = {
+  successAction?: string;
+  successUrl?: string;
+  accountAddress?: string;
+  content?: string;
+};
+type StoredTxQueueCallbackState = TxQueueCallbackState & {
+  createdAt: number;
+};
+export function setNextTxQueueCallback(state: TxQueueCallbackState) {
+  sessionStorage.setItem(TX_QUEUE_CALLBACK_KEY, JSON.stringify({
+    ...state,
+    createdAt: Date.now(),
+  }));
+}
+export function clearNextTxQueueCallback() {
+  sessionStorage.removeItem(TX_QUEUE_CALLBACK_KEY);
+}
+export function consumeNextTxQueueCallback(): TxQueueCallbackState | null {
+  try {
+    const raw = sessionStorage.getItem(TX_QUEUE_CALLBACK_KEY);
+    const parsed = raw ? JSON.parse(raw) as StoredTxQueueCallbackState : null;
+    if (!parsed) return null;
+    if (Date.now() - parsed.createdAt > TX_QUEUE_CALLBACK_TTL_MS) return null;
+    if (parsed.successAction && !ALLOWED_SUCCESS_ACTIONS.has(parsed.successAction)) return null;
+    const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      createdAt: _createdAt,
+      ...state
+    } = parsed;
+    return state;
+  } catch {
+    return null;
+  } finally {
+    clearNextTxQueueCallback();
+  }
+}

--- a/src/views/TxQueue.tsx
+++ b/src/views/TxQueue.tsx
@@ -1,61 +1,183 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { useAtom } from 'jotai';
+import { buildTxHash } from '@aeternity/aepp-sdk';
 import { transactionsQueueAtom } from '../atoms/txQueueAtoms';
+import { useAeSdk } from '../hooks/useAeSdk';
+import { TxPayloadType, useTransactionNotification } from '../features/transaction-notification';
+
+const getSafeReturnPath = (returnUrl: unknown) => {
+  if (typeof returnUrl !== 'string' || !returnUrl.trim()) return '/';
+
+  try {
+    const url = new URL(returnUrl, window.location.origin);
+    if (url.origin !== window.location.origin) return '/';
+    return `${url.pathname}${url.search}${url.hash}` || '/';
+  } catch {
+    return '/';
+  }
+};
+
+const getSuccessReturnPath = (query: Record<string, string>) => {
+  if (query.successUrl) return getSafeReturnPath(query.successUrl);
+
+  return getSafeReturnPath(query.returnUrl);
+};
+
+const isAlreadySubmittedError = (message: string) => (
+  /already|known|exists|mempool|tx already/i.test(message)
+);
+
+const broadcastInFlight = new Map<string, Promise<void>>();
 
 const TxQueue = () => {
   const { t } = useTranslation('transactions');
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
+  const navigate = useNavigate();
+  const { sdkInitialized, staticAeSdk } = useAeSdk();
+  const { notifyPendingTx } = useTransactionNotification();
   const [, setTransactionsQueue] = useAtom(transactionsQueueAtom);
+  const [error, setError] = useState<string | null>(null);
+
+  const query = useMemo(
+    () => Object.fromEntries(new URLSearchParams(location.search).entries()),
+    [location.search],
+  );
+
+  const signedTx = useMemo(() => {
+    const normalizeSignedTx = (value: unknown): string | undefined => {
+      if (typeof value !== 'string') return undefined;
+      const trimmed = value.trim().replace(/\s/g, '+');
+      if (!trimmed || trimmed === '{transaction}' || trimmed === 'undefined' || trimmed === 'null') {
+        return undefined;
+      }
+      return trimmed.startsWith('tx_') ? trimmed : undefined;
+    };
+
+    return normalizeSignedTx(
+      (query as any).transaction
+      ?? (query as any).signedTransaction
+      ?? (query as any).signed_tx
+      ?? (query as any).tx,
+    );
+  }, [query]);
+
+  const status = useMemo(
+    () => String((query as any).status || '').toLowerCase(),
+    [query],
+  );
 
   useEffect(() => {
+    if (!id) return;
+
+    // Update the transactions queue for the original tab/popup flow.
+    setTransactionsQueue((prevQueue) => ({
+      ...prevQueue,
+      [id]: {
+        ...prevQueue[id], // Keep existing data
+        ...query, // Merge in new query data
+        ...(signedTx ? { transaction: signedTx } : {}),
+        ...(status === 'completed' && !signedTx ? { status: 'cancelled' } : {}),
+      } as any, // Using any here because query can contain various properties
+    }));
+  }, [id, query, signedTx, status, setTransactionsQueue]);
+
+  useEffect(() => {
+    if (!id) return undefined;
+
     let timer: number | undefined;
-    if (id) {
-      // Parse query parameters
-      const query = Object.fromEntries(new URLSearchParams(location.search).entries());
-      const normalizeSignedTx = (value: unknown): string | undefined => {
-        if (typeof value !== 'string') return undefined;
-        const trimmed = value.trim();
-        if (!trimmed || trimmed === '{transaction}' || trimmed === 'undefined' || trimmed === 'null') {
-          return undefined;
-        }
-        return trimmed.startsWith('tx_') ? trimmed : undefined;
-      };
-      const signedTx = normalizeSignedTx(
-        (query as any).transaction
-        ?? (query as any).signedTransaction
-        ?? (query as any).signed_tx
-        ?? (query as any).tx,
-      );
-      const status = String((query as any).status || '').toLowerCase();
-
-      // Update the transactions queue
-      setTransactionsQueue((prevQueue) => ({
-        ...prevQueue,
-        [id]: {
-          ...prevQueue[id], // Keep existing data
-          ...query, // Merge in new query data
-          ...(signedTx ? { transaction: signedTx } : {}),
-          ...(status === 'completed' && !signedTx ? { status: 'cancelled' } : {}),
-        } as any, // Using any here because query can contain various properties
-      }));
-
-      // Close current tab after a short delay
-      timer = window.setTimeout(() => {
+    let cancelled = false;
+    const hasOpener = Boolean(window.opener);
+    const leaveQueue = (targetPath = getSuccessReturnPath(query)) => {
+      if (hasOpener) {
         window.close();
-      }, 200);
+        return;
+      }
+
+      navigate(targetPath, { replace: true });
+    };
+
+    const shouldBroadcastSignedTx = status === 'completed' && signedTx && !hasOpener;
+
+    if (!shouldBroadcastSignedTx) {
+      timer = window.setTimeout(leaveQueue, 200);
+      return () => {
+        if (timer) window.clearTimeout(timer);
+      };
     }
 
+    if (!sdkInitialized || !staticAeSdk) return undefined;
+
+    const broadcastSignedTx = async () => {
+      const storageKey = `txQueue:broadcasted:${signedTx}`;
+      const txHash = sessionStorage.getItem(storageKey) || buildTxHash(signedTx as any);
+      const continueAfterBroadcast = () => {
+        if (query.successAction === 'redirect-post-by-tx') {
+          notifyPendingTx(
+            {
+              type: TxPayloadType.CreatePost,
+              content: query.content || '',
+              accountAddress: query.accountAddress,
+            },
+            txHash,
+          );
+          timer = window.setTimeout(() => leaveQueue('/'), 500);
+        } else {
+          timer = window.setTimeout(() => leaveQueue(getSuccessReturnPath(query)), 500);
+        }
+      };
+
+      try {
+        if (!sessionStorage.getItem(storageKey)) {
+          let broadcastPromise = broadcastInFlight.get(signedTx);
+          if (!broadcastPromise) {
+            broadcastPromise = staticAeSdk.api.postTransaction({ tx: signedTx })
+              .then(() => {
+                sessionStorage.setItem(storageKey, txHash);
+              })
+              .finally(() => {
+                broadcastInFlight.delete(signedTx);
+              });
+            broadcastInFlight.set(signedTx, broadcastPromise);
+          }
+          await broadcastPromise;
+        }
+
+        if (!cancelled) {
+          continueAfterBroadcast();
+        }
+      } catch (err: any) {
+        const message = String(err?.message || err?.body?.reason || '');
+        if (isAlreadySubmittedError(message)) {
+          sessionStorage.setItem(storageKey, txHash);
+          if (!cancelled) {
+            continueAfterBroadcast();
+          }
+          return;
+        }
+
+        sessionStorage.removeItem(storageKey);
+        if (!cancelled) {
+          setError(message || 'Failed to submit transaction');
+        }
+      }
+    };
+
+    broadcastSignedTx();
+
     return () => {
+      cancelled = true;
       if (timer) window.clearTimeout(timer);
     };
-  }, [id, location.search, setTransactionsQueue]);
+  }, [id, navigate, notifyPendingTx, query, sdkInitialized, signedTx, staticAeSdk, status]);
 
   return (
     <div className="h-screen w-screen flex items-center justify-center">
-      <div className="text-white/80 text-lg">{t('processingTransaction')}</div>
+      <div className="text-white/80 text-lg">
+        {error || t('processingTransaction')}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes transaction broadcast/redirect flow and adds client-side persistence via `sessionStorage`; failures could strand users on `TxQueue` or cause duplicate/failed broadcasts if edge cases aren’t covered.
> 
> **Overview**
> Fixes deeplink signing flows when the original popup/tab is gone by **broadcasting the returned signed transaction from `TxQueue`** (if there’s no `window.opener`) via `staticAeSdk.api.postTransaction`, deduping via in-memory + `sessionStorage`, and safely navigating back using a same-origin `returnUrl`/`successUrl`.
> 
> Adds a small `sessionStorage`-backed *“next tx-queue callback”* (`txQueueCallback.ts`) that `AeSdkProvider` consumes to append extra success metadata (e.g. `successAction`, `accountAddress`, `content`) into the deeplink `x-success` URL; `PostForm` sets this for post creation and clears it afterwards.
> 
> Enhances transaction notifications to retain `txHash` on `confirmed`, attach `accountAddress` to `CreatePost` payloads, and **auto-redirect to the created post** by polling `PostsService.listAll` for the matching `tx_hash` once the tx is pending/confirmed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd88a7e691814924795ca18aaeac92b21b9fc006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->