### PR TITLE
build: resolve several warnings

### DIFF
--- a/src/libs/decimal/decimal.ts
+++ b/src/libs/decimal/decimal.ts
@@ -1,7 +1,11 @@
 /* eslint-disable */
-import assert from 'assert';
-
 import { BigNumber } from '@ethersproject/bignumber';
+
+function assert(condition: unknown, message = 'Assertion failed'): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
 
 const MAX_UINT_256 = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 const PRECISION = 18;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,9 +74,11 @@ export default defineConfig(({ mode }) => {
     css: {
       preprocessorOptions: {
         scss: {
+          api: 'modern-compiler',
+          loadPaths: [__dirname],
           additionalData: [
-            '@use "./src/styles/variables.scss" as *;',
-            '@use "./src/styles/mixins.scss" as *;',
+            '@use "src/styles/variables.scss" as *;',
+            '@use "src/styles/mixins.scss" as *;',
           ].join(' '),
         },
       },


### PR DESCRIPTION
fixes #32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized build/config and assert shim changes; decimal pow validation behavior should remain equivalent.
> 
> **Overview**
> This PR quiets build-time warnings by dropping the Node **`assert`** dependency in **`decimal`** and aligning Sass with Vite’s modern compiler settings.
> 
> **`decimal.ts`** no longer imports Node’s `assert`. A small local **`assert`** helper throws on failure and keeps the same checks in **`pow`**.
> 
> **`vite.config.ts`** sets SCSS to **`modern-compiler`**, adds **`loadPaths`** for the project root, and switches global **`@use`** paths to **`src/styles/...`** so shared variables/mixins resolve without deprecated Sass API noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9377cf9580eb83bf2cc1887440d3536f5b338d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->