### PR TITLE
fix: be able to operate on Android

### DIFF
--- a/src/atoms/txQueueAtoms.ts
+++ b/src/atoms/txQueueAtoms.ts
@@ -8,6 +8,10 @@ export type TxQueueEntry = {
   transaction?: Encoded.Transaction;
 };
 
+export const TX_QUEUE_ACK_CHANNEL = 'txQueue:ack';
+export const TX_QUEUE_RESULT_PREFIX = 'txQueue:result:';
+export const TX_QUEUE_RESULT_TTL_MS = 5 * 60 * 1000;
+
 // atomWithBroadcast implementation for cross-tab communication
 function atomWithBroadcast<Value>(key: string, initialValue: Value) {
   const baseAtom = atom(initialValue);

--- a/src/context/AeSdkProvider.tsx
+++ b/src/context/AeSdkProvider.tsx
@@ -9,11 +9,16 @@ import {
   useEffect, useMemo, useRef, useState,
 } from 'react';
 import { activeAccountAtom } from '../atoms/accountAtoms';
-import { transactionsQueueAtom } from '../atoms/txQueueAtoms';
+import {
+  TX_QUEUE_ACK_CHANNEL,
+  TX_QUEUE_RESULT_PREFIX,
+  TX_QUEUE_RESULT_TTL_MS,
+  transactionsQueueAtom,
+} from '../atoms/txQueueAtoms';
 import { walletInfoAtom } from '../atoms/walletAtoms';
 import { CONFIG } from '../config';
 import { useModal } from '../hooks/useModal';
-import { CURRENT_NETWORK } from '../utils/constants';
+import { CURRENT_NETWORK, IS_MOBILE } from '../utils/constants';
 import { INetwork } from '../utils/types';
 import { createDeepLinkUrl, openDeepLink } from '../utils/url';
 
@@ -50,17 +55,18 @@ const nodes: { instance: Node; name: string }[] = [
 ];
 
 export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
+  type ContractInitializeOptions = Parameters<typeof Contract.initialize>[0];
   type LegacyInitializableSdk = {
-    getContext: () => Record<string, unknown>;
+    getContext: () => Partial<ContractInitializeOptions>;
     initializeContract?: (
-      options: Record<string, unknown>,
+      options: ContractInitializeOptions,
     ) => ReturnType<typeof Contract.initialize>;
   };
 
   const ensureLegacyInitializeContract = useCallback((sdkInstance: LegacyInitializableSdk) => {
     if (typeof sdkInstance.initializeContract === 'function') return;
     // eslint-disable-next-line no-param-reassign -- intentional patch for legacy SDK
-    sdkInstance.initializeContract = (options: Record<string, unknown>) => Contract.initialize({
+    sdkInstance.initializeContract = (options: ContractInitializeOptions) => Contract.initialize({
       ...sdkInstance.getContext(),
       ...options,
     });
@@ -167,6 +173,9 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
 
           return new Promise((resolve, reject) => {
             let newWindow: Window | null = null;
+            const ackChannel = typeof BroadcastChannel !== 'undefined'
+              ? new BroadcastChannel(TX_QUEUE_ACK_CHANNEL)
+              : null;
             const windowFeatures = [
               'name=Superhero Wallet',
               'width=362',
@@ -181,6 +190,38 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
             let timeout: NodeJS.Timeout | null = null;
             let isCleanedUp = false;
             let unloadHandler: (() => void) | null = null;
+            const storedResultKey = `${TX_QUEUE_RESULT_PREFIX}${uniqueId}`;
+
+            const removeStoredResult = () => {
+              try {
+                localStorage.removeItem(storedResultKey);
+              } catch {
+                // Ignore unavailable storage; the in-memory broadcast path still applies.
+              }
+            };
+
+            const readStoredResult = () => {
+              try {
+                const storedResult = localStorage.getItem(storedResultKey);
+                const parsedStoredResult = storedResult ? JSON.parse(storedResult) : null;
+                const createdAt = Number(parsedStoredResult?.createdAt || 0);
+                const expiresAt = Number(parsedStoredResult?.expiresAt || 0);
+                const isExpired = parsedStoredResult && (
+                  (expiresAt && Date.now() > expiresAt)
+                  || (!expiresAt && (!createdAt || Date.now() - createdAt > TX_QUEUE_RESULT_TTL_MS))
+                );
+
+                if (isExpired) {
+                  removeStoredResult();
+                  return null;
+                }
+
+                return parsedStoredResult;
+              } catch {
+                removeStoredResult();
+                return null;
+              }
+            };
 
             // Cleanup function to prevent memory leaks
             const cleanup = () => {
@@ -203,6 +244,7 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
                 newWindow.close();
                 newWindow = null;
               }
+              ackChannel?.close();
             };
 
             openModal({
@@ -243,12 +285,13 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
             // Set a timeout to prevent infinite polling (5 minutes max)
             const MAX_POLL_TIME = 5 * 60 * 1000; // 5 minutes
             timeout = setTimeout(() => {
+              removeStoredResult();
               cleanup();
               reject(new Error('Transaction polling timeout'));
             }, MAX_POLL_TIME);
 
             // Handle page unload to cleanup interval
-            if (typeof window !== 'undefined') {
+            if (typeof window !== 'undefined' && !IS_MOBILE) {
               unloadHandler = () => {
                 cleanup();
               };
@@ -257,8 +300,18 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
 
             interval = setInterval(() => {
               const currentQueue = transactionsQueueRef.current;
-              if (Object.keys(currentQueue).includes(uniqueId)) {
-                if (currentQueue[uniqueId]?.status === 'cancelled') {
+              const parsedStoredResult = readStoredResult();
+              const isTerminalStoredResult = ['cancelled', 'completed'].includes(
+                parsedStoredResult?.status,
+              );
+              const queueEntry = isTerminalStoredResult
+                ? parsedStoredResult
+                : currentQueue[uniqueId];
+
+              if (queueEntry) {
+                if (queueEntry.status === 'cancelled') {
+                  ackChannel?.postMessage({ id: uniqueId, status: 'cancelled' });
+                  removeStoredResult();
                   cleanup();
                   reject(new Error('Transaction cancelled'));
                   // delete transaction from queue
@@ -269,10 +322,11 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
                 }
 
                 if (
-                  currentQueue[uniqueId]?.status === 'completed'
+                  queueEntry.status === 'completed'
                 ) {
-                  const signedTx = currentQueue[uniqueId]?.transaction;
+                  const signedTx = queueEntry.transaction;
                   if (!signedTx || typeof signedTx !== 'string' || !signedTx.startsWith('tx_')) {
+                    removeStoredResult();
                     cleanup();
                     // delete transaction from queue
                     const newQueue = { ...currentQueue };
@@ -281,8 +335,10 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
                     reject(new Error('Wallet did not return a signed transaction'));
                     return;
                   }
+                  ackChannel?.postMessage({ id: uniqueId, status: 'completed' });
+                  removeStoredResult();
                   cleanup();
-                  resolve(signedTx);
+                  resolve(signedTx as Encoded.Transaction);
                   // delete transaction from queue
                   const newQueue = { ...currentQueue };
                   delete newQueue[uniqueId];

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,9 +2,7 @@ import { COMMON_CONFIG } from '../config';
 import { IS_MOBILE } from './constants';
 
 export function createDeepLinkUrl({ type, callbackUrl, ...params }: Record<string, string>) {
-  const isIosMobileBrowser = /iPad|iPhone|iPod/.test(window.navigator.userAgent)
-    && window.navigator.userAgent.includes('Mobi');
-  const baseUrl = isIosMobileBrowser ? 'superhero://' : `${COMMON_CONFIG.WALLET_URL}/`;
+  const baseUrl = IS_MOBILE ? 'superhero://' : `${COMMON_CONFIG.WALLET_URL}/`;
   const url = new URL(type, baseUrl);
   if (callbackUrl) {
     url.searchParams.set('x-success', callbackUrl);

--- a/src/views/TxQueue.tsx
+++ b/src/views/TxQueue.tsx
@@ -1,35 +1,83 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { useAtom } from 'jotai';
-import { transactionsQueueAtom } from '../atoms/txQueueAtoms';
+import {
+  TX_QUEUE_ACK_CHANNEL,
+  TX_QUEUE_RESULT_PREFIX,
+  TX_QUEUE_RESULT_TTL_MS,
+  transactionsQueueAtom,
+} from '../atoms/txQueueAtoms';
+
+const RELAY_ACK_TIMEOUT_MS = 1500;
+
+const getSafeReturnPath = (returnUrl: unknown) => {
+  if (typeof returnUrl !== 'string' || !returnUrl.trim()) return '/';
+
+  try {
+    const url = new URL(returnUrl, window.location.origin);
+    if (url.origin !== window.location.origin) return '/';
+    return `${url.pathname}${url.search}${url.hash}` || '/';
+  } catch {
+    return '/';
+  }
+};
+
+const normalizeSignedTx = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim().replace(/\s/g, '+');
+  if (!trimmed || trimmed === '{transaction}' || trimmed === 'undefined' || trimmed === 'null') {
+    return undefined;
+  }
+  return trimmed.startsWith('tx_') ? trimmed : undefined;
+};
 
 const TxQueue = () => {
   const { t } = useTranslation('transactions');
   const { id } = useParams<{ id: string }>();
   const location = useLocation();
+  const navigate = useNavigate();
   const [, setTransactionsQueue] = useAtom(transactionsQueueAtom);
+
+  const query = useMemo(
+    () => Object.fromEntries(new URLSearchParams(location.search).entries()),
+    [location.search],
+  );
+
+  const signedTx = useMemo(() => normalizeSignedTx(
+    (query as any).transaction
+    ?? (query as any).signedTransaction
+    ?? (query as any).signed_tx
+    ?? (query as any).tx,
+  ), [query]);
+
+  const status = useMemo(
+    () => String((query as any).status || '').toLowerCase(),
+    [query],
+  );
 
   useEffect(() => {
     let timer: number | undefined;
+    let ackChannel: BroadcastChannel | null = null;
+    let acked = false;
+
     if (id) {
-      // Parse query parameters
-      const query = Object.fromEntries(new URLSearchParams(location.search).entries());
-      const normalizeSignedTx = (value: unknown): string | undefined => {
-        if (typeof value !== 'string') return undefined;
-        const trimmed = value.trim();
-        if (!trimmed || trimmed === '{transaction}' || trimmed === 'undefined' || trimmed === 'null') {
-          return undefined;
+      const leaveQueue = (targetPath = getSafeReturnPath((query as any).returnUrl)) => {
+        window.close();
+        if (!window.closed) {
+          navigate(targetPath, { replace: true });
         }
-        return trimmed.startsWith('tx_') ? trimmed : undefined;
       };
-      const signedTx = normalizeSignedTx(
-        (query as any).transaction
-        ?? (query as any).signedTransaction
-        ?? (query as any).signed_tx
-        ?? (query as any).tx,
-      );
-      const status = String((query as any).status || '').toLowerCase();
+
+      if (typeof BroadcastChannel !== 'undefined') {
+        ackChannel = new BroadcastChannel(TX_QUEUE_ACK_CHANNEL);
+        ackChannel.onmessage = (event) => {
+          if (event.data?.id !== id) return;
+          acked = true;
+          if (timer) window.clearTimeout(timer);
+          leaveQueue();
+        };
+      }
 
       // Update the transactions queue
       setTransactionsQueue((prevQueue) => ({
@@ -41,21 +89,47 @@ const TxQueue = () => {
           ...(status === 'completed' && !signedTx ? { status: 'cancelled' } : {}),
         } as any, // Using any here because query can contain various properties
       }));
+      try {
+        localStorage.setItem(
+          `${TX_QUEUE_RESULT_PREFIX}${id}`,
+          JSON.stringify({
+            ...query,
+            createdAt: Date.now(),
+            expiresAt: Date.now() + TX_QUEUE_RESULT_TTL_MS,
+            ...(signedTx ? { transaction: signedTx } : {}),
+            ...(status === 'completed' && !signedTx ? { status: 'cancelled' } : {}),
+          }),
+        );
+      } catch {
+        // The broadcast atom path still covers browsers where storage is unavailable.
+      }
 
-      // Close current tab after a short delay
+      // Android Chrome may open the callback in a temporary tab while the original
+      // app tab is still alive. Give that tab a moment to acknowledge the relay
+      // before closing or navigating away.
       timer = window.setTimeout(() => {
-        window.close();
-      }, 200);
+        if (!acked) leaveQueue();
+      }, RELAY_ACK_TIMEOUT_MS);
     }
 
     return () => {
       if (timer) window.clearTimeout(timer);
+      ackChannel?.close();
     };
-  }, [id, location.search, setTransactionsQueue]);
+  }, [
+    id,
+    navigate,
+    query,
+    signedTx,
+    status,
+    setTransactionsQueue,
+  ]);
 
   return (
     <div className="h-screen w-screen flex items-center justify-center">
-      <div className="text-white/80 text-lg">{t('processingTransaction')}</div>
+      <div className="text-white/80 text-lg">
+        {t('processingTransaction')}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the transaction signing callback/queue flow using `BroadcastChannel` and `localStorage` to reliably propagate results across tabs, which can affect a critical transaction-signing path. Risk is mitigated by TTL-based cleanup and fallback behavior, but regressions could leave transactions stuck or mis-reported on edge browsers.
> 
> **Overview**
> Improves the transaction signing callback flow (notably on Android) by adding an explicit `BroadcastChannel` ACK handshake plus a short delay before closing/navigating away, so the originating tab can reliably receive the result.
> 
> Persists terminal tx-queue outcomes in `localStorage` with a TTL (`TX_QUEUE_RESULT_*`) and updates polling in `AeSdkProvider` to prefer stored terminal results, clean them up, and avoid `beforeunload` handling on mobile. Deep-link URL generation is also simplified to use the global `IS_MOBILE` check for selecting the `superhero://` scheme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7db80189bff9565564663dd1ce29d33295b47306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->