### PR TITLE
Adjust time windows in post and leaderboard

### DIFF
--- a/src/api/__tests__/backend.listPopularPosts.test.ts
+++ b/src/api/__tests__/backend.listPopularPosts.test.ts
@@ -25,25 +25,24 @@ describe('SuperheroApi.listPopularPosts', () => {
     return call[0] as string;
   };
 
-  it('builds URL with window, page, and limit', async () => {
-    await SuperheroApi.listPopularPosts({ window: '7d', page: 2, limit: 20 });
+  it('builds URL with page and limit', async () => {
+    await SuperheroApi.listPopularPosts({ page: 2, limit: 20 });
     const url = getCalledUrl();
-    expect(url).toContain('window=7d');
+    expect(url).not.toContain('window=');
     expect(url).toContain('page=2');
     expect(url).toContain('limit=20');
   });
 
   it('builds URL without weights when none provided', async () => {
-    await SuperheroApi.listPopularPosts({ window: '24h', page: 1, limit: 10 });
+    await SuperheroApi.listPopularPosts({ page: 1, limit: 10 });
     const url = getCalledUrl();
-    expect(url).toContain('window=24h');
+    expect(url).not.toContain('window=');
     expect(url).not.toContain('comments');
     expect(url).not.toContain('reads');
   });
 
   it('appends weight params to URL', async () => {
     await SuperheroApi.listPopularPosts({
-      window: '24h',
       page: 1,
       limit: 10,
       weights: { comments: 'high', reads: 'low' },
@@ -55,7 +54,6 @@ describe('SuperheroApi.listPopularPosts', () => {
 
   it('appends all weight keys when provided', async () => {
     await SuperheroApi.listPopularPosts({
-      window: 'all',
       page: 1,
       limit: 10,
       weights: {
@@ -82,7 +80,6 @@ describe('SuperheroApi.listPopularPosts', () => {
 
   it('skips undefined weight values', async () => {
     await SuperheroApi.listPopularPosts({
-      window: '24h',
       page: 1,
       limit: 10,
       weights: { comments: 'high' },
@@ -95,25 +92,23 @@ describe('SuperheroApi.listPopularPosts', () => {
 
   it('does not append weights when weights is undefined', async () => {
     await SuperheroApi.listPopularPosts({
-      window: '24h',
       page: 1,
       limit: 10,
       weights: undefined,
     });
     const url = getCalledUrl();
     const params = new URL(url).searchParams;
-    expect([...params.keys()]).toEqual(['window', 'page', 'limit']);
+    expect([...params.keys()]).toEqual(['page', 'limit']);
   });
 
   it('does not append weights when weights is empty object', async () => {
     await SuperheroApi.listPopularPosts({
-      window: '24h',
       page: 1,
       limit: 10,
       weights: {},
     });
     const url = getCalledUrl();
     const params = new URL(url).searchParams;
-    expect([...params.keys()]).toEqual(['window', 'page', 'limit']);
+    expect([...params.keys()]).toEqual(['page', 'limit']);
   });
 });

--- a/src/api/backend.ts
+++ b/src/api/backend.ts
@@ -158,7 +158,6 @@ export const SuperheroApi = {
     }
   },
   listPopularPosts(params: {
-    window?: '24h'|'7d'|'all';
     page?: number;
     limit?: number;
     weights?: Partial<Record<
@@ -167,7 +166,6 @@ export const SuperheroApi = {
     >>;
   } = {}) {
     const qp = new URLSearchParams();
-    if (params.window) qp.set('window', params.window);
     if (params.page != null) qp.set('page', String(params.page));
     if (params.limit != null) qp.set('limit', String(params.limit));
     if (params.weights) {

--- a/src/features/social/components/SortControls.tsx
+++ b/src/features/social/components/SortControls.tsx
@@ -60,8 +60,6 @@ interface SortControlsProps {
   sortBy: string;
   onSortChange: (sortBy: string) => void;
   className?: string;
-  popularWindow?: '24h' | '7d' | 'all';
-  onPopularWindowChange?: (value: '24h' | '7d' | 'all') => void;
   popularFeedEnabled?: boolean;
   popularWeights?: PopularWeights;
   onPopularWeightsChange?: (weights: PopularWeights) => void;
@@ -70,7 +68,7 @@ interface SortControlsProps {
 // Component: Sort Controls
 const SortControls = memo(
   ({
-    sortBy, onSortChange, className = '', popularWindow = '24h', onPopularWindowChange, popularFeedEnabled = true,
+    sortBy, onSortChange, className = '', popularFeedEnabled = true,
     popularWeights = {}, onPopularWeightsChange,
   }: SortControlsProps) => {
     const mobileSortRef = useRef<HTMLDivElement>(null);
@@ -101,10 +99,6 @@ const SortControls = memo(
 
     const getEffectiveWeight = (key: WeightKey): WeightValue => popularWeights[key] ?? 'med';
 
-    const handleWindowChange = (value: '24h' | '7d' | 'all') => {
-      if (onPopularWindowChange) onPopularWindowChange(value);
-    };
-
     const handleWeightChange = (key: WeightKey, value: WeightValue) => {
       if (!onPopularWeightsChange) return;
       const next = { ...popularWeights };
@@ -124,7 +118,6 @@ const SortControls = memo(
 
     const handleResetCustomSettings = () => {
       handleResetWeights();
-      handleWindowChange('24h');
     };
 
     useEffect(() => {
@@ -151,7 +144,7 @@ const SortControls = memo(
         setMobileCustomizeOpen(false);
         setCustomizeOpen(false);
       }
-    }, [sortBy, popularWindow]);
+    }, [sortBy]);
 
     // Show "Latest Feed" title if popular feed is disabled
     if (!popularFeedEnabled) {
@@ -166,20 +159,11 @@ const SortControls = memo(
       );
     }
 
-    // Helper function to get the display title
-    const getPopularLabel = (window: '24h' | '7d' | 'all') => {
-      if (window === '24h') return 'Today';
-      if (window === '7d') return 'This week';
-      return 'All time';
-    };
-
     const getMobileTitle = () => {
       if (sortBy === 'latest') {
         return 'Latest';
       }
-      // Popular feed
-      const timeLabel = getPopularLabel(popularWindow);
-      return `Popular ${timeLabel.toLowerCase()}`;
+      return 'Popular';
     };
 
     const handleMobileSortToggle = (newSort: 'hot' | 'latest') => {
@@ -187,8 +171,7 @@ const SortControls = memo(
       onSortChange(newSort);
     };
 
-    const hasNonDefaultWindow = popularWindow !== '24h';
-    const hasCustomSettings = hasCustomWeights || hasNonDefaultWindow;
+    const hasCustomSettings = hasCustomWeights;
 
     const renderCustomizeControls = (isMobile = false) => (
       <>
@@ -211,36 +194,6 @@ const SortControls = memo(
             )}
           </div>
         )}
-        <div className="px-4 pt-3 pb-2">
-          <span className="text-[10px] font-semibold text-white/50 uppercase tracking-wider">Time Window</span>
-          <div className="mt-1.5 inline-flex items-center gap-0.5 bg-white/5 rounded-full p-0.5 border border-white/10">
-            {(['24h', '7d', 'all'] as const).map((tf) => {
-              const isActive = popularWindow === tf;
-              const label = getPopularLabel(tf);
-              return (
-                <button
-                  type="button"
-                  key={tf}
-                  onClick={(e) => {
-                    if (!isMobile) {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }
-                    handleWindowChange(tf);
-                  }}
-                  className={cn(
-                    'px-3 py-1.5 text-[11px] rounded-full border transition-all duration-200',
-                    isActive
-                      ? 'bg-[#1161FE] text-white border-transparent shadow-sm'
-                      : 'bg-transparent text-white/70 border-transparent hover:text-white/90 hover:bg-white/10',
-                  )}
-                >
-                  {label}
-                </button>
-              );
-            })}
-          </div>
-        </div>
         <div className="px-4 pt-2 pb-1">
           <span className="text-[10px] font-semibold text-white/50 uppercase tracking-wider">Weights</span>
         </div>
@@ -385,7 +338,7 @@ const SortControls = memo(
                             Customize Feed
                           </DialogTitle>
                           <DialogDescription className="mt-1 text-sm text-white/60">
-                            Tune the popular feed ranking and time window.
+                            Tune the popular feed ranking.
                           </DialogDescription>
                         </div>
                         <button

--- a/src/features/social/components/__tests__/SortControls.test.tsx
+++ b/src/features/social/components/__tests__/SortControls.test.tsx
@@ -60,12 +60,10 @@ vi.mock('../../../../components/ui/ae-button', () => ({
 
 describe('SortControls', () => {
   let onSortChange: ReturnType<typeof vi.fn>;
-  let onPopularWindowChange: ReturnType<typeof vi.fn>;
   let onPopularWeightsChange: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     onSortChange = vi.fn();
-    onPopularWindowChange = vi.fn();
     onPopularWeightsChange = vi.fn();
   });
 
@@ -74,8 +72,6 @@ describe('SortControls', () => {
       <SortControls
         sortBy="hot"
         onSortChange={onSortChange}
-        popularWindow="24h"
-        onPopularWindowChange={onPopularWindowChange}
         onPopularWeightsChange={onPopularWeightsChange}
         {...overrides}
       />
@@ -182,20 +178,6 @@ describe('SortControls', () => {
       matchMediaSpy.mockRestore();
     });
 
-    it('contains time window buttons (Today, This week, All time)', () => {
-      renderControls();
-      expect(screen.getAllByText('Today').length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText('This week').length).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText('All time').length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('calls onPopularWindowChange when clicking a time window', () => {
-      renderControls();
-      const weekButtons = screen.getAllByText('This week');
-      fireEvent.click(weekButtons[0]);
-      expect(onPopularWindowChange).toHaveBeenCalledWith('7d');
-    });
-
     it('renders all 8 weight labels', () => {
       renderControls();
       const expectedLabels = [
@@ -243,23 +225,16 @@ describe('SortControls', () => {
       expect(resetButtons.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('renders Reset when non-default window is set', () => {
-      renderControls({ popularWindow: '7d' });
-      const resetButtons = screen.getAllByText('Reset');
-      expect(resetButtons.length).toBeGreaterThanOrEqual(1);
-    });
-
     it('does not render Reset when defaults are active', () => {
-      renderControls({ popularWeights: {}, popularWindow: '24h' });
+      renderControls({ popularWeights: {} });
       expect(screen.queryByText('Reset')).not.toBeInTheDocument();
     });
 
-    it('resets both weights and window on click', () => {
-      renderControls({ popularWeights: { comments: 'high' }, popularWindow: '7d' });
+    it('resets custom weights on click', () => {
+      renderControls({ popularWeights: { comments: 'high' } });
       const resetButtons = screen.getAllByText('Reset');
       fireEvent.click(resetButtons[0]);
       expect(onPopularWeightsChange).toHaveBeenCalledWith({});
-      expect(onPopularWindowChange).toHaveBeenCalledWith('24h');
     });
   });
 

--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -109,7 +109,6 @@ const FeedList = ({
   // Force "latest" if popular feed is disabled, otherwise use URL param or default to "hot"
   const sortBy = !popularFeedEnabled ? 'latest' : (urlSortBy || 'hot');
   const filterBy = urlQuery.get('filterBy') || 'all';
-  const initialWindow = (urlQuery.get('window') as '24h' | '7d' | 'all' | null) || '24h';
   const shouldAutoFocusPost = urlQuery.get('post') === 'new';
 
   // Keep sortByRef in sync with sortBy to avoid stale closures in callbacks
@@ -117,22 +116,8 @@ const FeedList = ({
     sortByRef.current = sortBy;
   }, [sortBy]);
 
-  const [popularWindow, setPopularWindow] = useState<'24h' | '7d' | 'all'>(initialWindow);
   const [popularWeights, setPopularWeights] = useState<PopularWeights>({});
   const trendingInsertSeed = useRef<number>(Math.floor(Math.random() * 0x100000000));
-
-  // Keep popularWindow in sync with URL (e.g., browser back/forward or direct URL edits)
-  useEffect(() => {
-    const params = new URLSearchParams(location.search);
-    const fromUrl = (params.get('window') as '24h' | '7d' | 'all' | null) || '24h';
-    if (fromUrl !== popularWindow) {
-      setPopularWindow(fromUrl);
-      if (sortBy === 'hot') {
-        // Reset cached pages to avoid mixing windows
-        queryClient.removeQueries({ queryKey: ['popular-posts'], exact: false });
-      }
-    }
-  }, [location.search, sortBy, queryClient, popularWindow]);
 
   // Helper to map a token object or websocket payload into a Post-like item
   const mapTokenCreatedToPost = useCallback((payload: any): PostDto => {
@@ -413,10 +398,9 @@ const FeedList = ({
     refetch: refetchPopular,
   } = useInfiniteQuery({
     enabled: sortBy === 'hot',
-    queryKey: ['popular-posts', { limit: 10, window: popularWindow, weights: popularWeights }],
+    queryKey: ['popular-posts', { limit: 10, weights: popularWeights }],
     queryFn: async ({ pageParam = 1 }) => {
       const response = await SuperheroApi.listPopularPosts({
-        window: popularWindow,
         page: pageParam as number,
         limit: 10,
         weights: Object.keys(popularWeights).length > 0 ? popularWeights : undefined,
@@ -531,7 +515,7 @@ const FeedList = ({
     isFetchingNextPage: fetchingMoreLatestForHot,
   } = useInfiniteQuery({
     enabled: sortBy === 'hot' && (popularExhausted || (popularData?.pages ? ((popularData.pages as any[]) || []).flatMap((page: any) => page?.items ?? []).length < 10 : false)),
-    queryKey: ['latest-posts-for-hot', { limit: 10, window: popularWindow, excludeIds: Array.from(popularPostIds).sort().join(',') }],
+    queryKey: ['latest-posts-for-hot', { limit: 10, excludeIds: Array.from(popularPostIds).sort().join(',') }],
     queryFn: async ({ pageParam = 1 }) => {
       // Get fresh popularPostIds from the current popularData
       const currentPopularIds = new Set<string>();
@@ -792,21 +776,13 @@ const FeedList = ({
       }
 
       if (newSortBy === 'hot') {
-        navigate(`/?sortBy=hot&window=${popularWindow}`);
+        navigate('/?sortBy=hot');
       } else {
         navigate(`/?sortBy=${newSortBy}`);
       }
     },
-    [navigate, queryClient, popularWindow, popularFeedEnabled, sortBy],
+    [navigate, queryClient, popularFeedEnabled, sortBy],
   );
-
-  const handlePopularWindowChange = useCallback((w: '24h' | '7d' | 'all') => {
-    setPopularWindow(w);
-    if (sortBy === 'hot') {
-      navigate(`/?sortBy=hot&window=${w}`);
-      queryClient.removeQueries({ queryKey: ['popular-posts'], exact: false });
-    }
-  }, [navigate, sortBy, queryClient]);
 
   const handlePopularWeightsChange = useCallback((weights: PopularWeights) => {
     setPopularWeights(weights);
@@ -1282,8 +1258,6 @@ const FeedList = ({
             sortBy={sortBy}
             onSortChange={handleSortChange}
             className="sticky top-0 z-10 w-full"
-            popularWindow={popularWindow}
-            onPopularWindowChange={handlePopularWindowChange}
             popularFeedEnabled={popularFeedEnabled}
             popularWeights={popularWeights}
             onPopularWeightsChange={handlePopularWeightsChange}
@@ -1293,8 +1267,6 @@ const FeedList = ({
           <SortControls
             sortBy={sortBy}
             onSortChange={handleSortChange}
-            popularWindow={popularWindow}
-            onPopularWindowChange={handlePopularWindowChange}
             popularFeedEnabled={popularFeedEnabled}
             popularWeights={popularWeights}
             onPopularWeightsChange={handlePopularWeightsChange}

--- a/src/features/trending/__tests__/leaderboard-api.test.ts
+++ b/src/features/trending/__tests__/leaderboard-api.test.ts
@@ -59,8 +59,10 @@ describe('leaderboard API', () => {
     });
   });
 
-  it('uses recent time filter params for live leaderboard windows', async () => {
+  it('uses custom start and end dates when provided', async () => {
     const fetchJsonMock = SuperheroApi.fetchJson as any;
+    const startDate = '2026-05-04T10:00:00.000Z';
+    const endDate = '2026-05-04T18:00:00.000Z';
 
     fetchJsonMock.mockResolvedValueOnce({
       items: [{ address: 'ak_live', volume_usd: 800 }],
@@ -78,23 +80,27 @@ describe('leaderboard API', () => {
     });
 
     const result = await fetchLeaderboard({
-      timeframe: '30m',
+      timeframe: '7d',
       metric: 'pnl',
       page: 1,
       limit: 50,
+      startDate,
+      endDate,
     });
 
     expect(fetchJsonMock).toHaveBeenCalledTimes(1);
     const calledPath = fetchJsonMock.mock.calls[0][0] as string;
     const url = new URL(`https://example.com${calledPath}`);
 
-    expect(url.searchParams.get('timePeriod')).toBe('30');
-    expect(url.searchParams.get('timeUnit')).toBe('minutes');
+    expect(url.searchParams.get('startDate')).toBe(startDate);
+    expect(url.searchParams.get('endDate')).toBe(endDate);
     expect(url.searchParams.get('sortBy')).toBe('pnl');
     expect(url.searchParams.get('sortDir')).toBe('DESC');
     expect(url.searchParams.get('limit')).toBe('50');
     expect(url.searchParams.has('window')).toBe(false);
     expect(url.searchParams.has('points')).toBe(false);
+    expect(url.searchParams.has('timePeriod')).toBe(false);
+    expect(url.searchParams.has('timeUnit')).toBe(false);
     expect(result.meta.timeFilter).toEqual({
       value: 30,
       unit: 'minutes',

--- a/src/features/trending/__tests__/trendsSearch.test.ts
+++ b/src/features/trending/__tests__/trendsSearch.test.ts
@@ -291,7 +291,6 @@ describe('trendsSearch api helpers', () => {
       orderDirection: 'DESC',
     });
     expect(SuperheroApi.listPopularPosts).toHaveBeenCalledWith({
-      window: 'all',
       limit: 3,
       page: 1,
     });

--- a/src/features/trending/api/leaderboard.ts
+++ b/src/features/trending/api/leaderboard.ts
@@ -1,10 +1,8 @@
 import { SuperheroApi } from '../../../api/backend';
 
-export type LeaderboardTimeUnit = 'minutes' | 'hours';
-
 export interface LeaderboardTimeFilterMeta {
   value: number;
-  unit: LeaderboardTimeUnit;
+  unit: 'minutes' | 'hours';
   start: string;
   end: string;
 }
@@ -20,8 +18,8 @@ export interface PaginatedResponse<T> {
   };
 }
 
-// Timeframe options: recent windows, 7d, 30d, all-time
-export const LEADERBOARD_TIMEFRAMES = ['30m', '1h', '7d', '30d', 'all'] as const;
+// Timeframe options: preset windows plus optional custom start/end dates.
+export const LEADERBOARD_TIMEFRAMES = ['7d', '30d', 'all'] as const;
 export type LeaderboardTimeframe = (typeof LEADERBOARD_TIMEFRAMES)[number];
 
 // Metrics map directly to /api/accounts/leaderboard?sortBy=<metric>.
@@ -48,23 +46,19 @@ export interface LeaderboardQueryParams {
   page?: number;
   limit?: number;
   sortDir?: 'ASC' | 'DESC';
+  startDate?: string;
+  endDate?: string;
 }
 
 interface LeaderboardApiTimeframeParams {
   window?: string;
   points?: number;
-  timePeriod?: number;
-  timeUnit?: LeaderboardTimeUnit;
 }
 
 function mapTimeframeToApiParams(
   timeframe: LeaderboardTimeframe,
 ): LeaderboardApiTimeframeParams {
   switch (timeframe) {
-    case '30m':
-      return { timePeriod: 30, timeUnit: 'minutes' };
-    case '1h':
-      return { timePeriod: 1, timeUnit: 'hours' };
     case '7d':
       return { window: '7d', points: 7 };
     case '30d':
@@ -79,19 +73,20 @@ export async function fetchLeaderboard(
   params: LeaderboardQueryParams,
 ): Promise<PaginatedResponse<LeaderboardItem>> {
   const {
-    timeframe, metric, page = 1, limit = 18, sortDir,
+    timeframe, metric, page = 1, limit = 18, sortDir, startDate, endDate,
   } = params;
 
   const timeframeParams = mapTimeframeToApiParams(timeframe);
   const resolvedSortDir = sortDir ?? (metric === 'mdd' ? 'ASC' : 'DESC');
 
   const searchParams = new URLSearchParams();
-  if (timeframeParams.window) searchParams.set('window', timeframeParams.window);
-  if (timeframeParams.points) searchParams.set('points', String(timeframeParams.points));
-  if (timeframeParams.timePeriod) {
-    searchParams.set('timePeriod', String(timeframeParams.timePeriod));
+  if (startDate && endDate) {
+    searchParams.set('startDate', startDate);
+    searchParams.set('endDate', endDate);
+  } else {
+    if (timeframeParams.window) searchParams.set('window', timeframeParams.window);
+    if (timeframeParams.points) searchParams.set('points', String(timeframeParams.points));
   }
-  if (timeframeParams.timeUnit) searchParams.set('timeUnit', timeframeParams.timeUnit);
   searchParams.set('sortBy', metric);
   searchParams.set('sortDir', resolvedSortDir);
   searchParams.set('page', String(page));

--- a/src/features/trending/api/trendsSearch.ts
+++ b/src/features/trending/api/trendsSearch.ts
@@ -180,7 +180,6 @@ export async function fetchTrendingTokens(limit: number = DEFAULT_TAB_LIMIT) {
 
 export async function fetchPopularPosts(limit: number = DEFAULT_TAB_LIMIT) {
   return normalizeSection<TrendPostItem>(await SuperheroApi.listPopularPosts({
-    window: 'all',
     limit,
     page: 1,
   }) as PaginatedApiResponse<TrendPostItem>);

--- a/src/features/trending/components/leaderboard/LeaderboardFilters.tsx
+++ b/src/features/trending/components/leaderboard/LeaderboardFilters.tsx
@@ -1,3 +1,5 @@
+import { useRef } from 'react';
+import { Calendar } from 'lucide-react';
 import {
   LEADERBOARD_METRIC_OPTIONS,
   LEADERBOARD_TIMEFRAME_OPTIONS,
@@ -14,18 +16,121 @@ import {
   SelectValue,
 } from '../../../../components/ui/select';
 
+export interface LeaderboardDateRangeInputs {
+  startDate: string;
+  endDate: string;
+}
+
 interface LeaderboardFiltersProps {
   timeframe: LeaderboardTimeframe;
   metric: LeaderboardMetric;
+  dateRange: LeaderboardDateRangeInputs;
   onTimeframeChange: (value: LeaderboardTimeframe) => void;
   onMetricChange: (value: LeaderboardMetric) => void;
+  onDateRangeChange: (value: LeaderboardDateRangeInputs) => void;
 }
+
+const formatDateTimeInput = (value: string) => {
+  const digits = value.replace(/\D/g, '').slice(0, 12);
+  let formatted = digits.slice(0, 2);
+
+  if (digits.length > 2) formatted += `/${digits.slice(2, 4)}`;
+  if (digits.length > 4) formatted += `/${digits.slice(4, 8)}`;
+  if (digits.length > 8) formatted += ` ${digits.slice(8, 10)}`;
+  if (digits.length > 10) formatted += `:${digits.slice(10, 12)}`;
+
+  return formatted;
+};
+
+const DATE_TIME_INPUT_PATTERN = /^(\d{2})\/(\d{2})\/(\d{4}) (\d{2}):(\d{2})$/;
+
+const toPickerValue = (value: string) => {
+  const match = DATE_TIME_INPUT_PATTERN.exec(value);
+  if (!match) return '';
+
+  const [, day, month, year, hour, minute] = match;
+  return `${year}-${month}-${day}T${hour}:${minute}`;
+};
+
+const fromPickerValue = (value: string) => {
+  const [datePart, timePart] = value.split('T');
+  if (!datePart || !timePart) return '';
+
+  const [year, month, day] = datePart.split('-');
+  return `${day}/${month}/${year} ${timePart}`;
+};
+
+interface DateTimeRangeInputProps {
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const DateTimeRangeInput = ({
+  label,
+  placeholder,
+  value,
+  onChange,
+}: DateTimeRangeInputProps) => {
+  const pickerRef = useRef<HTMLInputElement>(null);
+
+  const openPicker = () => {
+    const picker = pickerRef.current;
+    if (!picker) return;
+
+    picker.focus();
+    if (typeof picker.showPicker === 'function') {
+      picker.showPicker();
+      return;
+    }
+
+    picker.click();
+  };
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={openPicker}
+        className="absolute left-2.5 top-2.5 z-10 flex h-5 w-5 items-center justify-center rounded-md text-white/35 transition-colors hover:bg-white/10 hover:text-white/70 focus:outline-none focus:ring-1 focus:ring-[#1161FE]/60"
+        aria-label={`Choose ${label.toLowerCase()} from calendar`}
+      >
+        <Calendar
+          aria-hidden="true"
+          className="h-3.5 w-3.5"
+        />
+      </button>
+      <input
+        type="text"
+        inputMode="numeric"
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onChange(formatDateTimeInput(event.target.value))}
+        maxLength={16}
+        className="w-full h-10 rounded-xl border border-white/10 bg-white/[0.03] pl-9 pr-3 text-xs text-white placeholder:text-white/25 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] outline-none backdrop-blur-[10px] transition-all duration-300 hover:bg-white/[0.06] focus:border-[#1161FE] focus:bg-white/[0.06] focus:shadow-[0_0_0_3px_rgba(17,97,254,0.18)]"
+        aria-label={`${label} in dd/mm/yyyy hh:mm format`}
+      />
+      <input
+        ref={pickerRef}
+        type="datetime-local"
+        value={toPickerValue(value)}
+        onChange={(event) => onChange(fromPickerValue(event.target.value))}
+        className="absolute left-3 top-2.5 h-px w-px opacity-0"
+        tabIndex={-1}
+        aria-hidden="true"
+      />
+    </div>
+  );
+};
 
 export const LeaderboardFilters = ({
   timeframe,
   metric,
+  dateRange,
   onTimeframeChange,
   onMetricChange,
+  onDateRangeChange,
 }: LeaderboardFiltersProps) => (
   <div className="flex flex-col md:flex-row w-full gap-3 md:items-center">
     {/* Timeframe segmented control */}
@@ -35,7 +140,7 @@ export const LeaderboardFilters = ({
           Timeframe
         </span>
       </div>
-      <div className="grid w-full grid-cols-5 gap-2">
+      <div className="grid w-full grid-cols-3 gap-2">
         {LEADERBOARD_TIMEFRAME_OPTIONS.map((option) => {
           const isActive = option.value === timeframe;
           return (
@@ -53,6 +158,38 @@ export const LeaderboardFilters = ({
             </button>
           );
         })}
+      </div>
+    </div>
+
+    {/* Custom date range */}
+    <div className="w-full md:w-auto md:min-w-[460px]">
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <span className="text-[11px] uppercase tracking-wide text-white/40">
+          Custom range
+        </span>
+        <span className="text-[10px] text-white/30">
+          dd/mm/yyyy hh:mm
+        </span>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <DateTimeRangeInput
+          label="Leaderboard start date and time"
+          placeholder="Start: dd/mm/yyyy hh:mm"
+          value={dateRange.startDate}
+          onChange={(startDate) => onDateRangeChange({
+            ...dateRange,
+            startDate,
+          })}
+        />
+        <DateTimeRangeInput
+          label="Leaderboard end date and time"
+          placeholder="End: dd/mm/yyyy hh:mm"
+          value={dateRange.endDate}
+          onChange={(endDate) => onDateRangeChange({
+            ...dateRange,
+            endDate,
+          })}
+        />
       </div>
     </div>
 

--- a/src/features/trending/components/tabs/TokenFeedTab.tsx
+++ b/src/features/trending/components/tabs/TokenFeedTab.tsx
@@ -10,8 +10,6 @@ type TokenFeedTabProps = {
   showComposer: boolean;
   holdersOnly: boolean;
   setHoldersOnly: (next: boolean) => void;
-  popularWindow: '24h' | '7d' | 'all';
-  setPopularWindow: (next: '24h' | '7d' | 'all') => void;
   showTradePanels: boolean;
   setShowTradePanels: (next: boolean | ((prev: boolean) => boolean)) => void;
 };
@@ -22,8 +20,6 @@ export const TokenFeedTab = ({
   showComposer,
   holdersOnly: _holdersOnly,
   setHoldersOnly,
-  popularWindow,
-  setPopularWindow,
   showTradePanels,
   setShowTradePanels,
 }: TokenFeedTabProps) => {
@@ -61,28 +57,6 @@ export const TokenFeedTab = ({
               </button>
             </div>
 
-            {holdersOnly && (
-              <div className="flex items-center gap-1">
-                {(['24h', '7d', 'all'] as const).map((window) => (
-                  <button
-                    key={window}
-                    type="button"
-                    onClick={() => setPopularWindow(window)}
-                    className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${popularWindow === window
-                      ? 'bg-white/15 text-white'
-                      : 'bg-white/5 text-white/60 hover:text-white'
-                    }`}
-                    aria-pressed={popularWindow === window}
-                  >
-                    {(() => {
-                      if (window === '24h') return '24h';
-                      if (window === '7d') return '7d';
-                      return 'All';
-                    })()}
-                  </button>
-                ))}
-              </div>
-            )}
           </div>
         </div>
       )}

--- a/src/features/trending/constants/leaderboard.ts
+++ b/src/features/trending/constants/leaderboard.ts
@@ -7,8 +7,6 @@ export const LEADERBOARD_TIMEFRAME_OPTIONS: {
   label: string;
   value: LeaderboardTimeframe;
 }[] = [
-  { label: '30M', value: '30m' },
-  { label: '1H', value: '1h' },
   { label: '7D', value: '7d' },
   { label: '30D', value: '30d' },
   { label: 'All', value: 'all' },

--- a/src/features/trending/views/LeaderboardView.tsx
+++ b/src/features/trending/views/LeaderboardView.tsx
@@ -6,6 +6,7 @@ import {
   LeaderboardFilters,
   LeaderboardCard,
   LeaderboardSkeleton,
+  type LeaderboardDateRangeInputs,
 } from '../components';
 import {
   fetchLeaderboard,
@@ -16,34 +17,84 @@ import {
 } from '../api/leaderboard';
 import {
   LEADERBOARD_TIMEFRAME_OPTIONS,
-  LEADERBOARD_METRIC_OPTIONS,
 } from '../constants/leaderboard';
 
 const DEFAULT_LEADERBOARD_PAGE_SIZE = 15;
-const RECENT_LEADERBOARD_PAGE_SIZE = 50;
+const DATE_TIME_INPUT_LENGTH = 16;
+const DATE_TIME_INPUT_PATTERN = /^(\d{2})\/(\d{2})\/(\d{4}) (\d{2}):(\d{2})$/;
 
-const isRecentTimeframe = (timeframe: LeaderboardTimeframe) => (
-  timeframe === '30m' || timeframe === '1h'
-);
+const parseDateTimeInput = (value: string) => {
+  if (!value) return null;
+
+  const match = DATE_TIME_INPUT_PATTERN.exec(value);
+  if (!match) return null;
+
+  const [, dayValue, monthValue, yearValue, hourValue, minuteValue] = match;
+  const day = Number(dayValue);
+  const month = Number(monthValue);
+  const year = Number(yearValue);
+  const hour = Number(hourValue);
+  const minute = Number(minuteValue);
+  const date = new Date(
+    year,
+    month - 1,
+    day,
+    hour,
+    minute,
+    0,
+    0,
+  );
+
+  if (
+    date.getFullYear() !== year
+    || date.getMonth() !== month - 1
+    || date.getDate() !== day
+    || date.getHours() !== hour
+    || date.getMinutes() !== minute
+  ) {
+    return null;
+  }
+
+  return date;
+};
 
 const LeaderboardView = () => {
   const { t } = useTranslation('trending');
   const [timeframe, setTimeframe] = useState<LeaderboardTimeframe>('7d');
   const [metric, setMetric] = useState<LeaderboardMetric>('pnl');
+  const [dateRange, setDateRange] = useState<LeaderboardDateRangeInputs>({
+    startDate: '',
+    endDate: '',
+  });
   const [page, setPage] = useState(1);
-  const leaderboardPageSize = isRecentTimeframe(timeframe)
-    ? RECENT_LEADERBOARD_PAGE_SIZE
-    : DEFAULT_LEADERBOARD_PAGE_SIZE;
+  const leaderboardPageSize = DEFAULT_LEADERBOARD_PAGE_SIZE;
+  const parsedStartDate = parseDateTimeInput(dateRange.startDate);
+  const parsedEndDate = parseDateTimeInput(dateRange.endDate);
+  const hasCustomDateInput = Boolean(dateRange.startDate || dateRange.endDate);
+  const hasInvalidDateFormat = Boolean(
+    (dateRange.startDate.length === DATE_TIME_INPUT_LENGTH && !parsedStartDate)
+      || (dateRange.endDate.length === DATE_TIME_INPUT_LENGTH && !parsedEndDate),
+  );
+  const isCustomDateRangeComplete = Boolean(parsedStartDate && parsedEndDate);
+  const isDateRangeInvalid = Boolean(
+    hasInvalidDateFormat
+      || (
+        parsedStartDate
+        && parsedEndDate
+        && parsedStartDate.getTime() > parsedEndDate.getTime()
+      ),
+  );
+  const customDateRange = isCustomDateRangeComplete && !isDateRangeInvalid
+    ? {
+      startDate: parsedStartDate!.toISOString(),
+      endDate: parsedEndDate!.toISOString(),
+    }
+    : null;
 
   const timeframeOption = LEADERBOARD_TIMEFRAME_OPTIONS.find(
     (option) => option.value === timeframe,
   );
-  const timeframeLabel = timeframeOption?.label ?? '7D';
-  const metricOption = LEADERBOARD_METRIC_OPTIONS.find(
-    (option) => option.value === metric,
-  );
-  const metricLabel = metricOption?.label ?? 'PnL';
-
+  const timeframeLabel = customDateRange ? 'Custom' : timeframeOption?.label ?? '7D';
   const {
     data,
     isLoading,
@@ -51,14 +102,25 @@ const LeaderboardView = () => {
     refetch,
     isFetching,
   } = useQuery<PaginatedResponse<LeaderboardItem>>({
-    queryKey: ['leaderboard', timeframe, metric, page, leaderboardPageSize],
+    queryKey: [
+      'leaderboard',
+      timeframe,
+      metric,
+      page,
+      leaderboardPageSize,
+      customDateRange?.startDate,
+      customDateRange?.endDate,
+    ],
     queryFn: () => fetchLeaderboard({
       timeframe,
       metric,
       page,
       limit: leaderboardPageSize,
       sortDir: metric === 'mdd' ? 'ASC' : 'DESC',
+      startDate: customDateRange?.startDate,
+      endDate: customDateRange?.endDate,
     }),
+    enabled: !isDateRangeInvalid,
     staleTime: 60 * 1000, // cache results per window/metric for 1 minute
     gcTime: 5 * 60 * 1000, // keep cached windows around for 5 minutes
   });
@@ -69,11 +131,17 @@ const LeaderboardView = () => {
 
   const handleTimeframeChange = (value: LeaderboardTimeframe) => {
     setTimeframe(value);
+    setDateRange({ startDate: '', endDate: '' });
     setPage(1);
   };
 
   const handleMetricChange = (value: LeaderboardMetric) => {
     setMetric(value);
+    setPage(1);
+  };
+
+  const handleDateRangeChange = (value: LeaderboardDateRangeInputs) => {
+    setDateRange(value);
     setPage(1);
   };
 
@@ -103,11 +171,27 @@ const LeaderboardView = () => {
             <LeaderboardFilters
               timeframe={timeframe}
               metric={metric}
+              dateRange={dateRange}
               onTimeframeChange={handleTimeframeChange}
               onMetricChange={handleMetricChange}
+              onDateRangeChange={handleDateRangeChange}
             />
           </div>
         </div>
+
+        {isDateRangeInvalid && (
+          <div className="bg-amber-500/10 border border-amber-500/40 text-amber-100 text-sm rounded-2xl px-4 py-3">
+            {hasInvalidDateFormat
+              ? 'Use valid dates and times in dd/mm/yyyy hh:mm format.'
+              : 'Start date must be before end date.'}
+          </div>
+        )}
+
+        {hasCustomDateInput && !isCustomDateRangeComplete && !isDateRangeInvalid && (
+          <div className="bg-white/[0.03] border border-white/10 text-white/60 text-sm rounded-2xl px-4 py-3">
+            Enter both start and end dates to apply a custom leaderboard range.
+          </div>
+        )}
 
         {/* Error state */}
         {isError && (
@@ -167,7 +251,6 @@ const LeaderboardView = () => {
                     rank={(currentPage - 1) * leaderboardPageSize + index + 1}
                     item={item}
                     timeframeLabel={timeframeLabel}
-                    metricLabel={metricLabel}
                   />
                 ))}
               </div>

--- a/src/features/trending/views/LeaderboardView.tsx
+++ b/src/features/trending/views/LeaderboardView.tsx
@@ -207,99 +207,100 @@ const LeaderboardView = () => {
           </div>
         )}
 
-        {/* Content */}
-        <div className="bg-white/[0.02] border border-white/10 backdrop-blur-[20px] rounded-[24px] p-4 sm:p-6">
-          {/* Loading */}
-          {isLoading && (
-            <>
-              <div className="hidden md:block">
-                <LeaderboardSkeleton rows={8} variant="table" />
-              </div>
-              <div className="md:hidden">
-                <LeaderboardSkeleton rows={6} variant="card" />
-              </div>
-            </>
-          )}
-
-          {/* Empty state */}
-          {!isLoading && !isFetching && items.length === 0 && !isError && (
-            <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
-              <h2 className="text-base font-semibold text-white">
-                {t('noTopTraders')}
-              </h2>
-              <p className="text-sm text-white/70 max-w-md">
-                {t('leaderboardHighlights')}
-              </p>
-              <ul className="text-xs text-white/50 space-y-1 max-w-md list-disc list-inside text-left sm:text-center sm:list-none sm:space-y-0 sm:space-x-3 sm:flex sm:justify-center sm:flex-wrap">
-                <li>{t('leaderboardTip1')}</li>
-                <li>{t('leaderboardTip2')}</li>
-                <li>{t('leaderboardTip3')}</li>
-              </ul>
-              <p className="text-xs text-white/40 mt-1">
-                {t('tryDifferentTimeframe')}
-              </p>
-            </div>
-          )}
-
-          {/* Data */}
-          {items.length > 0 && (
-            <>
-              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-4">
-                {items.map((item, index) => (
-                  <LeaderboardCard
-                    key={item.address}
-                    rank={(currentPage - 1) * leaderboardPageSize + index + 1}
-                    item={item}
-                    timeframeLabel={timeframeLabel}
-                  />
-                ))}
-              </div>
-
-              {/* Pagination */}
-              <div className="flex flex-col sm:flex-row items-center justify-between gap-3 mt-6">
-                <div className="text-xs text-white/60">
-                  Page
-                  {' '}
-                  <span className="font-semibold text-white">
-                    {currentPage}
-                  </span>
-                  {' '}
-                  of
-                  {' '}
-                  <span className="font-semibold text-white">
-                    {totalPages}
-                  </span>
+        {!isError && (
+          <div className="bg-white/[0.02] border border-white/10 backdrop-blur-[20px] rounded-[24px] p-4 sm:p-6">
+            {/* Loading */}
+            {isLoading && (
+              <>
+                <div className="hidden md:block">
+                  <LeaderboardSkeleton rows={8} variant="table" />
                 </div>
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    disabled={currentPage <= 1 || isFetching}
-                    onClick={() => setPage((p) => Math.max(1, p - 1))}
-                    className={`px-3 py-2 rounded-lg text-xs font-medium border border-white/15 transition-colors ${
-                      currentPage <= 1 || isFetching
-                        ? 'bg-white/5 text-white/30 cursor-not-allowed'
-                        : 'bg-white/5 text-white/80 hover:bg-white/10'
-                    }`}
-                  >
-                    Previous
-                  </button>
-                  <button
-                    type="button"
-                    disabled={currentPage >= totalPages || isFetching}
-                    onClick={() => setPage((p) => (p < totalPages ? p + 1 : p))}
-                    className={`px-3 py-2 rounded-lg text-xs font-medium border border-white/15 transition-colors ${
-                      currentPage >= totalPages || isFetching
-                        ? 'bg-white/5 text-white/30 cursor-not-allowed'
-                        : 'bg-white/5 text-white/80 hover:bg-white/10'
-                    }`}
-                  >
-                    Next
-                  </button>
+                <div className="md:hidden">
+                  <LeaderboardSkeleton rows={6} variant="card" />
                 </div>
+              </>
+            )}
+
+            {/* Empty state */}
+            {!isLoading && !isFetching && items.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-16 text-center gap-3">
+                <h2 className="text-base font-semibold text-white">
+                  {t('noTopTraders')}
+                </h2>
+                <p className="text-sm text-white/70 max-w-md">
+                  {t('leaderboardHighlights')}
+                </p>
+                <ul className="text-xs text-white/50 space-y-1 max-w-md list-disc list-inside text-left sm:text-center sm:list-none sm:space-y-0 sm:space-x-3 sm:flex sm:justify-center sm:flex-wrap">
+                  <li>{t('leaderboardTip1')}</li>
+                  <li>{t('leaderboardTip2')}</li>
+                  <li>{t('leaderboardTip3')}</li>
+                </ul>
+                <p className="text-xs text-white/40 mt-1">
+                  {t('tryDifferentTimeframe')}
+                </p>
               </div>
-            </>
-          )}
-        </div>
+            )}
+
+            {/* Data */}
+            {items.length > 0 && (
+              <>
+                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3 sm:gap-4">
+                  {items.map((item, index) => (
+                    <LeaderboardCard
+                      key={item.address}
+                      rank={(currentPage - 1) * leaderboardPageSize + index + 1}
+                      item={item}
+                      timeframeLabel={timeframeLabel}
+                    />
+                  ))}
+                </div>
+
+                {/* Pagination */}
+                <div className="flex flex-col sm:flex-row items-center justify-between gap-3 mt-6">
+                  <div className="text-xs text-white/60">
+                    Page
+                    {' '}
+                    <span className="font-semibold text-white">
+                      {currentPage}
+                    </span>
+                    {' '}
+                    of
+                    {' '}
+                    <span className="font-semibold text-white">
+                      {totalPages}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      disabled={currentPage <= 1 || isFetching}
+                      onClick={() => setPage((p) => Math.max(1, p - 1))}
+                      className={`px-3 py-2 rounded-lg text-xs font-medium border border-white/15 transition-colors ${
+                        currentPage <= 1 || isFetching
+                          ? 'bg-white/5 text-white/30 cursor-not-allowed'
+                          : 'bg-white/5 text-white/80 hover:bg-white/10'
+                      }`}
+                    >
+                      Previous
+                    </button>
+                    <button
+                      type="button"
+                      disabled={currentPage >= totalPages || isFetching}
+                      onClick={() => setPage((p) => (p < totalPages ? p + 1 : p))}
+                      className={`px-3 py-2 rounded-lg text-xs font-medium border border-white/15 transition-colors ${
+                        currentPage >= totalPages || isFetching
+                          ? 'bg-white/5 text-white/30 cursor-not-allowed'
+                          : 'bg-white/5 text-white/80 hover:bg-white/10'
+                      }`}
+                    >
+                      Next
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/features/trending/views/TokenSaleDetails.tsx
+++ b/src/features/trending/views/TokenSaleDetails.tsx
@@ -107,7 +107,6 @@ const TokenSaleDetails = () => {
   });
   const { ownedTokens } = useOwnedTokens();
   const [holdersOnly, setHoldersOnly] = useState(true);
-  const [popularWindow, setPopularWindow] = useState<'24h' | '7d' | 'all'>('24h');
   const [showComposer, setShowComposer] = useState(false);
   const tradePrefillAppliedRef = useRef(false);
   const tabAutoScrollInitRef = useRef(false);
@@ -692,8 +691,6 @@ const TokenSaleDetails = () => {
                 showComposer={showComposer}
                 holdersOnly={holdersOnly}
                 setHoldersOnly={setHoldersOnly}
-                popularWindow={popularWindow}
-                setPopularWindow={setPopularWindow}
                 showTradePanels={showTradePanels}
                 setShowTradePanels={setShowTradePanels}
               />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes query parameters and cache keys for the popular feed and leaderboard, which can alter ranking results and pagination/caching behavior. Adds new date parsing/validation paths that could block queries or send unintended ranges if edge cases slip through.
> 
> **Overview**
> **Popular posts no longer support a selectable time window.** `SuperheroApi.listPopularPosts` drops the `window` param entirely, and callers/tests are updated so popular feed requests and React Query cache keys no longer vary by `window` (including homepage feed and trending search fallbacks).
> 
> **Leaderboard filtering shifts from “recent” presets to presets + optional custom ranges.** The 30m/1h timeframe options are removed, `fetchLeaderboard` can now send `startDate`/`endDate` (and omits `window`/`points` when used), and the UI adds custom date/time inputs with validation and disables querying on invalid ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d10be32e122ca5932df0d4139e9199b542f88221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->