### PR TITLE
test(ci): add summary with screenshots

### DIFF
--- a/.github/workflows/pr-screenshots.yaml
+++ b/.github/workflows/pr-screenshots.yaml
@@ -1,0 +1,102 @@
+name: PR Screenshots
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches-ignore:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Take screenshots
+        run: npm run test:e2e:screenshots
+
+      - name: Deploy report to GitHub Pages
+        if: always()
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./playwright-report
+          destination_dir: pr/${{ github.event.pull_request.number }}
+          keep_files: true
+
+      - name: Add report link to PR description
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          REPORT_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr/${{ github.event.pull_request.number }}/
+        with:
+          script: |
+            const marker = '<!-- screenshots-report-bot -->';
+            const prNumber = context.payload.pull_request.number;
+            const reportUrl = process.env.REPORT_URL;
+            const footnote = `${marker}\n---\n📸 [Screenshots report](${reportUrl}) — updated ${new Date().toUTCString()}`;
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const currentBody = pr.body ?? '';
+            const baseBody = currentBody.includes(marker)
+              ? currentBody.slice(0, currentBody.indexOf(marker)).trimEnd()
+              : currentBody.trimEnd();
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              body: `${baseBody}\n\n${footnote}`,
+            });
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out gh-pages branch
+        id: checkout
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+        continue-on-error: true
+
+      - name: Remove PR report directory
+        if: steps.checkout.outcome == 'success'
+        run: |
+          if [ -d "pr/${{ github.event.pull_request.number }}" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -rf "pr/${{ github.event.pull_request.number }}"
+            git commit -m "chore: remove screenshot report for PR #${{ github.event.pull_request.number }}"
+            git push || true
+          fi

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test';
-import fs from 'fs';
-import path from 'path';
 
 /**
  * Screenshot capture suite.
- * No assertions — tests never fail due to visual differences.
- * Screenshots are saved to e2e-screenshots/ and uploaded as CI artifacts.
+ * Screenshots are attached to the Playwright test so the HTML report embeds them.
+ * Tests only fail on HTTP errors, not visual differences.
  */
 
 const VIEWPORTS = [
@@ -21,8 +19,6 @@ const PAGES = [
   { name: 'trends-invite', path: '/trends/invite' },
 ];
 
-const OUTPUT_DIR = path.join(process.cwd(), 'e2e-screenshots');
-
 test.describe('page screenshots', () => {
   test.beforeEach(async ({ page }) => {
     // Prevent the first-visit welcome modal from appearing.
@@ -33,17 +29,17 @@ test.describe('page screenshots', () => {
 
   VIEWPORTS.forEach((viewport) => {
     PAGES.forEach((pageConfig) => {
-      test(`${pageConfig.name} @ ${viewport.name} (${viewport.width}×${viewport.height})`, async ({ page }) => {
+      test(`${pageConfig.name} @ ${viewport.name} (${viewport.width}×${viewport.height})`, async ({ page }, testInfo) => {
         await page.setViewportSize({ width: viewport.width, height: viewport.height });
         const response = await page.goto(pageConfig.path);
         expect(response?.status(), `${pageConfig.path} should return HTTP 200`).toBe(200);
         await page.locator('#root').waitFor({ state: 'visible' });
         await page.waitForLoadState('load');
 
-        fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-        await page.screenshot({
-          path: path.join(OUTPUT_DIR, `${pageConfig.name}--${viewport.name}.png`),
-          fullPage: true,
+        const screenshot = await page.screenshot({ fullPage: true, type: 'jpeg', quality: 80 });
+        await testInfo.attach(`${pageConfig.name}--${viewport.name}.jpg`, {
+          body: screenshot,
+          contentType: 'image/jpeg',
         });
       });
     });

--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -35,6 +35,7 @@ test.describe('page screenshots', () => {
         expect(response?.status(), `${pageConfig.path} should return HTTP 200`).toBe(200);
         await page.locator('#root').waitFor({ state: 'visible' });
         await page.waitForLoadState('load');
+        await page.waitForTimeout(3000);
 
         const screenshot = await page.screenshot({ fullPage: true, type: 'jpeg', quality: 80 });
         await testInfo.attach(`${pageConfig.name}--${viewport.name}.jpg`, {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,8 +4,13 @@ export default defineConfig({
   testDir: './e2e',
   forbidOnly: !!process.env.CI,
   timeout: 60_000,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+  ],
   use: {
     navigationTimeout: 60_000,
+    screenshot: 'only-on-failure',
   },
   projects: [{ name: 'chromium', use: devices['Desktop Chrome'] }],
   webServer: {


### PR DESCRIPTION
This pull request improves the handling and reporting of end-to-end (E2E) test screenshots in the CI workflow. The main changes ensure that screenshots are more efficiently generated, stored, and displayed in GitHub Actions job summaries, making it easier to review visual test results directly from the CI output.

**E2E Screenshot Handling Improvements:**

* The E2E test script now saves screenshots as JPEGs instead of PNGs, specifying compression quality for smaller file sizes and consistent format (`e2e/screenshots.spec.ts`).
* Playwright is configured to capture screenshots only on test failure, reducing unnecessary image generation (`playwright.config.ts`).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and E2E reporting only; workflow uses `contents: write` and `pull-requests: write` to publish Pages and edit PR bodies, with no application runtime changes.
> 
> **Overview**
> Adds a **PR Screenshots** GitHub Actions workflow that runs on non-`main` pull requests (open/sync/reopen), runs the screenshot E2E suite, publishes the Playwright HTML report to GitHub Pages under `pr/<number>`, and appends or refreshes a screenshots link in the PR description via a bot marker. A **cleanup** job on PR close removes that report folder from `gh-pages`.
> 
> The screenshot tests no longer write PNGs to `e2e-screenshots/`; they attach **JPEG** full-page captures to each test so the HTML report embeds them, with a short settle wait before capture. **Playwright** now emits `list` + `html` reporters to `playwright-report` and sets automatic screenshots to **only-on-failure** (separate from the intentional attach flow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24c9458f2358d6a6e0c1600f6ebf0a090f1a1f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/604/) — updated Wed, 17 Jun 2026 09:25:11 GMT