### PR TITLE
refactor: align right the share button in post item

### DIFF
--- a/src/features/social/components/ReplyToFeedItem.tsx
+++ b/src/features/social/components/ReplyToFeedItem.tsx
@@ -280,6 +280,9 @@ const ReplyToFeedItem = memo(({
           />
         </div>
       )}
+      <div className="absolute bottom-4 right-2 md:bottom-5 md:right-5 z-10">
+        <SharePopover postId={item.id} postSlug={(item as any)?.slug} />
+      </div>
       {/* Main row: avatar left, content right */}
       <div className="flex gap-3 items-start">
         <div className="flex-shrink-0 pt-0.5">
@@ -422,7 +425,7 @@ const ReplyToFeedItem = memo(({
           )}
 
           {/* Actions */}
-          <div className="mt-3 flex items-center justify-between">
+          <div className="mt-3 flex items-center pr-10 md:pr-12">
             <div className="inline-flex items-center gap-5 text-[13px] text-white/70">
               <button
                 type="button"
@@ -445,7 +448,6 @@ const ReplyToFeedItem = memo(({
               </button>
               <PostTipButton toAddress={authorAddress} postId={String(postId)} />
             </div>
-            <SharePopover postId={item.id} postSlug={(item as any)?.slug} />
           </div>
 
           {/* Nested replies for this item */}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only layout tweak that repositions `SharePopover` and adjusts padding to avoid overlap; no data/auth logic changes.
> 
> **Overview**
> Moves the post `SharePopover` out of the actions row and pins it to the bottom-right of `ReplyToFeedItem` via absolute positioning.
> 
> Updates the actions container styling (`pr-10 md:pr-12`, removes `justify-between`) to preserve spacing and prevent the new fixed share button from overlapping other controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ede253e93f5984ba65e6bb0f6319d1295d38b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->