### PR TITLE
feat: add ROI explanation in the leaderboard

### DIFF
--- a/src/features/trending/views/LeaderboardView.tsx
+++ b/src/features/trending/views/LeaderboardView.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { AlertCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { Head } from '../../../seo/Head';
@@ -192,6 +193,16 @@ const LeaderboardView = () => {
             Enter both start and end dates to apply a custom leaderboard range.
           </div>
         )}
+
+        <div className="flex items-start gap-3 rounded-2xl border border-sky-400/20 bg-sky-500/10 px-4 py-3 text-sm text-sky-50">
+          <AlertCircle
+            aria-hidden="true"
+            className="mt-0.5 h-4 w-4 shrink-0 text-sky-200"
+          />
+          <p className="leading-relaxed text-sky-50/90">
+            {t('leaderboardRoiExplanation')}
+          </p>
+        </div>
 
         {/* Error state */}
         {isError && (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -587,6 +587,7 @@
     "leaderboardTip1": "Trade trend tokens regularly to build up your volume.",
     "leaderboardTip2": "Keep your PnL and ROI positive over time.",
     "leaderboardTip3": "Own and hold trending tokens to grow your AUM.",
+    "leaderboardRoiExplanation": "ROI shows how efficiently a user turned capital into profit during the selected leaderboard period. For most leaderboard windows, it is calculated as PNL divided by the portfolio value at the start of the period, shown as a percentage.",
     "retry": "Retry",
     "noTopTraders": "No top traders for this view yet",
     "leaderboardHighlights": "The leaderboard highlights wallets with strong on-chain trading performance over the selected timeframe.",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a static informational callout and a new i18n string; no data fetching or business logic is modified.
> 
> **Overview**
> Adds a new informational callout to the trading leaderboard explaining how **ROI** is calculated, rendered as a styled banner with an `AlertCircle` icon in `LeaderboardView`.
> 
> Introduces the new `trending.leaderboardRoiExplanation` translation string in `en.json` and wires it into the view via `t()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf379b082482f1eff577ec6cf8c7b0ffd4b2666e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->