### PR TITLE
Release

### DIFF
--- a/src/atoms/txQueueAtoms.ts
+++ b/src/atoms/txQueueAtoms.ts
@@ -10,7 +10,6 @@ export type TxQueueEntry = {
 
 export const TX_QUEUE_ACK_CHANNEL = 'txQueue:ack';
 export const TX_QUEUE_RESULT_PREFIX = 'txQueue:result:';
-export const TX_QUEUE_RESULT_TTL_MS = 5 * 60 * 1000;
 
 // atomWithBroadcast implementation for cross-tab communication
 function atomWithBroadcast<Value>(key: string, initialValue: Value) {

--- a/src/context/AeSdkProvider.tsx
+++ b/src/context/AeSdkProvider.tsx
@@ -12,7 +12,6 @@ import { activeAccountAtom } from '../atoms/accountAtoms';
 import {
   TX_QUEUE_ACK_CHANNEL,
   TX_QUEUE_RESULT_PREFIX,
-  TX_QUEUE_RESULT_TTL_MS,
   transactionsQueueAtom,
 } from '../atoms/txQueueAtoms';
 import { walletInfoAtom } from '../atoms/walletAtoms';
@@ -192,37 +191,6 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
             let unloadHandler: (() => void) | null = null;
             const storedResultKey = `${TX_QUEUE_RESULT_PREFIX}${uniqueId}`;
 
-            const removeStoredResult = () => {
-              try {
-                localStorage.removeItem(storedResultKey);
-              } catch {
-                // Ignore unavailable storage; the in-memory broadcast path still applies.
-              }
-            };
-
-            const readStoredResult = () => {
-              try {
-                const storedResult = localStorage.getItem(storedResultKey);
-                const parsedStoredResult = storedResult ? JSON.parse(storedResult) : null;
-                const createdAt = Number(parsedStoredResult?.createdAt || 0);
-                const expiresAt = Number(parsedStoredResult?.expiresAt || 0);
-                const isExpired = parsedStoredResult && (
-                  (expiresAt && Date.now() > expiresAt)
-                  || (!expiresAt && (!createdAt || Date.now() - createdAt > TX_QUEUE_RESULT_TTL_MS))
-                );
-
-                if (isExpired) {
-                  removeStoredResult();
-                  return null;
-                }
-
-                return parsedStoredResult;
-              } catch {
-                removeStoredResult();
-                return null;
-              }
-            };
-
             // Cleanup function to prevent memory leaks
             const cleanup = () => {
               if (isCleanedUp) return;
@@ -285,7 +253,7 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
             // Set a timeout to prevent infinite polling (5 minutes max)
             const MAX_POLL_TIME = 5 * 60 * 1000; // 5 minutes
             timeout = setTimeout(() => {
-              removeStoredResult();
+              localStorage.removeItem(storedResultKey);
               cleanup();
               reject(new Error('Transaction polling timeout'));
             }, MAX_POLL_TIME);
@@ -300,18 +268,19 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
 
             interval = setInterval(() => {
               const currentQueue = transactionsQueueRef.current;
-              const parsedStoredResult = readStoredResult();
-              const isTerminalStoredResult = ['cancelled', 'completed'].includes(
-                parsedStoredResult?.status,
-              );
-              const queueEntry = isTerminalStoredResult
-                ? parsedStoredResult
-                : currentQueue[uniqueId];
+              const storedResult = localStorage.getItem(storedResultKey);
+              let parsedStoredResult: any = null;
+              try {
+                parsedStoredResult = storedResult ? JSON.parse(storedResult) : null;
+              } catch {
+                localStorage.removeItem(storedResultKey);
+              }
+              const queueEntry = currentQueue[uniqueId] || parsedStoredResult;
 
               if (queueEntry) {
                 if (queueEntry.status === 'cancelled') {
                   ackChannel?.postMessage({ id: uniqueId, status: 'cancelled' });
-                  removeStoredResult();
+                  localStorage.removeItem(storedResultKey);
                   cleanup();
                   reject(new Error('Transaction cancelled'));
                   // delete transaction from queue
@@ -326,7 +295,7 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
                 ) {
                   const signedTx = queueEntry.transaction;
                   if (!signedTx || typeof signedTx !== 'string' || !signedTx.startsWith('tx_')) {
-                    removeStoredResult();
+                    localStorage.removeItem(storedResultKey);
                     cleanup();
                     // delete transaction from queue
                     const newQueue = { ...currentQueue };
@@ -336,7 +305,7 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
                     return;
                   }
                   ackChannel?.postMessage({ id: uniqueId, status: 'completed' });
-                  removeStoredResult();
+                  localStorage.removeItem(storedResultKey);
                   cleanup();
                   resolve(signedTx as Encoded.Transaction);
                   // delete transaction from queue

--- a/src/views/TxQueue.tsx
+++ b/src/views/TxQueue.tsx
@@ -5,7 +5,6 @@ import { useAtom } from 'jotai';
 import {
   TX_QUEUE_ACK_CHANNEL,
   TX_QUEUE_RESULT_PREFIX,
-  TX_QUEUE_RESULT_TTL_MS,
   transactionsQueueAtom,
 } from '../atoms/txQueueAtoms';
 
@@ -89,20 +88,14 @@ const TxQueue = () => {
           ...(status === 'completed' && !signedTx ? { status: 'cancelled' } : {}),
         } as any, // Using any here because query can contain various properties
       }));
-      try {
-        localStorage.setItem(
-          `${TX_QUEUE_RESULT_PREFIX}${id}`,
-          JSON.stringify({
-            ...query,
-            createdAt: Date.now(),
-            expiresAt: Date.now() + TX_QUEUE_RESULT_TTL_MS,
-            ...(signedTx ? { transaction: signedTx } : {}),
-            ...(status === 'completed' && !signedTx ? { status: 'cancelled' } : {}),
-          }),
-        );
-      } catch {
-        // The broadcast atom path still covers browsers where storage is unavailable.
-      }
+      localStorage.setItem(
+        `${TX_QUEUE_RESULT_PREFIX}${id}`,
+        JSON.stringify({
+          ...query,
+          ...(signedTx ? { transaction: signedTx } : {}),
+          ...(status === 'completed' && !signedTx ? { status: 'cancelled' } : {}),
+        }),
+      );
 
       // Android Chrome may open the callback in a temporary tab while the original
       // app tab is still alive. Give that tab a moment to acknowledge the relay


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how signed transaction results are persisted/polled via `localStorage`, removing expiry/guardrails and some error handling; this could leave stale entries or throw in restricted storage environments, affecting transaction completion flow.
> 
> **Overview**
> Simplifies the tx-queue cross-tab result relay by removing `TX_QUEUE_RESULT_TTL_MS` and all created/expiry metadata for stored results.
> 
> `TxQueue` now always writes the callback result to `localStorage` without a try/catch, and `AeSdkProvider` polling logic no longer performs TTL/expiry checks— it just parses the stored JSON (clearing it on parse failure) and uses it as a fallback when the in-memory queue entry is missing, removing the result on completion/cancel/timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed501de377e87921a3e2774b10f32adf8db98191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->