### PR TITLE
Release

### DIFF
--- a/src/components/layout/RightRail.tsx
+++ b/src/components/layout/RightRail.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Gem } from 'lucide-react';
 import WalletOverviewCard from '@/components/wallet/WalletOverviewCard';
 import FeedRailSearch from '@/components/layout/FeedRailSearch';
 import { useCurrencies } from '@/hooks/useCurrencies';
@@ -187,6 +188,34 @@ const RightRail = ({
         <BuyAeWidget embedded />
       </div>
       */}
+
+      {/* Buy AE promo */}
+      <div className="bg-white/[0.03] border border-white/10 rounded-[20px] p-4 shadow-none">
+        <div className="flex items-center gap-2 mb-2">
+          <Gem className="h-[1.1rem] w-[1.1rem] text-cyan-300 shrink-0" aria-hidden />
+          <h4 className="m-0 text-white text-base font-bold">
+            {t('buyAeRail.title')}
+          </h4>
+        </div>
+        <p className="text-[11px] text-[var(--light-font-color)] mb-3">
+          {t('buyAeRail.description')}
+        </p>
+        <a
+          href="https://www.gate.io/trade/AE_USDT"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block w-full bg-gradient-to-r from-emerald-400 to-cyan-500 text-black border-none rounded-xl py-2.5 px-3 text-xs font-semibold cursor-pointer transition-all duration-200 hover:-translate-y-0.5 no-underline text-center"
+        >
+          {t('buyAeRail.gateButton')}
+        </a>
+        <button
+          type="button"
+          className="mt-2 w-full bg-transparent border-0 text-xs font-semibold text-cyan-200 cursor-pointer hover:text-white transition-colors"
+          onClick={() => navigate('/buy-ae')}
+        >
+          {t('buyAeRail.moreWays')}
+        </button>
+      </div>
 
       {/* Trading Leaderboard promo */}
       <div className="bg-white/[0.03] border border-white/10 rounded-[20px] p-4 shadow-none mb-4">

--- a/src/features/trending/views/LeaderboardView.tsx
+++ b/src/features/trending/views/LeaderboardView.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { AlertCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { Head } from '../../../seo/Head';
@@ -192,6 +193,16 @@ const LeaderboardView = () => {
             Enter both start and end dates to apply a custom leaderboard range.
           </div>
         )}
+
+        <div className="flex items-start gap-3 rounded-2xl border border-sky-400/20 bg-sky-500/10 px-4 py-3 text-sm text-sky-50">
+          <AlertCircle
+            aria-hidden="true"
+            className="mt-0.5 h-4 w-4 shrink-0 text-sky-200"
+          />
+          <p className="leading-relaxed text-sky-50/90">
+            {t('leaderboardRoiExplanation')}
+          </p>
+        </div>
 
         {/* Error state */}
         {isError && (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -155,6 +155,12 @@
       "liveTrending": "Live Trending",
       "searchForTag": "Search for {{tag}} (Score: {{score}})"
     },
+    "buyAeRail": {
+      "title": "Buy AE",
+      "description": "Need AE for fees, tips, and trend tokens? Start with Gate.io or compare more ways.",
+      "gateButton": "Buy AE on Gate.io",
+      "moreWays": "Explore more ways"
+    },
     "tips": {
       "hardwareWallets": "Use hardware wallets for large amounts",
       "hardwareWalletsExpanded": "Hardware wallets like Ledger or Trezor provide the highest security for storing significant amounts of cryptocurrency.",
@@ -988,7 +994,40 @@
     "qGlossaryLi2": "Sale address: the contract that mints/burns tokens on the curve.",
     "qGlossaryLi3": "DAO: on‑chain treasury + governance for a token community.",
     "qGlossaryLi4": "Tx hash: the transaction ID; view in explorers to verify."
+  },
+  "buyAe": {
+    "pageTitle": "Buy AE – Superhero",
+    "pageDescription": "Learn what AE is and the main ways to get AE for Superhero.",
+    "eyebrow": "Get AE",
+    "heroTitle": "Buy or earn AE for Superhero",
+    "heroDescription": "AE is the native coin of the aeternity blockchain. You use it to pay network fees, tip, trade trend tokens, and participate in on-chain activity on Superhero.",
+    "badgeBuy": "Buy",
+    "badgeBridge": "Bridge",
+    "badgeEarn": "Earn",
+    "onThisPage": "On this page",
+    "tip": "Availability and pairs can change. Always confirm details with the provider before sending funds.",
+    "whatIsAeTitle": "What is AE?",
+    "whatIsAeDescription": "AE powers the aeternity blockchain. It is used for transaction fees, smart-contract interactions, tipping, and buying or selling community tokens on Superhero.",
+    "waysTitle": "Ways to get AE",
+    "gateTitle": "Swap or Buy on Gate.io",
+    "gateDescription": "Gate.io provides an AE/USDT market and is one of the main centralized exchange options for AE liquidity.",
+    "gateAction": "Open Gate.io AE/USDT",
+    "changellyTitle": "Swap or Buy on Changelly",
+    "changellyDescription": "Changelly provides many AE pairs and is one of the best options for AE liquidity.",
+    "changellyAction":"Open Changelly",
+    "bridgeTitle": "Bridge or swap from other assets",
+    "bridgeDescription": "If you already hold crypto, use available Superhero DeFi tools or supported bridges and swaps to move value toward AE when routes are available.",
+    "bridgeAction": "Open Superhero DeFi",
+    "referTitle": "Use Refer & Earn",
+    "referDescription": "Superhero invitations can help grow the network and unlock rewards when invitees become active. Use the invite page to create links and track rewards.",
+    "referAction": "Open Refer & Earn",
+    "xEarnTitle": "Earn by posting on X",
+    "xEarnDescription": "A future earning path will reward activity from posting on X (formerly Twitter). This option is coming soon.",
+    "comingSoon": "Coming soon",
+    "safetyTitle": "Before you buy",
+    "safetyLi1": "Confirm the token, network, deposit address, withdrawal fees, and minimum withdrawal amount.",
+    "safetyLi2": "Start with a small test transaction before moving larger amounts.",
+    "safetyLi3": "Keep custody in your own wallet when possible and never share private keys or seed phrases."
   }
 }
-
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -587,6 +587,7 @@
     "leaderboardTip1": "Trade trend tokens regularly to build up your volume.",
     "leaderboardTip2": "Keep your PnL and ROI positive over time.",
     "leaderboardTip3": "Own and hold trending tokens to grow your AUM.",
+    "leaderboardRoiExplanation": "ROI shows how efficiently a user turned capital into profit during the selected leaderboard period. For most leaderboard windows, it is calculated as PNL divided by the portfolio value at the start of the period, shown as a percentage.",
     "retry": "Retry",
     "noTopTraders": "No top traders for this view yet",
     "leaderboardHighlights": "The leaderboard highlights wallets with strong on-chain trading performance over the selected timeframe.",

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -34,6 +34,7 @@ const Governance = lazy(() => import('./views/Governance'));
 const Terms = lazy(() => import('./views/Terms'));
 const Privacy = lazy(() => import('./views/Privacy'));
 const FAQ = lazy(() => import('./views/FAQ'));
+const BuyAe = lazy(() => import('./views/BuyAe'));
 const Whitepaper = lazy(() => import('./views/Whitepaper'));
 const TxQueue = lazy(() => import('./views/TxQueue'));
 
@@ -257,6 +258,7 @@ export const routes: RouteObject[] = [
   { path: '/terms', element: <Terms /> },
   { path: '/privacy', element: <Privacy /> },
   { path: '/faq', element: <FAQ /> },
+  { path: '/buy-ae', element: <BuyAe /> },
   { path: '/whitepaper', element: <Whitepaper /> },
   {
     path: '*',

--- a/src/views/BuyAe.tsx
+++ b/src/views/BuyAe.tsx
@@ -1,0 +1,222 @@
+/* eslint-disable
+  react/function-component-definition,
+  no-use-before-define
+*/
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import {
+  ArrowLeftRight,
+  Handshake,
+  Landmark,
+  type LucideIcon,
+} from 'lucide-react';
+import { Head } from '../seo/Head';
+
+type MethodIcon = LucideIcon | typeof IconX;
+
+type MethodDef = {
+  id: string;
+  Icon: MethodIcon;
+  titleKey: string;
+  descriptionKey: string;
+  actionKey?: string;
+  href?: string;
+  to?: string;
+  disabled?: boolean;
+};
+
+function IconX({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      className={className}
+      aria-hidden
+    >
+      <path d="M7 7l10 10M17 7L7 17" />
+    </svg>
+  );
+}
+
+const METHOD_DEFS: MethodDef[] = [
+  {
+    id: 'gate',
+    Icon: Landmark,
+    titleKey: 'gateTitle',
+    descriptionKey: 'gateDescription',
+    actionKey: 'gateAction',
+    href: 'https://www.gate.io/trade/AE_USDT',
+  },
+  {
+    id: 'Changelly',
+    Icon: ArrowLeftRight,
+    titleKey: 'changellyTitle',
+    descriptionKey: 'changellyDescription',
+    actionKey: 'changellyAction',
+    href: 'https://changelly.com/',
+  },
+  {
+    id: 'refer',
+    Icon: Handshake,
+    titleKey: 'referTitle',
+    descriptionKey: 'referDescription',
+    actionKey: 'referAction',
+    to: '/trends/invite',
+  },
+  {
+    id: 'x-earn',
+    Icon: IconX,
+    titleKey: 'xEarnTitle',
+    descriptionKey: 'xEarnDescription',
+    actionKey: 'comingSoon',
+    disabled: true,
+  },
+];
+
+export default function BuyAe() {
+  const { t } = useTranslation('buyAe');
+
+  return (
+    <div className="max-w-[1000px] mx-auto p-6 text-white">
+      <Head
+        title={t('pageTitle')}
+        description={t('pageDescription')}
+        canonicalPath="/buy-ae"
+      />
+
+      <div className="rounded-2xl p-7 bg-gradient-to-b from-white/6 to-white/3 text-white mb-4 border border-white/10 backdrop-blur-md">
+        <div className="text-sm opacity-90">{t('eyebrow')}</div>
+        <div className="text-[32px] font-extrabold leading-tight">{t('heroTitle')}</div>
+        <div className="text-[15px] opacity-90 mt-2">{t('heroDescription')}</div>
+        <div className="flex gap-2.5 mt-3.5 flex-wrap">
+          <Badge label={t('badgeBuy')} />
+          <Badge label={t('badgeBridge')} />
+          <Badge label={t('badgeEarn')} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-[260px_1fr]">
+        <Card>
+          <div className="font-extrabold mb-2">{t('onThisPage')}</div>
+          <div className="grid gap-1.5">
+            <a href="#what-is-ae" className="no-underline text-white text-sm opacity-90">
+              {t('whatIsAeTitle')}
+            </a>
+            <a href="#ways-to-get-ae" className="no-underline text-white text-sm opacity-90">
+              {t('waysTitle')}
+            </a>
+            <a href="#before-you-buy" className="no-underline text-white text-sm opacity-90">
+              {t('safetyTitle')}
+            </a>
+          </div>
+          <div className="mt-4 text-xs opacity-75">{t('tip')}</div>
+        </Card>
+
+        <div className="grid gap-4">
+          <Card id="what-is-ae">
+            <div className="font-extrabold mb-2">{t('whatIsAeTitle')}</div>
+            <p className="text-[15px] opacity-90 leading-relaxed m-0">
+              {t('whatIsAeDescription')}
+            </p>
+          </Card>
+
+          <Card id="ways-to-get-ae">
+            <div className="font-extrabold mb-2">{t('waysTitle')}</div>
+            <div className="grid gap-3">
+              {METHOD_DEFS.map((method) => (
+                <MethodCard key={method.id} method={method} />
+              ))}
+            </div>
+          </Card>
+
+          <Card id="before-you-buy">
+            <div className="font-extrabold mb-2">{t('safetyTitle')}</div>
+            <ul className="m-0 pl-4.5 leading-relaxed text-[15px] opacity-90">
+              <li>{t('safetyLi1')}</li>
+              <li>{t('safetyLi2')}</li>
+              <li>{t('safetyLi3')}</li>
+            </ul>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const Badge = ({ label }: { label: string }) => (
+  <span className="px-2.5 py-1.5 rounded-full bg-white/12 border border-white/20 text-xs">
+    {label}
+  </span>
+);
+
+const Card = ({ id, children }: { id?: string; children: React.ReactNode }) => (
+  <section
+    id={id}
+    className="p-4 border border-white/10 rounded-xl bg-white/5 backdrop-blur-md text-white shadow-[0_8px_24px_rgba(0,0,0,0.25)]"
+  >
+    {children}
+  </section>
+);
+
+const MethodIconBox = ({ Icon }: { Icon: MethodIcon }) => (
+  <div className="flex items-center justify-center w-9 h-9 shrink-0 rounded-lg bg-white/10 border border-white/15">
+    <Icon className="w-4 h-4 text-cyan-300" />
+  </div>
+);
+
+const MethodCard = ({ method }: { method: MethodDef }) => {
+  const { t } = useTranslation('buyAe');
+  const action = method.actionKey ? t(method.actionKey) : undefined;
+
+  return (
+    <div className="border border-white/10 rounded-xl bg-white/5 p-3">
+      <div className="flex items-start gap-3">
+        <MethodIconBox Icon={method.Icon} />
+        <div className="min-w-0 flex-1">
+          <div className="font-bold">{t(method.titleKey)}</div>
+          <div className="mt-1 text-sm text-white/75 leading-relaxed">
+            {t(method.descriptionKey)}
+          </div>
+          {action && (
+            <div className="mt-3">
+              <MethodAction method={method} label={action} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const MethodAction = ({ method, label }: { method: MethodDef; label: string }) => {
+  const className = [
+    'inline-flex items-center justify-center rounded-lg px-3 py-2 text-xs',
+    'font-semibold no-underline transition-colors',
+    method.disabled
+      ? 'bg-white/10 text-white/45 cursor-not-allowed'
+      : 'bg-white text-black hover:bg-white/85',
+  ].join(' ');
+
+  if (method.disabled) {
+    return <span className={className}>{label}</span>;
+  }
+
+  if (method.to) {
+    return (
+      <Link to={method.to} className={className}>
+        {label}
+      </Link>
+    );
+  }
+
+  return (
+    <a href={method.href} target="_blank" rel="noopener noreferrer" className={className}>
+      {label}
+    </a>
+  );
+};


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Marketing and copy-only UI with external links and a new route; no auth, payments, or core trading logic changes.
> 
> **Overview**
> Adds a **Buy AE** discovery flow: a new `/buy-ae` page explains what AE is and lists ways to obtain it (Gate.io, Changelly, Refer & Earn, plus a disabled “earn on X” placeholder), with safety copy and SEO `Head`.
> 
> The **right rail** gains a Buy AE promo card—primary CTA to Gate.io AE/USDT and a secondary link to `/buy-ae`—using new `common.buyAeRail` strings.
> 
> The **trading leaderboard** shows an informational callout (`leaderboardRoiExplanation`) clarifying how ROI is calculated for the selected period.
> 
> English locale updates cover the rail strings, ROI text, and the full `buyAe` translation namespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33819548055abcef99575fdba3d75fe09daffc0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->