### PR TITLE
Release

### DIFF
--- a/src/atoms/accountAtoms.ts
+++ b/src/atoms/accountAtoms.ts
@@ -1,3 +1,8 @@
+import { safeLocalJSONStorage } from '@/utils/jotaiSafeLocalStorage';
 import { atomWithStorage } from 'jotai/utils';
 
-export const activeAccountAtom = atomWithStorage<string | undefined>('account:activeAccount', undefined);
+export const activeAccountAtom = atomWithStorage<string | undefined>(
+  'account:activeAccount',
+  undefined,
+  safeLocalJSONStorage,
+);

--- a/src/atoms/currencyAtoms.ts
+++ b/src/atoms/currencyAtoms.ts
@@ -1,3 +1,4 @@
+import { safeLocalJSONStorage } from '@/utils/jotaiSafeLocalStorage';
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 
@@ -7,6 +8,7 @@ import type { CurrencyRates } from '../utils/types';
 export const currencyRatesAtom = atomWithStorage<CurrencyRates>(
   'currency:rates',
   {},
+  safeLocalJSONStorage,
 );
 
 // Updated whenever currencyRatesAtom is refreshed by the global poller.

--- a/src/atoms/dexAtoms.ts
+++ b/src/atoms/dexAtoms.ts
@@ -1,4 +1,9 @@
 /* eslint-disable max-len */
+import {
+  createClampedNumberJSONStorage,
+  safeLocalJSONStorage,
+  type SyncJSONNumberStorage,
+} from '@/utils/jotaiSafeLocalStorage';
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { DexTokenDto } from '@/api/generated';
@@ -14,24 +19,22 @@ type LiquidityPositionData = {
   valueUsd?: string;
 };
 
-// DEX settings with localStorage persistence
-export const slippagePctAtom = atomWithStorage<number>('dex:slippage', (() => {
-  try {
-    const v = localStorage.getItem('dex:slippage');
-    return v != null ? Math.max(0, Math.min(50, Number(v) || 5)) : 5;
-  } catch {
-    return 5;
-  }
-})());
+const dexSlippagePctStorage = createClampedNumberJSONStorage(safeLocalJSONStorage as SyncJSONNumberStorage, {
+  min: 0,
+  max: 50,
+  writeFallback: 5,
+});
 
-export const deadlineMinsAtom = atomWithStorage<number>('dex:deadline', (() => {
-  try {
-    const v = localStorage.getItem('dex:deadline');
-    return v != null ? Math.max(1, Math.min(60, Number(v) || 30)) : 30;
-  } catch {
-    return 30;
-  }
-})());
+const dexDeadlineMinsStorage = createClampedNumberJSONStorage(safeLocalJSONStorage as SyncJSONNumberStorage, {
+  min: 1,
+  max: 60,
+  writeFallback: 30,
+});
+
+// DEX settings (quota-safe persistence; clamped on read/write and in useDex on write)
+export const slippagePctAtom = atomWithStorage<number>('dex:slippage', 5, dexSlippagePctStorage);
+
+export const deadlineMinsAtom = atomWithStorage<number>('dex:deadline', 30, dexDeadlineMinsStorage);
 
 // DEX state atoms
 // Structure: {[accountAddress]: {[pairAddress]: LiquidityPositionData}}
@@ -39,4 +42,8 @@ export const providedLiquidityAtom = atom<Record<string, Record<string, Liquidit
 
 // Recent activities with localStorage persistence
 // Structure: {[accountAddress]: RecentActivity[]}
-export const recentActivitiesAtom = atomWithStorage<Record<string, RecentActivity[]>>('dex:recentActivities', {});
+export const recentActivitiesAtom = atomWithStorage<Record<string, RecentActivity[]>>(
+  'dex:recentActivities',
+  {},
+  safeLocalJSONStorage,
+);

--- a/src/atoms/invitationAtoms.ts
+++ b/src/atoms/invitationAtoms.ts
@@ -1,5 +1,4 @@
 import { atom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
 import type { Encoded } from '@aeternity/aepp-sdk';
 
 export interface InvitationInfo {
@@ -26,11 +25,11 @@ export interface InvitationStatus {
   secretKey?: string;
 }
 
-// Persistent storage for generated invitations
-export const invitationListAtom = atomWithStorage<InvitationInfo[]>('invite_list', []);
+// Current-session generated invitations. Do not persist invitation secrets locally.
+export const invitationListAtom = atom<InvitationInfo[]>([]);
 
-// Current invitation code from URL
-export const invitationCodeAtom = atomWithStorage<string | undefined>('invite_code', undefined);
+// Current invitation code from URL.
+export const invitationCodeAtom = atom<string | undefined>(undefined);
 
 // Claimed invitations cache - stores claimer info
 export interface ClaimedInfo {

--- a/src/atoms/tokenTradeAtoms.ts
+++ b/src/atoms/tokenTradeAtoms.ts
@@ -1,3 +1,8 @@
+import {
+  createClampedNumberJSONStorage,
+  safeLocalJSONStorage,
+  type SyncJSONNumberStorage,
+} from '@/utils/jotaiSafeLocalStorage';
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { TokenDto } from '@/api/generated/models/TokenDto';
@@ -33,15 +38,16 @@ export const tokenBAtom = atom<number | undefined>(undefined);
 export const tokenAFocusedAtom = atom<boolean>(false);
 export const nextPriceAtom = atom<Decimal>(Decimal.ZERO);
 
-// Slippage with localStorage persistence
-export const slippageAtom = atomWithStorage<number>('tokenTrade:slippage', (() => {
-  try {
-    const v = localStorage.getItem('tokenTrade:slippage');
-    return v != null ? Math.max(0, Math.min(50, Number(v) || 1)) : 1;
-  } catch {
-    return 1;
-  }
-})());
+const tokenTradeSlippageStorage = createClampedNumberJSONStorage(
+  safeLocalJSONStorage as SyncJSONNumberStorage,
+  {
+    min: 0,
+    max: 50,
+    writeFallback: 1,
+  },
+);
+
+export const slippageAtom = atomWithStorage<number>('tokenTrade:slippage', 1, tokenTradeSlippageStorage);
 
 // Computed atoms
 export const currentTokenUnitPriceAtom = atom<Decimal>((get) => {
@@ -96,9 +102,11 @@ export const priceImpactPercentAtom = atom<Decimal>((get) => {
   return priceImpactDiff.div(currentTokenUnitPrice).mul(100);
 });
 
-export const estimatedNextTokenPriceImpactDifferenceFormattedPercentageAtom = atom<string>((get) => {
-  const priceImpactPercent = get(priceImpactPercentAtom);
-  return priceImpactPercent.gt(Decimal.from(1))
-    ? priceImpactPercent.prettify(2)
-    : priceImpactPercent.prettify();
-});
+export const estimatedNextTokenPriceImpactDifferenceFormattedPercentageAtom = atom<string>(
+  (get) => {
+    const priceImpactPercent = get(priceImpactPercentAtom);
+    return priceImpactPercent.gt(Decimal.from(1))
+      ? priceImpactPercent.prettify(2)
+      : priceImpactPercent.prettify();
+  },
+);

--- a/src/atoms/walletAtoms.ts
+++ b/src/atoms/walletAtoms.ts
@@ -1,4 +1,5 @@
 import { CurrencyCode } from '@/utils/types';
+import { safeLocalJSONStorage } from '@/utils/jotaiSafeLocalStorage';
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { WalletInfo } from 'node_modules/@aeternity/aepp-sdk/es/aepp-wallet-communication/rpc/types';
@@ -9,20 +10,21 @@ export interface TokenBalance {
   balance: string;
 }
 
-// Core wallet state atoms with persistence
-export const addressAtom = atomWithStorage<string | null>('wallet:address', null);
-export const balanceAtom = atomWithStorage<Record<string, number>>('wallet:balance', {});
-export const selectedCurrencyAtom = atomWithStorage<CurrencyCode>('wallet:currency', 'usd');
-export const tokenBalancesAtom = atomWithStorage<TokenBalance[]>('wallet:tokenBalances', []);
-export const tokenPricesAtom = atomWithStorage<Record<string, string>>('wallet:tokenPrices', {});
-export const cookiesConsentAtom = atomWithStorage<Record<string, boolean>>('wallet:cookiesConsent', {});
-export const aex9BalancesAtom = atomWithStorage<Record<string, any[]>>('wallet:aex9Balances', {});
+// Core wallet state atoms with persistence (quota-safe; see jotaiSafeLocalStorage)
+export const addressAtom = atomWithStorage<string | null>('wallet:address', null, safeLocalJSONStorage);
+export const balanceAtom = atomWithStorage<Record<string, number>>('wallet:balance', {}, safeLocalJSONStorage);
+export const selectedCurrencyAtom = atomWithStorage<CurrencyCode>('wallet:currency', 'usd', safeLocalJSONStorage);
+export const tokenBalancesAtom = atomWithStorage<TokenBalance[]>('wallet:tokenBalances', [], safeLocalJSONStorage);
+export const tokenPricesAtom = atomWithStorage<Record<string, string>>('wallet:tokenPrices', {}, safeLocalJSONStorage);
+export const cookiesConsentAtom = atomWithStorage<Record<string, boolean>>('wallet:cookiesConsent', {}, safeLocalJSONStorage);
+/** In-memory only — full AEX-9 lists can exceed localStorage quota when paginated from MDW. */
+export const aex9BalancesAtom = atom<Record<string, any[]>>({});
 
 // Non-persisted wallet state
 export const profileAtom = atom<Record<string, any>>({});
 export const pinnedItemsAtom = atom<any[]>([]);
-export const chainNamesAtom = atomWithStorage<Record<string, string>>('wallet:chainNames', {});
-export const chainNameLookupCheckedAtAtom = atomWithStorage<Record<string, number>>('wallet:chainNames:checkedAt', {});
+export const chainNamesAtom = atomWithStorage<Record<string, string>>('wallet:chainNames', {}, safeLocalJSONStorage);
+export const chainNameLookupCheckedAtAtom = atomWithStorage<Record<string, number>>('wallet:chainNames:checkedAt', {}, safeLocalJSONStorage);
 /** Profile display names (public_name from /api/profile). Used for author labels in feed. */
 export const profileDisplayNamesAtom = atom<Record<string, string>>({});
 export const verifiedUrlsAtom = atom<string[]>([]);
@@ -40,9 +42,14 @@ export const scanningForAccountsAtom = atom<boolean>(false);
 // Derived atoms
 export const isConnectedAtom = atom((get) => get(addressAtom) !== null);
 export const hasBalanceAtom = atom((get) => {
-  const balance = get(balanceAtom);
-  return typeof balance === 'number' ? balance > 0 : parseFloat(balance) > 0;
+  const byAccount = get(balanceAtom);
+  if (byAccount instanceof Promise) return false;
+  if (typeof byAccount === 'number') return byAccount > 0;
+  if (byAccount && typeof byAccount === 'object') {
+    return Object.values(byAccount).some((n) => Number(n) > 0);
+  }
+  return false;
 });
 
 // New Atoms
-export const walletInfoAtom = atomWithStorage<WalletInfo | undefined>('wallet:walletInfo', undefined);
+export const walletInfoAtom = atomWithStorage<WalletInfo | undefined>('wallet:walletInfo', undefined, safeLocalJSONStorage);

--- a/src/components/layout/app-header/WebAppHeader.tsx
+++ b/src/components/layout/app-header/WebAppHeader.tsx
@@ -17,7 +17,11 @@ const WebAppHeader = () => {
   useEffect(() => {
     // force theme to be dark
     document.documentElement.dataset.theme = 'dark';
-    localStorage.setItem('theme', 'dark');
+    try {
+      localStorage.setItem('theme', 'dark');
+    } catch {
+      // ignore quota / private mode
+    }
   }, []);
 
   const sidebarItems = useMemo(() => getAppNavigationItems(activeAccount), [activeAccount]);

--- a/src/context/AeSdkProvider.tsx
+++ b/src/context/AeSdkProvider.tsx
@@ -18,6 +18,7 @@ import { walletInfoAtom } from '../atoms/walletAtoms';
 import { CONFIG } from '../config';
 import { useModal } from '../hooks/useModal';
 import { CURRENT_NETWORK, IS_MOBILE } from '../utils/constants';
+import { safeLocalStringStorage } from '../utils/jotaiSafeLocalStorage';
 import { INetwork } from '../utils/types';
 import { createDeepLinkUrl, openDeepLink } from '../utils/url';
 
@@ -253,7 +254,7 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
             // Set a timeout to prevent infinite polling (5 minutes max)
             const MAX_POLL_TIME = 5 * 60 * 1000; // 5 minutes
             timeout = setTimeout(() => {
-              localStorage.removeItem(storedResultKey);
+              safeLocalStringStorage.removeItem(storedResultKey);
               cleanup();
               reject(new Error('Transaction polling timeout'));
             }, MAX_POLL_TIME);
@@ -268,19 +269,19 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
 
             interval = setInterval(() => {
               const currentQueue = transactionsQueueRef.current;
-              const storedResult = localStorage.getItem(storedResultKey);
+              const storedResult = safeLocalStringStorage.getItem(storedResultKey);
               let parsedStoredResult: any = null;
               try {
                 parsedStoredResult = storedResult ? JSON.parse(storedResult) : null;
               } catch {
-                localStorage.removeItem(storedResultKey);
+                safeLocalStringStorage.removeItem(storedResultKey);
               }
               const queueEntry = currentQueue[uniqueId] || parsedStoredResult;
 
               if (queueEntry) {
                 if (queueEntry.status === 'cancelled') {
                   ackChannel?.postMessage({ id: uniqueId, status: 'cancelled' });
-                  localStorage.removeItem(storedResultKey);
+                  safeLocalStringStorage.removeItem(storedResultKey);
                   cleanup();
                   reject(new Error('Transaction cancelled'));
                   // delete transaction from queue
@@ -295,7 +296,7 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
                 ) {
                   const signedTx = queueEntry.transaction;
                   if (!signedTx || typeof signedTx !== 'string' || !signedTx.startsWith('tx_')) {
-                    localStorage.removeItem(storedResultKey);
+                    safeLocalStringStorage.removeItem(storedResultKey);
                     cleanup();
                     // delete transaction from queue
                     const newQueue = { ...currentQueue };
@@ -305,7 +306,7 @@ export const AeSdkProvider = ({ children }: { children: React.ReactNode }) => {
                     return;
                   }
                   ackChannel?.postMessage({ id: uniqueId, status: 'completed' });
-                  localStorage.removeItem(storedResultKey);
+                  safeLocalStringStorage.removeItem(storedResultKey);
                   cleanup();
                   resolve(signedTx as Encoded.Transaction);
                   // delete transaction from queue

--- a/src/features/dex/atoms/positionsAtoms.ts
+++ b/src/features/dex/atoms/positionsAtoms.ts
@@ -1,3 +1,4 @@
+import { safeLocalJSONStorage } from '@/utils/jotaiSafeLocalStorage';
 import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import { LiquidityPosition } from '../types/pool';
@@ -6,6 +7,7 @@ import { LiquidityPosition } from '../types/pool';
 export const liquidityPositionsAtom = atomWithStorage<Record<string, LiquidityPosition[]>>(
   'liquidityPositions',
   {},
+  safeLocalJSONStorage,
 );
 
 // Loading state for positions

--- a/src/features/trending/hooks/__tests__/useInvitations.test.ts
+++ b/src/features/trending/hooks/__tests__/useInvitations.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { getArgumentAccountAddresses } from '../useInvitations';
+
+describe('getArgumentAccountAddresses', () => {
+  it('extracts account addresses from middleware argument shapes', () => {
+    expect(getArgumentAccountAddresses('ak_single')).toEqual(['ak_single']);
+
+    expect(getArgumentAccountAddresses({
+      type: 'address',
+      value: 'ak_wrapped',
+    })).toEqual(['ak_wrapped']);
+
+    expect(getArgumentAccountAddresses([
+      { type: 'address', value: 'ak_first' },
+      'ak_second',
+      { type: 'int', value: '123' },
+    ])).toEqual(['ak_first', 'ak_second']);
+
+    expect(getArgumentAccountAddresses({
+      type: 'list',
+      value: [
+        { type: 'address', value: 'ak_batched_one' },
+        { type: 'address', value: 'ak_batched_two' },
+      ],
+    })).toEqual(['ak_batched_one', 'ak_batched_two']);
+  });
+});

--- a/src/features/trending/hooks/useInvitations.ts
+++ b/src/features/trending/hooks/useInvitations.ts
@@ -284,7 +284,7 @@ export function useInvitations() {
       inviteAmount,
     );
 
-    // Add to state and localStorage
+    // Keep generated invitations in memory for the current session only.
     const now = Date.now();
     const newInvitations: InvitationInfo[] = keyPairs.map(({ secretKey, address }) => ({
       inviter: activeAccount as Encoded.AccountAddress,
@@ -294,7 +294,6 @@ export function useInvitations() {
       date: now,
     }));
 
-    // Update state (this will also update localStorage via atomWithStorage)
     setInvitationList((prev) => [...newInvitations, ...prev]);
 
     // Trigger refresh to update invitation statuses

--- a/src/features/trending/hooks/useInvitations.ts
+++ b/src/features/trending/hooks/useInvitations.ts
@@ -34,6 +34,29 @@ import {
 import { ITransaction } from '../../../utils/types';
 
 const INVITE_CODE_QUERY_KEY = 'invite_code';
+const ACCOUNT_ADDRESS_PREFIX = 'ak_';
+
+function collectAccountAddresses(value: unknown): Encoded.AccountAddress[] {
+  if (typeof value === 'string') {
+    return value.startsWith(ACCOUNT_ADDRESS_PREFIX)
+      ? [value as Encoded.AccountAddress]
+      : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(collectAccountAddresses);
+  }
+
+  if (value && typeof value === 'object' && 'value' in value) {
+    return collectAccountAddresses((value as { value: unknown }).value);
+  }
+
+  return [];
+}
+
+export function getArgumentAccountAddresses(argument: unknown): Encoded.AccountAddress[] {
+  return collectAccountAddresses(argument);
+}
 
 export function useInvitations() {
   const navigate = useNavigate();
@@ -75,18 +98,9 @@ export function useInvitations() {
     const revokeTx = transactionList.find((tx) => {
       if (tx?.tx?.function !== TX_FUNCTIONS.revoke_invitation_code) return false;
 
-      const arg0 = tx?.tx?.arguments?.[0]?.value;
-
-      // Middleware can return either:
-      // - { type: "address", value: "ak_..." }
-      // - { type: "list", value: [{ type: "address", value: "ak_..." }, ...] }
-      if (typeof arg0 === 'string') return arg0 === invitee;
-
-      if (Array.isArray(arg0)) {
-        return arg0.some((item: any) => item?.value === invitee || item === invitee);
-      }
-
-      return false;
+      return getArgumentAccountAddresses(tx?.tx?.arguments?.[0]?.value).includes(
+        invitee as Encoded.AccountAddress,
+      );
     }) ?? false;
 
     return revokeTx || recentlyRevokedInvitations.includes(invitee);
@@ -109,25 +123,17 @@ export function useInvitations() {
     [activeAccountInviteList],
   );
 
-  const getInvitationStatus = useCallback((
+  const getInvitationStatusDetails = useCallback((
     invitee: Encoded.AccountAddress,
-    transaction: ITransaction,
-  ): InvitationStatus => {
+  ) => {
     const revokeStatus = getInvitationRevokeStatus(invitee);
     const claimedData = claimedInvitations[invitee];
     const claimed = !!claimedData;
-    const status = determineInvitationStatus(claimed, revokeStatus);
-    const secretKey = getInvitationSecretKey(invitee);
-
-    // Extract claimed info if available
     const claimedInfo = typeof claimedData === 'object' ? claimedData as ClaimedInfo : null;
 
     return {
-      hash: transaction.hash,
-      status,
+      status: determineInvitationStatus(claimed, revokeStatus),
       invitee,
-      date: moment(transaction.microTime).format(DATE_LONG),
-      amount: Decimal.from(toAe(transaction.tx.arguments[2].value)).prettify(),
       revoked: !!revokeStatus,
       ...(typeof revokeStatus === 'object' && {
         revokedAt: moment(revokeStatus.microTime).format(DATE_LONG),
@@ -136,25 +142,74 @@ export function useInvitations() {
       claimed,
       ...(claimedInfo && {
         claimedBy: claimedInfo.claimedBy,
-        claimedAt: claimedInfo.claimedAt ? moment(claimedInfo.claimedAt).format(DATE_LONG) : undefined,
+        claimedAt: claimedInfo.claimedAt
+          ? moment(claimedInfo.claimedAt).format(DATE_LONG)
+          : undefined,
         claimTxHash: claimedInfo.claimTxHash,
       }),
-      secretKey,
     };
   }, [
     getInvitationRevokeStatus,
     claimedInvitations,
     determineInvitationStatus,
+  ]);
+
+  const getInvitationStatus = useCallback((
+    invitee: Encoded.AccountAddress,
+    transaction: ITransaction,
+  ): InvitationStatus => {
+    const secretKey = getInvitationSecretKey(invitee);
+
+    return {
+      ...getInvitationStatusDetails(invitee),
+      hash: transaction.hash,
+      date: moment(transaction.microTime).format(DATE_LONG),
+      amount: Decimal.from(toAe(transaction.tx.arguments[2].value)).prettify(),
+      secretKey,
+    };
+  }, [
+    getInvitationStatusDetails,
     getInvitationSecretKey,
   ]);
 
+  const getStoredInvitationStatus = useCallback((
+    invitation: InvitationInfo,
+  ): InvitationStatus => {
+    const invitee = invitation.invitee as Encoded.AccountAddress;
+
+    return {
+      ...getInvitationStatusDetails(invitee),
+      hash: `local-${invitee}`,
+      date: moment(invitation.date).format(DATE_LONG),
+      amount: Decimal.from(invitation.amount).prettify(),
+      secretKey: invitation.secretKey,
+    };
+  }, [
+    getInvitationStatusDetails,
+  ]);
+
   // Computed invitations with status
-  const invitations = useMemo(() => transactionList
-    .filter((transaction) => transaction?.tx?.function === TX_FUNCTIONS.register_invitation_code)
-    .flatMap((transaction) => {
-      const invitees = transaction.tx.arguments?.[0]?.value?.map((item: any) => item.value) || [];
-      return invitees.map((invitee: string) => getInvitationStatus(invitee as `ak_${string}`, transaction));
-    }), [transactionList, getInvitationStatus]);
+  const invitations = useMemo(() => {
+    const transactionInvitations = transactionList
+      .filter((transaction) => transaction?.tx?.function === TX_FUNCTIONS.register_invitation_code)
+      .flatMap((transaction) => getArgumentAccountAddresses(transaction.tx.arguments?.[0]?.value)
+        .map((invitee) => getInvitationStatus(invitee, transaction)));
+
+    const transactionInvitees = new Set(
+      transactionInvitations.map(({ invitee }) => invitee),
+    );
+
+    const storedInvitations = activeAccountInviteList
+      .filter(({ invitee }) => !transactionInvitees.has(invitee))
+      .map(getStoredInvitationStatus);
+
+    return [...transactionInvitations, ...storedInvitations];
+  }, [
+    transactionList,
+    activeAccountInviteList,
+    getInvitationStatus,
+    getStoredInvitationStatus,
+  ]);
 
   // Load transactions from middleware
   const loadTransactionsFromMiddleware = useCallback(async (
@@ -326,10 +381,7 @@ export function useInvitations() {
   }, [activeAccount, refreshTrigger, loadAccountInvitations, setLoading]);
 
   // Load claimed invitations when we have invitations to check
-  // Use transactionList as dependency to avoid infinite loop caused by claimedInvitations updates
   useEffect(() => {
-    if (transactionList.length === 0) return;
-
     // Get list of invitees that need to be checked (haven't been checked yet)
     const inviteesToCheck = invitations
       .filter((inv) => !checkedInviteesRef.current.has(inv.invitee))
@@ -389,7 +441,7 @@ export function useInvitations() {
     };
 
     loadClaimed();
-  }, [transactionList, invitations, loadAccountInvitations, setClaimedInvitations]);
+  }, [invitations, loadAccountInvitations, setClaimedInvitations]);
 
   return {
     // Data

--- a/src/features/trending/views/TokenSaleDetails.tsx
+++ b/src/features/trending/views/TokenSaleDetails.tsx
@@ -176,24 +176,11 @@ const TokenSaleDetails = () => {
     }
   }, [location.search, showTradePanels, isMobile]);
 
-  // Check if token is newly created (from local storage or state)
+  // Post-deploy flow: CreateTokenView navigates here with ?created=true (see also txHash).
   const isTokenNewlyCreated = useMemo(() => {
     const params = new URLSearchParams(location.search);
-    const hasCreatedParam = params.get('created') === 'true';
-
-    if (hasCreatedParam) {
-      return true;
-    }
-
-    try {
-      const recentTokens = JSON.parse(
-        localStorage.getItem('recentlyCreatedTokens') || '[]',
-      );
-      return recentTokens.includes(tokenName);
-    } catch {
-      return false;
-    }
-  }, [tokenName, location.search]);
+    return params.get('created') === 'true';
+  }, [location.search]);
 
   const txHash = useMemo(() => {
     const params = new URLSearchParams(location.search);

--- a/src/hooks/__tests__/useInvitation.test.tsx
+++ b/src/hooks/__tests__/useInvitation.test.tsx
@@ -62,7 +62,7 @@ describe('useInvitation', () => {
       });
   });
 
-  it('registers generated invite keys and stores them locally', async () => {
+  it('registers generated invite keys and keeps them in memory', async () => {
     const { useInvitation } = await import('../useInvitation');
     const { result } = renderHook(() => useInvitation());
 
@@ -76,18 +76,19 @@ describe('useInvitation', () => {
       2000000000000000000n,
     );
 
-    const stored = JSON.parse(localStorage.getItem('invite_list') || '[]');
-    expect(stored).toEqual([
-      expect.objectContaining({
-        inviter: 'ak_inviter',
-        invitee: 'ak_invitee_two',
-        secretKey: 'sk_two',
-        amount: 2,
-      }),
+    expect(localStorage.getItem('invite_list')).toBeNull();
+
+    expect(result.current.activeAccountInviteList).toEqual([
       expect.objectContaining({
         inviter: 'ak_inviter',
         invitee: 'ak_invitee_one',
         secretKey: 'sk_one',
+        amount: 2,
+      }),
+      expect.objectContaining({
+        inviter: 'ak_inviter',
+        invitee: 'ak_invitee_two',
+        secretKey: 'sk_two',
         amount: 2,
       }),
     ]);
@@ -107,7 +108,7 @@ describe('useInvitation', () => {
       expect(result.current.invitationCode).toBe('secret-123');
     });
 
-    expect(localStorage.getItem('invite_code')).toBe('secret-123');
+    expect(localStorage.getItem('invite_code')).toBeNull();
     expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
 
     act(() => {

--- a/src/hooks/__tests__/useWalletConnect.test.tsx
+++ b/src/hooks/__tests__/useWalletConnect.test.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from 'react';
-import { Provider } from 'jotai';
+import { createStore, Provider } from 'jotai';
 import { renderHook, waitFor, act } from '@testing-library/react';
+import { recentActivitiesAtom } from '@/atoms/dexAtoms';
+import { balanceAtom, walletInfoAtom } from '@/atoms/walletAtoms';
+import { liquidityPositionsAtom } from '@/features/dex/atoms/positionsAtoms';
 import {
   beforeEach, describe, expect, it, vi,
 } from 'vitest';
@@ -9,6 +12,8 @@ import { useWalletConnect } from '../useWalletConnect';
 const walletConnectMocks = vi.hoisted(() => {
   let currentLocation = { search: '' };
   let activeAccount: string | undefined;
+  let accounts: string[] = [];
+  let sdkInitialized = true;
   let latestWalletHandler: ((payload: any) => void) | undefined;
 
   const mockNavigate = vi.fn((to: any) => {
@@ -57,12 +62,22 @@ const walletConnectMocks = vi.hoisted(() => {
     resetState: () => {
       currentLocation = { search: '' };
       activeAccount = undefined;
+      accounts = [];
+      sdkInitialized = true;
       latestWalletHandler = undefined;
       createdConnections.length = 0;
     },
+    setSdkInitialized: (value: boolean) => {
+      sdkInitialized = value;
+    },
+    getSdkInitialized: () => sdkInitialized,
     setActiveAccountValue: (value?: string) => {
       activeAccount = value;
     },
+    setAccountsValue: (value: string[]) => {
+      accounts = value;
+    },
+    getAccounts: () => accounts,
     setLocationSearch: (search: string) => {
       currentLocation = { search };
     },
@@ -72,7 +87,9 @@ const walletConnectMocks = vi.hoisted(() => {
 
 vi.mock('@aeternity/aepp-sdk', () => ({
   BrowserWindowMessageConnection: walletConnectMocks.MockBrowserWindowMessageConnection,
-  walletDetector: (...args: any[]) => walletConnectMocks.walletDetectorMock(...args),
+  walletDetector: (connection: unknown, handler: (payload: any) => void) => (
+    walletConnectMocks.walletDetectorMock(connection, handler)
+  ),
 }));
 
 vi.mock('react-router-dom', async () => {
@@ -96,6 +113,8 @@ vi.mock('@/hooks/useAeSdk', () => ({
     setActiveAccount: (...args: any[]) => walletConnectMocks.mockSetActiveAccount(...args),
     setAccounts: (...args: any[]) => walletConnectMocks.mockSetAccounts(...args),
     activeAccount: walletConnectMocks.getActiveAccount(),
+    accounts: walletConnectMocks.getAccounts(),
+    sdkInitialized: walletConnectMocks.getSdkInitialized(),
   }),
 }));
 
@@ -109,11 +128,82 @@ describe('useWalletConnect', () => {
   beforeEach(() => {
     walletConnectMocks.resetState();
     vi.clearAllMocks();
+    localStorage.clear();
     walletConnectMocks.mockValidateHash.mockReturnValue({ valid: true });
     walletConnectMocks.mockAddStaticAccount.mockResolvedValue(undefined);
     walletConnectMocks.mockDisconnectWallet.mockResolvedValue(undefined);
     walletConnectMocks.mockScanForAccounts.mockResolvedValue(undefined);
     walletConnectMocks.mockSubscribeAddress.mockResolvedValue(undefined);
+  });
+
+  it('does not wipe per-account balance cache before sdkInitialized; clears once ready with no session', async () => {
+    walletConnectMocks.setSdkInitialized(false);
+
+    const store = createStore();
+    store.set(balanceAtom, { ak_persist: 42 });
+
+    const storeWrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+    const { rerender } = renderHook(() => useWalletConnect(), { wrapper: storeWrapper });
+
+    expect(store.get(balanceAtom)).toEqual({ ak_persist: 42 });
+
+    walletConnectMocks.setSdkInitialized(true);
+    rerender();
+
+    await waitFor(() => {
+      expect(store.get(balanceAtom)).toEqual({});
+    });
+  });
+
+  it('does not wipe caches while a persisted wallet session may reconnect', async () => {
+    const store = createStore();
+    store.set(balanceAtom, { ak_persist: 42 });
+    store.set(walletInfoAtom, { name: 'wallet' } as any);
+
+    const storeWrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+    renderHook(() => useWalletConnect(), { wrapper: storeWrapper });
+
+    await waitFor(() => {
+      expect(store.get(balanceAtom)).toEqual({ ak_persist: 42 });
+    });
+  });
+
+  it('prunes per-account caches to restored sdk accounts', async () => {
+    walletConnectMocks.setAccountsValue(['ak_keep']);
+    walletConnectMocks.setActiveAccountValue('ak_active');
+
+    const store = createStore();
+    store.set(balanceAtom, { ak_keep: 1, ak_active: 2, ak_drop: 3 });
+    store.set(recentActivitiesAtom, {
+      ak_keep: [{ account: 'ak_keep', hash: 'th_keep' } as any],
+      ak_drop: [{ account: 'ak_drop', hash: 'th_drop' } as any],
+    });
+    store.set(liquidityPositionsAtom, {
+      ak_active: [{ balance: '1' } as any],
+      ak_drop: [{ balance: '2' } as any],
+    });
+
+    const storeWrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+    renderHook(() => useWalletConnect(), { wrapper: storeWrapper });
+
+    await waitFor(() => {
+      expect(store.get(balanceAtom)).toEqual({ ak_keep: 1, ak_active: 2 });
+      expect(store.get(recentActivitiesAtom)).toEqual({
+        ak_keep: [{ account: 'ak_keep', hash: 'th_keep' }],
+      });
+      expect(store.get(liquidityPositionsAtom)).toEqual({
+        ak_active: [{ balance: '1' }],
+      });
+    });
   });
 
   it('consumes the address query only once after restoring a valid static account', async () => {
@@ -175,6 +265,9 @@ describe('useWalletConnect', () => {
 
     localStorage.setItem('account:activeAccount', 'ak_saved');
     localStorage.setItem('wallet:walletInfo', '{"name":"wallet"}');
+    localStorage.setItem('wallet:balance', '{"ak_old":1,"ak_other":2}');
+    localStorage.setItem('dex:recentActivities', '{"ak_old":[]}');
+    localStorage.setItem('liquidityPositions', '{"ak_old":[]}');
 
     const pendingScan = result.current.scanForWallets();
     const pendingConnection = walletConnectMocks.createdConnections[0];
@@ -185,6 +278,9 @@ describe('useWalletConnect', () => {
 
     expect(localStorage.getItem('account:activeAccount')).toBeNull();
     expect([null, 'undefined']).toContain(localStorage.getItem('wallet:walletInfo'));
+    expect(localStorage.getItem('wallet:balance')).toBe('{}');
+    expect(localStorage.getItem('dex:recentActivities')).toBe('{}');
+    expect(localStorage.getItem('liquidityPositions')).toBe('{}');
     expect(walletConnectMocks.mockStopScan).toHaveBeenCalledTimes(1);
     expect(pendingConnection.disconnect).toHaveBeenCalledTimes(1);
     expect(walletConnectMocks.mockDisconnectWallet).toHaveBeenCalledTimes(1);

--- a/src/hooks/useDex.ts
+++ b/src/hooks/useDex.ts
@@ -9,21 +9,11 @@ export const useDex = () => {
   const setSlippage = useCallback((value: number) => {
     const clampedValue = Math.max(0, Math.min(50, value || 0));
     setSlippagePct(clampedValue);
-    try {
-      localStorage.setItem('dex:slippage', String(clampedValue));
-    } catch {
-      // Ignore storage errors
-    }
   }, [setSlippagePct]);
 
   const setDeadline = useCallback((value: number) => {
     const clampedValue = Math.max(1, Math.min(60, value || 10));
     setDeadlineMins(clampedValue);
-    try {
-      localStorage.setItem('dex:deadline', String(clampedValue));
-    } catch {
-      // Ignore storage errors
-    }
   }, [setDeadlineMins]);
 
   // TODO: should improve this, it should come from a cached API

--- a/src/hooks/useInvitation.ts
+++ b/src/hooks/useInvitation.ts
@@ -11,8 +11,6 @@ import { useAccount } from './useAccount';
 import { useCommunityFactory } from './useCommunityFactory';
 
 const INVITE_CODE_QUERY_KEY = 'invite_code';
-const LS_KEY_INVITE_LIST = 'invite_list';
-const LS_KEY_INVITE_CODE = 'invite_code';
 
 export interface InvitationInfo {
   inviter: Encoded.AccountAddress;
@@ -22,33 +20,10 @@ export interface InvitationInfo {
   amount: number;
 }
 
-// LocalStorage helper functions
-function readAllInvitations(): InvitationInfo[] {
-  try {
-    const raw = localStorage.getItem(LS_KEY_INVITE_LIST);
-    if (!raw) return [];
-    const arr = JSON.parse(raw);
-    if (!Array.isArray(arr)) return [];
-    return arr;
-  } catch {
-    return [];
-  }
-}
-
-function writeAllInvitations(list: InvitationInfo[]) {
-  localStorage.setItem(LS_KEY_INVITE_LIST, JSON.stringify(list));
-}
-
-function getActiveAccountInviteList(inviter: Encoded.AccountAddress): InvitationInfo[] {
-  return readAllInvitations().filter((x) => x.inviter === inviter);
-}
-
 function prepareInviteLink(secretKey: string): string {
   // eslint-disable-next-line no-restricted-globals
   return `${location.protocol}//${location.host}#${INVITE_CODE_QUERY_KEY}=${normalizeSecretKey(secretKey)}`;
 }
-
-let initialized = false;
 
 export function useInvitation() {
   const navigate = useNavigate();
@@ -58,19 +33,6 @@ export function useInvitation() {
 
   const [invitationCode, setInvitationCode] = useState<string | undefined>();
   const [invitationList, setInvitationList] = useState<InvitationInfo[]>([]);
-
-  // Initialize invitation list from localStorage
-  useEffect(() => {
-    if (!initialized) {
-      initialized = true;
-      try {
-        const storedList = readAllInvitations();
-        setInvitationList(storedList);
-      } catch {
-        // Handle error silently
-      }
-    }
-  }, []);
 
   // Computed equivalent - active account's invitations
   const activeAccountInviteList = useMemo(() => {
@@ -101,7 +63,7 @@ export function useInvitation() {
       amountValue,
     );
 
-    // Add to localStorage and update state
+    // Keep generated invitations in memory for the current session only.
     const now = Date.now();
     const newInvitations: InvitationInfo[] = keyPairs.map(({ secretKey, address }) => ({
       inviter: activeAccount as Encoded.AccountAddress,
@@ -111,15 +73,7 @@ export function useInvitation() {
       date: now,
     }));
 
-    // Update localStorage
-    const currentList = readAllInvitations();
-    newInvitations.forEach((invitation) => {
-      currentList.unshift(invitation);
-    });
-    writeAllInvitations(currentList);
-
-    // Update local state
-    setInvitationList(currentList);
+    setInvitationList((prev) => [...newInvitations, ...prev]);
 
     return keyPairs.map(({ secretKey }) => secretKey);
   }, [activeAccount, getAffiliationTreasury]);
@@ -128,19 +82,12 @@ export function useInvitation() {
   const removeStoredInvite = useCallback((invitee: Encoded.AccountAddress, secretKey?: string) => {
     if (!activeAccount) return;
 
-    const list = readAllInvitations();
-    const filtered = list.filter(
-      (inv) => inv.secretKey !== secretKey || inv.invitee !== invitee,
-    );
-    writeAllInvitations(filtered);
-
-    // Update local state
-    setInvitationList(filtered);
+    setInvitationList((prev) => prev
+      .filter((inv) => inv.secretKey !== secretKey || inv.invitee !== invitee));
   }, [activeAccount]);
 
   // Reset invite code function
   const resetInviteCode = useCallback(() => {
-    localStorage.removeItem(LS_KEY_INVITE_CODE);
     const currentHash = location.hash;
     if (currentHash) {
       navigate({ hash: '' });
@@ -148,19 +95,9 @@ export function useInvitation() {
     setInvitationCode(undefined);
   }, [location.hash, navigate]);
 
-  // Load invitation code from localStorage on mount
+  // Clear current-session invitations when active account disconnects.
   useEffect(() => {
-    const code = localStorage.getItem(LS_KEY_INVITE_CODE);
-    if (code) {
-      setInvitationCode(code);
-    }
-  }, []);
-
-  // Load invitation list when active account changes
-  useEffect(() => {
-    if (activeAccount) {
-      setInvitationList(getActiveAccountInviteList(activeAccount as Encoded.AccountAddress));
-    } else {
+    if (!activeAccount) {
       setInvitationList([]);
     }
   }, [activeAccount]);
@@ -173,7 +110,6 @@ export function useInvitation() {
       const inviteCode = hashParsed.get(INVITE_CODE_QUERY_KEY);
       if (inviteCode) {
         setInvitationCode(inviteCode);
-        localStorage.setItem(LS_KEY_INVITE_CODE, inviteCode);
         navigate('/', { replace: true }); // Navigate to home route
       }
     }

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -44,7 +44,7 @@ export const useWallet = () => {
 
   const resetState = useCallback(() => {
     setAddress(null);
-    setBalance(0);
+    setBalance({});
     setProfile({});
     setCookiesConsent({});
   }, [setAddress, setBalance, setProfile, setCookiesConsent]);

--- a/src/hooks/useWalletConnect.ts
+++ b/src/hooks/useWalletConnect.ts
@@ -3,13 +3,12 @@ import {
   BrowserWindowMessageConnection,
   walletDetector,
 } from '@aeternity/aepp-sdk';
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import {
   useCallback,
   useEffect, useRef,
 } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { WalletInfo } from 'node_modules/@aeternity/aepp-sdk/es/aepp-wallet-communication/rpc/types';
 import {
   CURRENT_NETWORK,
   IS_FRAMED_AEPP,
@@ -20,12 +19,45 @@ import { useAeSdk } from './useAeSdk';
 import { openDeepLink } from '../utils/url';
 import { validateHash } from '../utils/address';
 import type { Wallet, Wallets } from '../utils/types';
+import { recentActivitiesAtom } from '../atoms/dexAtoms';
 import {
+  aex9BalancesAtom,
+  balanceAtom,
   walletInfoAtom,
   walletConnectedAtom,
   connectingWalletAtom,
   scanningForAccountsAtom,
 } from '../atoms/walletAtoms';
+import { liquidityPositionsAtom } from '../features/dex/atoms/positionsAtoms';
+
+function pruneAccountKeyedMap<T>(
+  prev: Record<string, T>,
+  allowed: Set<string>,
+): Record<string, T> {
+  if (allowed.size === 0) return {};
+  const next: Record<string, T> = {};
+  let changed = false;
+  Object.entries(prev).forEach(([k, v]) => {
+    if (allowed.has(k)) next[k] = v;
+    else changed = true;
+  });
+  if (Object.keys(prev).length !== Object.keys(next).length) changed = true;
+  return changed ? next : prev;
+}
+
+/** Jotai may type persisted atoms as possibly async; runtime storage here is sync. */
+function asSyncAccountMap<T>(
+  prev: Record<string, T> | Promise<Record<string, T>>,
+): Record<string, T> {
+  return prev instanceof Promise ? {} : prev;
+}
+
+function clearAccountKeyedMap<T>(
+  prev: Record<string, T> | Promise<Record<string, T>>,
+): Record<string, T> {
+  const syncPrev = asSyncAccountMap(prev);
+  return Object.keys(syncPrev).length === 0 ? syncPrev : {};
+}
 
 export function useWalletConnect() {
   const wallet = useRef<Wallet | undefined>(undefined);
@@ -34,7 +66,7 @@ export function useWalletConnect() {
   const scanPromiseRef = useRef<Promise<Wallet | undefined> | null>(null);
   const reconnectionAttemptedRef = useRef(false);
 
-  const [walletInfo, setWalletInfo] = useAtom<WalletInfo | undefined>(walletInfoAtom);
+  const [walletInfo, setWalletInfo] = useAtom(walletInfoAtom);
   const [scanningForAccounts, setScanningForAccounts] = useAtom(scanningForAccountsAtom);
   const [connectingWallet, setConnectingWallet] = useAtom(connectingWalletAtom);
   const [walletConnected, setWalletConnected] = useAtom(walletConnectedAtom);
@@ -42,8 +74,19 @@ export function useWalletConnect() {
   const location = useLocation();
   const navigate = useNavigate();
   const {
-    aeSdk, scanForAccounts, addStaticAccount, setActiveAccount, setAccounts, activeAccount,
+    aeSdk,
+    scanForAccounts,
+    addStaticAccount,
+    setActiveAccount,
+    setAccounts,
+    activeAccount,
+    accounts,
+    sdkInitialized,
   } = useAeSdk();
+  const setBalanceByAccount = useSetAtom(balanceAtom);
+  const setAex9ByAccount = useSetAtom(aex9BalancesAtom);
+  const setRecentActivitiesByAccount = useSetAtom(recentActivitiesAtom);
+  const setLiquidityPositionsByAccount = useSetAtom(liquidityPositionsAtom);
   const activeAccountRef = useRef(activeAccount);
   const walletInfoRef = useRef(walletInfo);
   const walletConnectedRef = useRef(walletConnected);
@@ -76,6 +119,39 @@ export function useWalletConnect() {
     }
     checkAddressWalletConnection();
   }, [activeAccount, addStaticAccount, location.search, navigate]);
+
+  // Drop per-account caches for addresses no longer in this session (balance, tokens,
+  // DEX activity / LP) so localStorage does not grow without bound across past accounts.
+  useEffect(() => {
+    if (!sdkInitialized) return;
+
+    const allowed = new Set(
+      [...(accounts ?? []), activeAccount].filter(Boolean) as string[],
+    );
+    if (allowed.size === 0) {
+      if (walletInfo || connectingWallet || walletConnected) return;
+      setBalanceByAccount(clearAccountKeyedMap);
+      setAex9ByAccount(clearAccountKeyedMap);
+      setRecentActivitiesByAccount(clearAccountKeyedMap);
+      setLiquidityPositionsByAccount(clearAccountKeyedMap);
+      return;
+    }
+    setBalanceByAccount((prev) => pruneAccountKeyedMap(asSyncAccountMap(prev), allowed));
+    setAex9ByAccount((prev) => pruneAccountKeyedMap(asSyncAccountMap(prev), allowed));
+    setRecentActivitiesByAccount((prev) => pruneAccountKeyedMap(asSyncAccountMap(prev), allowed));
+    setLiquidityPositionsByAccount((prev) => pruneAccountKeyedMap(asSyncAccountMap(prev), allowed));
+  }, [
+    sdkInitialized,
+    activeAccount,
+    accounts,
+    walletInfo,
+    connectingWallet,
+    walletConnected,
+    setBalanceByAccount,
+    setAex9ByAccount,
+    setRecentActivitiesByAccount,
+    setLiquidityPositionsByAccount,
+  ]);
 
   // Cleanup any pending wallet detection when this hook's owner unmounts
   useEffect(() => () => {
@@ -195,6 +271,9 @@ export function useWalletConnect() {
     try {
       localStorage.removeItem('account:activeAccount');
       localStorage.removeItem('wallet:walletInfo');
+      localStorage.removeItem('wallet:balance');
+      localStorage.removeItem('dex:recentActivities');
+      localStorage.removeItem('liquidityPositions');
     } catch {
       // ignore storage errors
     }
@@ -222,6 +301,10 @@ export function useWalletConnect() {
     setWalletConnected(false);
     setActiveAccount(undefined);
     setAccounts([]);
+    setBalanceByAccount({});
+    setAex9ByAccount({});
+    setRecentActivitiesByAccount({});
+    setLiquidityPositionsByAccount({});
     try {
       await aeSdk.disconnectWallet();
     } catch {
@@ -319,7 +402,6 @@ export function useWalletConnect() {
 
         // If we think we're connected but have no accounts, the connection is stale
         if (!hasAccounts) {
-          console.warn('Wallet connection lost, cleaning up state');
           setWalletConnected(false);
           setWalletInfo(undefined);
           wallet.current = undefined;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { HelmetProvider, Helmet } from 'react-helmet-async';
 import { OpenAPI } from './api/generated';
 import { CONFIG } from './config';
+import { evictLegacyAex9BalancesCache } from './utils/jotaiSafeLocalStorage';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 import ToastProvider from './components/ToastProvider';
@@ -31,6 +32,7 @@ const queryClient = new QueryClient({
 });
 
 (async () => {
+  evictLegacyAex9BalancesCache();
   root.render(
     <React.StrictMode>
       <HelmetProvider>

--- a/src/utils/__tests__/jotaiSafeLocalStorage.test.ts
+++ b/src/utils/__tests__/jotaiSafeLocalStorage.test.ts
@@ -1,0 +1,133 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import {
+  createClampedNumberJSONStorage,
+  evictLegacyAex9BalancesCache,
+  isStorageQuotaExceededError,
+  safeLocalStringStorage,
+  type SyncJSONNumberStorage,
+} from '../jotaiSafeLocalStorage';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+});
+
+describe('isStorageQuotaExceededError', () => {
+  it('detects DOMException QuotaExceededError', () => {
+    const e = new DOMException('q', 'QuotaExceededError');
+    expect(isStorageQuotaExceededError(e)).toBe(true);
+  });
+
+  it('detects duck-typed quota errors', () => {
+    expect(isStorageQuotaExceededError({ name: 'QuotaExceededError' })).toBe(true);
+  });
+
+  it('detects legacy quota error shapes', () => {
+    expect(isStorageQuotaExceededError({ name: 'NS_ERROR_DOM_QUOTA_REACHED' })).toBe(true);
+    expect(isStorageQuotaExceededError({ code: 22 })).toBe(true);
+    expect(isStorageQuotaExceededError({ code: 1014 })).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isStorageQuotaExceededError(new Error('nope'))).toBe(false);
+    expect(isStorageQuotaExceededError(null)).toBe(false);
+  });
+});
+
+describe('safeLocalStringStorage', () => {
+  it('evicts the largest known-heavy key and retries once when quota is exceeded', () => {
+    localStorage.setItem('wallet:aex9Balances', 'small');
+    localStorage.setItem('liquidityPositions', 'x'.repeat(200));
+    localStorage.setItem('dex:recentActivities', 'medium');
+
+    const quotaError = new DOMException('full', 'QuotaExceededError');
+    const setSpy = vi.spyOn(Storage.prototype, 'setItem');
+    setSpy
+      .mockImplementationOnce(() => {
+        throw quotaError;
+      })
+      .mockImplementation(function setItem(this: Storage, key: string, value: string) {
+        setSpy.mockRestore();
+        this.setItem(key, value);
+      });
+
+    expect(() => safeLocalStringStorage.setItem('wallet:currency', '"usd"')).not.toThrow();
+    expect(localStorage.getItem('liquidityPositions')).toBeNull();
+    expect(localStorage.getItem('wallet:currency')).toBe('"usd"');
+    expect(localStorage.getItem('wallet:aex9Balances')).toBe('small');
+    expect(localStorage.getItem('dex:recentActivities')).toBe('medium');
+  });
+
+  it('does not throw when quota retry still fails', () => {
+    localStorage.setItem('liquidityPositions', 'x'.repeat(200));
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('full', 'QuotaExceededError');
+    });
+
+    expect(() => safeLocalStringStorage.setItem('wallet:currency', '"usd"')).not.toThrow();
+  });
+});
+
+describe('createClampedNumberJSONStorage', () => {
+  const makeBase = (): SyncJSONNumberStorage & { log: { key: string; value: number }[] } => {
+    const map = new Map<string, number>();
+    const log: { key: string; value: number }[] = [];
+    return {
+      log,
+      getItem(key, initialValue) {
+        if (!map.has(key)) return initialValue;
+        return map.get(key)!;
+      },
+      setItem(key, value) {
+        log.push({ key, value });
+        map.set(key, value);
+      },
+      removeItem(key) {
+        map.delete(key);
+      },
+    };
+  };
+
+  it('clamps on read using initialValue when stored value is out of range', () => {
+    const base = makeBase();
+    base.setItem('k', 999);
+    const storage = createClampedNumberJSONStorage(base, { min: 0, max: 50, writeFallback: 5 });
+    expect(storage.getItem('k', 5)).toBe(50);
+  });
+
+  it('clamps on read when stored value is NaN', () => {
+    const base = makeBase();
+    base.setItem('k', Number.NaN);
+    const storage = createClampedNumberJSONStorage(base, { min: 1, max: 60, writeFallback: 30 });
+    expect(storage.getItem('k', 30)).toBe(30);
+  });
+
+  it('clamps on write and persists coerced value', () => {
+    const base = makeBase();
+    const storage = createClampedNumberJSONStorage(base, { min: 0, max: 50, writeFallback: 1 });
+    storage.setItem('dex:slippage', 200);
+    expect(base.log.at(-1)).toEqual({ key: 'dex:slippage', value: 50 });
+    expect(storage.getItem('dex:slippage', 5)).toBe(50);
+  });
+
+  it('uses writeFallback when write payload is not finite', () => {
+    const base = makeBase();
+    const storage = createClampedNumberJSONStorage(base, { min: 0, max: 50, writeFallback: 7 });
+    storage.setItem('k', Number.NaN);
+    expect(base.log.at(-1)?.value).toBe(7);
+  });
+});
+
+describe('evictLegacyAex9BalancesCache', () => {
+  it('removes legacy wallet:aex9Balances key', () => {
+    const spy = vi.spyOn(Storage.prototype, 'removeItem');
+    evictLegacyAex9BalancesCache();
+    expect(spy).toHaveBeenCalledWith('wallet:aex9Balances');
+  });
+});

--- a/src/utils/jotaiSafeLocalStorage.ts
+++ b/src/utils/jotaiSafeLocalStorage.ts
@@ -1,0 +1,206 @@
+import { createJSONStorage } from 'jotai/utils';
+
+type SyncStringStorage = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+};
+
+export function isStorageQuotaExceededError(e: unknown): boolean {
+  const error = e as { code?: number; name?: string } | null;
+  return (
+    !!error
+    && typeof error === 'object'
+    && (
+      error.name === 'QuotaExceededError'
+      || error.name === 'NS_ERROR_DOM_QUOTA_REACHED'
+      || error.code === 22
+      || error.code === 1014
+    )
+  );
+}
+
+/** Large / rebuildable caches safe to drop before retrying a failed write. */
+const EVICTABLE_KEYS = [
+  'wallet:aex9Balances',
+  'liquidityPositions',
+  'dex:recentActivities',
+] as const;
+
+function getWindowLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getItemLength(raw: Storage, key: string): number {
+  try {
+    return raw.getItem(key)?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+function tryRemoveKey(raw: Storage, key: string): void {
+  try {
+    raw.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+function tryWrite(raw: Storage, key: string, value: string): void {
+  raw.setItem(key, value);
+}
+
+function evictLargestRetrying(raw: Storage, key: string, value: string): boolean {
+  const keysBySize = EVICTABLE_KEYS
+    .map((evictKey) => ({ key: evictKey, length: getItemLength(raw, evictKey) }))
+    .filter(({ length }) => length > 0)
+    .sort((a, b) => b.length - a.length);
+
+  if (keysBySize.length === 0) {
+    try {
+      tryWrite(raw, key, value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return keysBySize.some(({ key: evictKey }) => {
+    tryRemoveKey(raw, evictKey);
+    try {
+      tryWrite(raw, key, value);
+      return true;
+    } catch (e) {
+      return !isStorageQuotaExceededError(e);
+    }
+  });
+}
+
+/**
+ * localStorage adapter that never throws: quota errors trigger one eviction pass
+ * of known-heavy keys, then a single retry; failures are swallowed so UI state can
+ * still update in memory.
+ */
+function createSafeLocalStringStorage(): SyncStringStorage {
+  const raw = getWindowLocalStorage();
+
+  if (!raw) {
+    const mem = new Map<string, string>();
+    return {
+      getItem: (key) => (mem.has(key) ? mem.get(key)! : null),
+      setItem: (key, value) => {
+        mem.set(key, value);
+      },
+      removeItem: (key) => {
+        mem.delete(key);
+      },
+    };
+  }
+
+  return {
+    getItem(key) {
+      try {
+        return raw.getItem(key);
+      } catch {
+        return null;
+      }
+    },
+    setItem(key, value) {
+      try {
+        tryWrite(raw, key, value);
+      } catch (e) {
+        if (!isStorageQuotaExceededError(e)) return;
+        evictLargestRetrying(raw, key, value);
+      }
+    },
+    removeItem(key) {
+      tryRemoveKey(raw, key);
+    },
+  };
+}
+
+let safeStringStorageSingleton: { kind: 'browser' | 'memory'; storage: SyncStringStorage } | null = null;
+
+function getSafeLocalStringStorage(): SyncStringStorage {
+  const hasBrowserStorage = !!getWindowLocalStorage();
+  if (
+    !safeStringStorageSingleton
+    || (hasBrowserStorage && safeStringStorageSingleton.kind === 'memory')
+  ) {
+    safeStringStorageSingleton = {
+      kind: hasBrowserStorage ? 'browser' : 'memory',
+      storage: createSafeLocalStringStorage(),
+    };
+  }
+  return safeStringStorageSingleton.storage;
+}
+
+/**
+ * JSON sync storage for `atomWithStorage` — never throws; quota-safe.
+ * Use for any persisted Jotai state in this app (wallet, DEX, account, etc.).
+ * Cast bridges jotai `createJSONStorage()` typing for arbitrary JSON values.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const safeLocalJSONStorage = createJSONStorage(
+  getSafeLocalStringStorage,
+) as any;
+
+export const safeLocalStringStorage: SyncStringStorage = {
+  getItem(key) {
+    return getSafeLocalStringStorage().getItem(key);
+  },
+  setItem(key, value) {
+    getSafeLocalStringStorage().setItem(key, value);
+  },
+  removeItem(key) {
+    getSafeLocalStringStorage().removeItem(key);
+  },
+};
+
+/** Jotai JSON sync storage shape for numeric atoms (see `atomWithStorage`). */
+export type SyncJSONNumberStorage = {
+  getItem: (key: string, initialValue: number) => number;
+  setItem: (key: string, value: number) => void;
+  removeItem: (key: string) => void;
+};
+
+function clampFiniteNumber(n: unknown, min: number, max: number, fallback: number): number {
+  const x = typeof n === 'number' ? n : Number(n);
+  if (!Number.isFinite(x)) return Math.max(min, Math.min(max, fallback));
+  return Math.max(min, Math.min(max, x));
+}
+
+/**
+ * Wraps JSON storage so persisted numbers stay within bounds on read and write
+ * (guards corrupt or hand-edited localStorage).
+ */
+export function createClampedNumberJSONStorage(
+  base: SyncJSONNumberStorage,
+  options: { min: number; max: number; writeFallback: number },
+): SyncJSONNumberStorage {
+  const { min, max, writeFallback } = options;
+  return {
+    getItem(key, initialValue) {
+      const raw = base.getItem(key, initialValue);
+      return clampFiniteNumber(raw, min, max, initialValue);
+    },
+    setItem(key, value) {
+      const coerced = clampFiniteNumber(value, min, max, writeFallback);
+      base.setItem(key, coerced);
+    },
+    removeItem(key) {
+      base.removeItem(key);
+    },
+  };
+}
+
+/** One-time cleanup: AEX-9 balances are no longer persisted (too large). */
+export function evictLegacyAex9BalancesCache(): void {
+  safeLocalStringStorage.removeItem('wallet:aex9Balances');
+}

--- a/src/views/TxQueue.tsx
+++ b/src/views/TxQueue.tsx
@@ -7,6 +7,7 @@ import {
   TX_QUEUE_RESULT_PREFIX,
   transactionsQueueAtom,
 } from '../atoms/txQueueAtoms';
+import { safeLocalStringStorage } from '../utils/jotaiSafeLocalStorage';
 
 const RELAY_ACK_TIMEOUT_MS = 1500;
 
@@ -88,7 +89,7 @@ const TxQueue = () => {
           ...(status === 'completed' && !signedTx ? { status: 'cancelled' } : {}),
         } as any, // Using any here because query can contain various properties
       }));
-      localStorage.setItem(
+      safeLocalStringStorage.setItem(
         `${TX_QUEUE_RESULT_PREFIX}${id}`,
         JSON.stringify({
           ...query,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches wallet connection state and broad localStorage persistence paths; bugs could cause unexpected cache eviction or lost persisted preferences, but changes are mostly defensive around quota/private-mode failures.
> 
> **Overview**
> Introduces `jotaiSafeLocalStorage` and migrates most `atomWithStorage` usage (wallet, account, currency, DEX, LP positions) to a **quota-safe, non-throwing** storage adapter, including clamped numeric persistence for slippage/deadline settings.
> 
> Stops persisting sensitive/large data locally: invitation secrets and invite codes are now *session-only*, AEX-9 balances are no longer stored (with a startup eviction of legacy `wallet:aex9Balances`), and wallet/DEX per-account caches are now pruned/cleared based on the restored SDK session to prevent unbounded localStorage growth.
> 
> Updates transaction queue persistence and a few direct `localStorage` writes to be failure-tolerant, and adjusts tests accordingly (plus adds unit tests for the new storage helpers and middleware argument parsing in `useInvitations`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e26f8ba262408181b68463f9a8febbcbad2ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->