### PR TITLE
Release

### DIFF
--- a/src/features/social/components/ReplyToFeedItem.tsx
+++ b/src/features/social/components/ReplyToFeedItem.tsx
@@ -258,6 +258,7 @@ const ReplyToFeedItem = memo(({
 
   return (
     <article
+      id={`post-${postId}`}
       ref={containerRef}
       className={cn(
         'relative w-full px-3 md:px-4 py-4 md:py-5 border-b border-white/10 bg-transparent transition-colors',

--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -792,11 +792,12 @@ const FeedList = ({
   const handleItemClick = useCallback(
     (idOrSlug: string) => {
       const idStr = String(idOrSlug);
+      const feedUrl = `${location.pathname}${location.search}`;
       if (idStr.startsWith('token-created:')) {
         const parts = idStr.replace(/_v3$/, '').split(':');
         const tokenNameEnc = parts[1] || '';
         const tokenName = decodeURIComponent(tokenNameEnc);
-        navigate(`/trends/tokens/${tokenName}`);
+        navigate(`/trends/tokens/${tokenName}`, { state: { fromFeedUrl: feedUrl } });
         return;
       }
       // Save current feed scroll position before leaving only for post detail
@@ -805,9 +806,9 @@ const FeedList = ({
       } catch {
         // ignore
       }
-      navigate(`/post/${idStr.replace(/_v3$/, '')}`);
+      navigate(`/post/${idStr.replace(/_v3$/, '')}`, { state: { fromFeedUrl: feedUrl } });
     },
-    [navigate],
+    [navigate, location.pathname, location.search],
   );
 
   // Render helpers

--- a/src/features/social/views/FeedList.tsx
+++ b/src/features/social/views/FeedList.tsx
@@ -803,6 +803,17 @@ const FeedList = ({
       // Save current feed scroll position before leaving only for post detail
       try {
         sessionStorage.setItem('feedScrollY', String(window.scrollY || 0));
+        // Prefer storing an ID that matches an existing DOM element.
+        // The post DOM id uses the raw `item.id` which often includes a `_v3` suffix.
+        // `idStr` may be a slug or an id with the suffix stripped; check both
+        // and store the variant that exists in the current document so restore works.
+        let targetToStore = idStr;
+        // If an element exists for the given id, use it. Otherwise try the `_v3` variant.
+        if (!document.getElementById(`post-${targetToStore}`) && !targetToStore.endsWith('_v3')) {
+          const withV3 = `${targetToStore}_v3`;
+          if (document.getElementById(`post-${withV3}`)) targetToStore = withV3;
+        }
+        sessionStorage.setItem('feedScrollTargetId', targetToStore);
       } catch {
         // ignore
       }
@@ -1074,6 +1085,26 @@ const FeedList = ({
 
   // Restore scroll position when returning from detail pages
   useEffect(() => {
+    const targetId = sessionStorage.getItem('feedScrollTargetId');
+    if (targetId) {
+      requestAnimationFrame(() => {
+        // Try direct match, then try appending `_v3`, then try stripping `_v3`.
+        const el = document.getElementById(`post-${targetId}`)
+          || document.getElementById(`post-${targetId}_v3`)
+          || document.getElementById(`post-${String(targetId).replace(/_v3$/, '')}`);
+        if (el && typeof el.scrollIntoView === 'function') {
+          el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'auto' });
+        } else {
+          const saved = sessionStorage.getItem('feedScrollY');
+          const savedY = saved ? Number(saved) : 0;
+          if (!Number.isNaN(savedY) && savedY > 0) window.scrollTo(0, savedY);
+        }
+        sessionStorage.removeItem('feedScrollTargetId');
+        sessionStorage.removeItem('feedScrollY');
+      });
+      return;
+    }
+
     const saved = sessionStorage.getItem('feedScrollY');
     const savedY = saved ? Number(saved) : 0;
     if (!Number.isNaN(savedY) && savedY > 0) {

--- a/src/features/social/views/PostDetail.tsx
+++ b/src/features/social/views/PostDetail.tsx
@@ -1,6 +1,8 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef } from 'react';
-import { useNavigate, useParams, Link } from 'react-router-dom';
+import {
+  useNavigate, useParams, Link, useLocation,
+} from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Decimal } from '@/libs/decimal';
 import { useAeSdk } from '@/hooks/useAeSdk';
@@ -103,6 +105,7 @@ const PostDetail = ({ standalone = true }: { standalone?: boolean } = {}) => {
   const { t } = useTranslation(['forms', 'social', 'common']);
   const { slug } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { activeNetwork } = useAeSdk();
 
@@ -301,7 +304,20 @@ const PostDetail = ({ standalone = true }: { standalone?: boolean } = {}) => {
         />
       ) : null}
       <div className="mb-4">
-        <AeButton onClick={() => { navigate('/'); }} variant="ghost" size="sm" outlined className="!border !border-solid !border-white/15 hover:!border-white/35">
+        <AeButton
+          onClick={() => {
+            const fromFeedUrl = (location.state as { fromFeedUrl?: string })?.fromFeedUrl;
+            if (fromFeedUrl) {
+              navigate(fromFeedUrl);
+              return;
+            }
+            navigate('/');
+          }}
+          variant="ghost"
+          size="sm"
+          outlined
+          className="!border !border-solid !border-white/15 hover:!border-white/35"
+        >
           ←
           {' '}
           {t('common:labels.back')}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Client-only navigation and sessionStorage UX; no auth or API changes, with graceful fallback to existing scroll-Y behavior.
> 
> **Overview**
> Improves **feed → detail → back** navigation so users return to the same feed view and scroll position instead of always landing on `/`.
> 
> Feed items get stable DOM anchors (`id="post-{postId}"`) so the list can scroll back to the opened post. Before navigating to a post or token trend, the feed saves `feedScrollY`, a resolved `feedScrollTargetId` (handling slug vs `_v3` id mismatches), and passes **`fromFeedUrl`** (pathname + search) in router state. On mount, the feed prefers **`scrollIntoView`** on that post, with pixel scroll as fallback.
> 
> **Post detail** back uses `fromFeedUrl` when present so sort/filter query strings are preserved; otherwise it still goes home.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a3f8cadda2067fd8040fed817e7b40e3882ea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->