### PR TITLE
Release

### DIFF
--- a/src/@components/Address/AddressAvatarWithChainName.tsx
+++ b/src/@components/Address/AddressAvatarWithChainName.tsx
@@ -45,10 +45,14 @@ export const AddressAvatarWithChainName = memo(({
   variant = 'default',
 }: AddressAvatarWithChainNameProps) => {
   const navigate = useNavigate();
+  const resolvedShowBalanceInHover = showBalanceInHover ?? (variant === 'feed' ? showBalance : true);
 
   // Hooks must be called unconditionally before any early returns
   // Use empty string as fallback to ensure hooks are always called with a valid value
-  const { decimalBalance, aex9Balances, loadAccountData } = useAccountBalances(address || '');
+  const { decimalBalance, aex9Balances, loadAccountData } = useAccountBalances(
+    address || '',
+    { enabled: showBalance },
+  );
   const { chainName } = useChainName(address || '');
   const { data: cachedProfile } = useQuery({
     queryKey: ['SuperheroApi.getProfile', address || ''],
@@ -101,10 +105,13 @@ export const AddressAvatarWithChainName = memo(({
   // Start loading data immediately when hover starts (not when card becomes visible)
   // This way data is loading/loaded by the time the 300ms delay expires
   useEffect(() => {
-    if (address && (showBalance || hover)) {
+    if (
+      address
+      && (showBalance || (hover && isHoverEnabled && resolvedShowBalanceInHover))
+    ) {
       loadAccountDataRef.current();
     }
-  }, [address, showBalance, hover]);
+  }, [address, isHoverEnabled, resolvedShowBalanceInHover, showBalance, hover]);
 
   // Handle click outside to close card
   useEffect(() => {
@@ -123,8 +130,6 @@ export const AddressAvatarWithChainName = memo(({
     e.stopPropagation();
     navigate(`/users/${address}`);
   };
-
-  const resolvedShowBalanceInHover = showBalanceInHover ?? (variant === 'feed' ? showBalance : true);
 
   // Guard against undefined/null address after hooks are called
   if (!address) {

--- a/src/features/trending/__tests__/leaderboard-api.test.ts
+++ b/src/features/trending/__tests__/leaderboard-api.test.ts
@@ -1,5 +1,5 @@
 import {
-  describe, expect, it, vi,
+  beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import { fetchLeaderboard } from '../api/leaderboard';
 import { SuperheroApi } from '../../../api/backend';
@@ -11,6 +11,10 @@ vi.mock('../../../api/backend', () => ({
 }));
 
 describe('leaderboard API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('builds correct query params and normalizes meta', async () => {
     const fetchJsonMock = SuperheroApi.fetchJson as any;
 
@@ -52,6 +56,50 @@ describe('leaderboard API', () => {
         totalPages: 4,
         currentPage: 2,
       },
+    });
+  });
+
+  it('uses recent time filter params for live leaderboard windows', async () => {
+    const fetchJsonMock = SuperheroApi.fetchJson as any;
+
+    fetchJsonMock.mockResolvedValueOnce({
+      items: [{ address: 'ak_live', volume_usd: 800 }],
+      meta: {
+        page: 1,
+        totalItems: 1,
+        totalPages: 1,
+        timeFilter: {
+          value: 30,
+          unit: 'minutes',
+          start: '2026-04-28T20:07:00.000Z',
+          end: '2026-04-28T20:37:00.000Z',
+        },
+      },
+    });
+
+    const result = await fetchLeaderboard({
+      timeframe: '30m',
+      metric: 'pnl',
+      page: 1,
+      limit: 50,
+    });
+
+    expect(fetchJsonMock).toHaveBeenCalledTimes(1);
+    const calledPath = fetchJsonMock.mock.calls[0][0] as string;
+    const url = new URL(`https://example.com${calledPath}`);
+
+    expect(url.searchParams.get('timePeriod')).toBe('30');
+    expect(url.searchParams.get('timeUnit')).toBe('minutes');
+    expect(url.searchParams.get('sortBy')).toBe('pnl');
+    expect(url.searchParams.get('sortDir')).toBe('DESC');
+    expect(url.searchParams.get('limit')).toBe('50');
+    expect(url.searchParams.has('window')).toBe(false);
+    expect(url.searchParams.has('points')).toBe(false);
+    expect(result.meta.timeFilter).toEqual({
+      value: 30,
+      unit: 'minutes',
+      start: '2026-04-28T20:07:00.000Z',
+      end: '2026-04-28T20:37:00.000Z',
     });
   });
 

--- a/src/features/trending/api/leaderboard.ts
+++ b/src/features/trending/api/leaderboard.ts
@@ -1,5 +1,14 @@
 import { SuperheroApi } from '../../../api/backend';
 
+export type LeaderboardTimeUnit = 'minutes' | 'hours';
+
+export interface LeaderboardTimeFilterMeta {
+  value: number;
+  unit: LeaderboardTimeUnit;
+  start: string;
+  end: string;
+}
+
 // Generic pagination shape used across the app
 export interface PaginatedResponse<T> {
   items: T[];
@@ -7,11 +16,12 @@ export interface PaginatedResponse<T> {
     totalItems: number;
     totalPages: number;
     currentPage: number;
+    timeFilter?: LeaderboardTimeFilterMeta;
   };
 }
 
-// Timeframe options: 7d, 30d, all-time
-export const LEADERBOARD_TIMEFRAMES = ['7d', '30d', 'all'] as const;
+// Timeframe options: recent windows, 7d, 30d, all-time
+export const LEADERBOARD_TIMEFRAMES = ['30m', '1h', '7d', '30d', 'all'] as const;
 export type LeaderboardTimeframe = (typeof LEADERBOARD_TIMEFRAMES)[number];
 
 // Metrics map directly to /api/accounts/leaderboard?sortBy=<metric>.
@@ -26,6 +36,7 @@ export type LeaderboardItem = {
   mdd_pct?: number;
   buy_count?: number;
   sell_count?: number;
+  volume_usd?: number;
   created_tokens_count?: number;
   owned_trends_count?: number;
   portfolio_value_usd_sparkline?: [number, number][];
@@ -39,27 +50,28 @@ export interface LeaderboardQueryParams {
   sortDir?: 'ASC' | 'DESC';
 }
 
-function mapTimeframeToWindow(timeframe: LeaderboardTimeframe): string {
-  switch (timeframe) {
-    case '7d':
-      return '7d';
-    case '30d':
-      return '30d';
-    case 'all':
-    default:
-      return 'all';
-  }
+interface LeaderboardApiTimeframeParams {
+  window?: string;
+  points?: number;
+  timePeriod?: number;
+  timeUnit?: LeaderboardTimeUnit;
 }
 
-function mapTimeframeToPoints(timeframe: LeaderboardTimeframe): number {
+function mapTimeframeToApiParams(
+  timeframe: LeaderboardTimeframe,
+): LeaderboardApiTimeframeParams {
   switch (timeframe) {
+    case '30m':
+      return { timePeriod: 30, timeUnit: 'minutes' };
+    case '1h':
+      return { timePeriod: 1, timeUnit: 'hours' };
     case '7d':
-      return 7;
+      return { window: '7d', points: 7 };
     case '30d':
-      return 30;
+      return { window: '30d', points: 30 };
     case 'all':
     default:
-      return 30;
+      return { window: 'all', points: 30 };
   }
 }
 
@@ -67,19 +79,23 @@ export async function fetchLeaderboard(
   params: LeaderboardQueryParams,
 ): Promise<PaginatedResponse<LeaderboardItem>> {
   const {
-    timeframe, metric, page = 1, limit = 20, sortDir = 'DESC',
+    timeframe, metric, page = 1, limit = 18, sortDir,
   } = params;
 
-  const windowParam = mapTimeframeToWindow(timeframe);
-  const points = mapTimeframeToPoints(timeframe);
+  const timeframeParams = mapTimeframeToApiParams(timeframe);
+  const resolvedSortDir = sortDir ?? (metric === 'mdd' ? 'ASC' : 'DESC');
 
   const searchParams = new URLSearchParams();
-  searchParams.set('window', windowParam);
+  if (timeframeParams.window) searchParams.set('window', timeframeParams.window);
+  if (timeframeParams.points) searchParams.set('points', String(timeframeParams.points));
+  if (timeframeParams.timePeriod) {
+    searchParams.set('timePeriod', String(timeframeParams.timePeriod));
+  }
+  if (timeframeParams.timeUnit) searchParams.set('timeUnit', timeframeParams.timeUnit);
   searchParams.set('sortBy', metric);
-  searchParams.set('sortDir', sortDir);
+  searchParams.set('sortDir', resolvedSortDir);
   searchParams.set('page', String(page));
   searchParams.set('limit', String(limit));
-  searchParams.set('points', String(points));
 
   const path = `/api/accounts/leaderboard?${searchParams.toString()}`;
 
@@ -93,6 +109,7 @@ export async function fetchLeaderboard(
       window?: string;
       sortBy?: string;
       sortDir?: string;
+      timeFilter?: LeaderboardTimeFilterMeta;
     };
   };
 
@@ -103,6 +120,7 @@ export async function fetchLeaderboard(
     totalItems: metaSource.totalItems ?? items.length,
     totalPages: metaSource.totalPages ?? 1,
     currentPage: metaSource.page ?? page,
+    timeFilter: metaSource.timeFilter,
   };
 
   return { items, meta };

--- a/src/features/trending/components/index.ts
+++ b/src/features/trending/components/index.ts
@@ -1,11 +1,11 @@
 export { default as TokenTradeCard } from './TokenTradeCard';
 export { default as TradeTokenInput } from './TradeTokenInput';
 export { default as AssetInput } from './AssetInput';
-export { default as MessageBox } from './MessageBox';
-export { default as TransactionConfirmDetailRow } from './TransactionConfirmDetailRow';
-export { default as ImpactBadge } from './ImpactBadge';
+export { MessageBox } from './MessageBox';
+export { TransactionConfirmDetailRow } from './TransactionConfirmDetailRow';
+export { ImpactBadge } from './ImpactBadge';
 export { default as FractionFormatter } from '@/features/shared/components/FractionFormatter';
-export { default as TokenRanking } from './TokenRanking';
+export { TokenRanking } from './TokenRanking';
 // Skeleton components
 export * from './Skeletons';
 

--- a/src/features/trending/components/leaderboard/LeaderboardFilters.tsx
+++ b/src/features/trending/components/leaderboard/LeaderboardFilters.tsx
@@ -35,7 +35,7 @@ export const LeaderboardFilters = ({
           Timeframe
         </span>
       </div>
-      <div className="flex w-full items-center justify-between gap-2">
+      <div className="grid w-full grid-cols-5 gap-2">
         {LEADERBOARD_TIMEFRAME_OPTIONS.map((option) => {
           const isActive = option.value === timeframe;
           return (
@@ -43,7 +43,7 @@ export const LeaderboardFilters = ({
               key={option.value}
               type="button"
               onClick={() => onTimeframeChange(option.value)}
-              className={`flex-1 px-2 py-2 h-10 text-xs rounded-lg border transition-all duration-300 focus:outline-none ${
+              className={`px-2 py-2 h-10 text-xs rounded-lg border transition-all duration-300 focus:outline-none ${
                 isActive
                   ? 'bg-gradient-to-r from-purple-500 to-pink-500 text-white border-transparent shadow-lg'
                   : 'bg-white/[0.02] text-white border-white/10 hover:bg-white/[0.05]'

--- a/src/features/trending/constants/leaderboard.ts
+++ b/src/features/trending/constants/leaderboard.ts
@@ -7,6 +7,8 @@ export const LEADERBOARD_TIMEFRAME_OPTIONS: {
   label: string;
   value: LeaderboardTimeframe;
 }[] = [
+  { label: '30M', value: '30m' },
+  { label: '1H', value: '1h' },
   { label: '7D', value: '7d' },
   { label: '30D', value: '30d' },
   { label: 'All', value: 'all' },

--- a/src/features/trending/views/LeaderboardView.tsx
+++ b/src/features/trending/views/LeaderboardView.tsx
@@ -19,11 +19,21 @@ import {
   LEADERBOARD_METRIC_OPTIONS,
 } from '../constants/leaderboard';
 
+const DEFAULT_LEADERBOARD_PAGE_SIZE = 15;
+const RECENT_LEADERBOARD_PAGE_SIZE = 50;
+
+const isRecentTimeframe = (timeframe: LeaderboardTimeframe) => (
+  timeframe === '30m' || timeframe === '1h'
+);
+
 const LeaderboardView = () => {
   const { t } = useTranslation('trending');
   const [timeframe, setTimeframe] = useState<LeaderboardTimeframe>('7d');
   const [metric, setMetric] = useState<LeaderboardMetric>('pnl');
   const [page, setPage] = useState(1);
+  const leaderboardPageSize = isRecentTimeframe(timeframe)
+    ? RECENT_LEADERBOARD_PAGE_SIZE
+    : DEFAULT_LEADERBOARD_PAGE_SIZE;
 
   const timeframeOption = LEADERBOARD_TIMEFRAME_OPTIONS.find(
     (option) => option.value === timeframe,
@@ -41,12 +51,12 @@ const LeaderboardView = () => {
     refetch,
     isFetching,
   } = useQuery<PaginatedResponse<LeaderboardItem>>({
-    queryKey: ['leaderboard', timeframe, metric, page],
+    queryKey: ['leaderboard', timeframe, metric, page, leaderboardPageSize],
     queryFn: () => fetchLeaderboard({
       timeframe,
       metric,
       page,
-      limit: 15,
+      limit: leaderboardPageSize,
       sortDir: metric === 'mdd' ? 'ASC' : 'DESC',
     }),
     staleTime: 60 * 1000, // cache results per window/metric for 1 minute
@@ -83,7 +93,8 @@ const LeaderboardView = () => {
             </h1>
             <p className="mt-2 text-sm md:text-base leading-relaxed text-white/70 max-w-2xl">
               Discover the most active Superhero traders ranked by on-chain performance.
-              Increase your trading volume, consistency, and trend ownership to climb the board and turn your wallet into a public on-chain track record.
+              Increase your trading volume, consistency, and trend ownership to climb the
+              board and turn your wallet into a public on-chain track record.
             </p>
           </div>
 
@@ -153,7 +164,7 @@ const LeaderboardView = () => {
                 {items.map((item, index) => (
                   <LeaderboardCard
                     key={item.address}
-                    rank={(currentPage - 1) * 15 + index + 1}
+                    rank={(currentPage - 1) * leaderboardPageSize + index + 1}
                     item={item}
                     timeframeLabel={timeframeLabel}
                     metricLabel={metricLabel}

--- a/src/hooks/useAccountBalances.ts
+++ b/src/hooks/useAccountBalances.ts
@@ -13,7 +13,14 @@ const ACCOUNT_DATA_TTL_MS = 30_000;
 const accountLoadRequests = new Map<string, Promise<void>>();
 const accountLastLoadedAt = new Map<string, number>();
 
-export const useAccountBalances = (selectedAccount: string) => {
+interface UseAccountBalancesOptions {
+  enabled?: boolean;
+}
+
+export const useAccountBalances = (
+  selectedAccount: string,
+  { enabled = true }: UseAccountBalancesOptions = {},
+) => {
   const { sdk } = useAeSdk();
   const [chainNames] = useAtom(chainNamesAtom);
   const [_balance, setBalance] = useAtom(balanceAtom);
@@ -153,10 +160,10 @@ export const useAccountBalances = (selectedAccount: string) => {
   // Automatically reload account data when the selected account changes
   // Only depend on selectedAccount to avoid infinite loops
   useEffect(() => {
-    if (selectedAccount) {
+    if (enabled && selectedAccount) {
       loadAccountDataRef.current();
     }
-  }, [selectedAccount]);
+  }, [enabled, selectedAccount]);
 
   return {
     selectedAccount,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes leaderboard API query parameters/default limits and adds new timeframe behavior that depends on backend support; also alters when account balance data is fetched, which could affect UI freshness/performance.
> 
> **Overview**
> Adds *recent* leaderboard timeframes (`30m`, `1h`) and switches API query construction to use `timePeriod`/`timeUnit` for live windows while keeping `window`/`points` for longer ranges; response meta now optionally includes a `timeFilter` and items include `volume_usd`.
> 
> Updates the leaderboard UI to show the new timeframe options, adjust page size (50 for recent windows, 15 otherwise), and incorporate the page size into caching and rank calculations.
> 
> Optimizes balance fetching by adding an `enabled` option to `useAccountBalances` and using it in `AddressAvatarWithChainName` so balances load only when explicitly shown or when hover-balance is enabled; also adds/adjusts tests and fixes a few component re-exports to named exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a07ea17abfcea5517a9600a7b7bc55e9e0549a81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->