### PR TITLE
feat: add collection filtering and display enhancements

### DIFF
--- a/src/api/__tests__/governance.test.ts
+++ b/src/api/__tests__/governance.test.ts
@@ -2,9 +2,12 @@ import {
   beforeEach, describe, expect, it, vi,
 } from 'vitest';
 import { GovernanceApi } from '../governance';
+import { CONFIG } from '../../config';
 
 const mockFetch = vi.fn();
-const GOVERNANCE_API_URL = 'https://governance-server-mainnet.prd.service.aepps.com';
+// Derive from the active config (mainnet vs testnet via VITE_NETWORK) the same way
+// the client does, so these path/options assertions hold on either network.
+const GOVERNANCE_API_URL = CONFIG.GOVERNANCE_API_URL.replace(/\/$/, '');
 
 describe('GovernanceApi', () => {
   beforeEach(() => {

--- a/src/api/generated/services/TokensService.ts
+++ b/src/api/generated/services/TokensService.ts
@@ -26,7 +26,7 @@ export class TokensService {
     }: {
         orderBy?: 'name' | 'price' | 'market_cap' | 'created_at' | 'holders_count' | 'treasury',
         orderDirection?: 'ASC' | 'DESC',
-        collection?: 'all' | 'word' | 'number',
+        collection?: string,
         limit?: number,
         page?: number,
         ownerAddress?: string,

--- a/src/features/trending/components/TokenListTableRow.tsx
+++ b/src/features/trending/components/TokenListTableRow.tsx
@@ -1,7 +1,6 @@
 import { TokenDto } from '@/api/generated/models/TokenDto';
 import { PriceDataFormatter } from '@/features/shared/components';
 import { toAe } from '@/utils/bondingCurve';
-import { collectionLabel } from '@/utils/collection';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';

--- a/src/features/trending/components/TokenListTableRow.tsx
+++ b/src/features/trending/components/TokenListTableRow.tsx
@@ -1,6 +1,7 @@
 import { TokenDto } from '@/api/generated/models/TokenDto';
 import { PriceDataFormatter } from '@/features/shared/components';
 import { toAe } from '@/utils/bondingCurve';
+import { collectionLabel } from '@/utils/collection';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -120,9 +121,16 @@ const TokenListTableRow = ({
 
         {/* Name + Market Cap */}
         <td className="cell cell-name py-3 pl-2 pr-1 align-middle">
-          <div className="text-[13px] font-bold text-white truncate">
-            <span className="text-white/40 text-[.85em] mr-0.5">#</span>
-            {token.symbol || token.name}
+          <div className="flex items-center gap-1.5 min-w-0">
+            <div className="text-[13px] font-bold text-white truncate">
+              <span className="text-white/40 text-[.85em] mr-0.5">#</span>
+              {token.symbol || token.name}
+            </div>
+            {collectionLabel(token.collection) && (
+              <span className="shrink-0 inline-flex items-center rounded-full bg-white/10 px-1.5 py-[1px] text-[9px] font-semibold leading-none text-white/50">
+                {collectionLabel(token.collection)}
+              </span>
+            )}
           </div>
           <div className="text-[11px] text-white/40 mt-0.5 tabular-nums">
             <PriceDataFormatter
@@ -183,9 +191,16 @@ const TokenListTableRow = ({
         <td className="cell cell-name px-3">
           <div className="flex items-center gap-2.5">
             <div className="min-w-0 flex-1">
-              <div className="token-name text-sm font-bold text-white truncate">
-                <span className="text-white/40 text-[.85em] mr-0.5">#</span>
-                {token.symbol || token.name}
+              <div className="flex items-center gap-1.5 min-w-0">
+                <div className="token-name text-sm font-bold text-white truncate">
+                  <span className="text-white/40 text-[.85em] mr-0.5">#</span>
+                  {token.symbol || token.name}
+                </div>
+                {collectionLabel(token.collection) && (
+                  <span className="shrink-0 inline-flex items-center rounded-full bg-white/10 px-1.5 py-[1px] text-[9px] font-semibold leading-none text-white/50">
+                    {collectionLabel(token.collection)}
+                  </span>
+                )}
               </div>
               {token.name && token.symbol && token.name !== token.symbol && (
                 <div className="text-[11px] text-white/40 truncate leading-3 mt-0.5">

--- a/src/features/trending/components/TokenListTableRow.tsx
+++ b/src/features/trending/components/TokenListTableRow.tsx
@@ -126,11 +126,6 @@ const TokenListTableRow = ({
               <span className="text-white/40 text-[.85em] mr-0.5">#</span>
               {token.symbol || token.name}
             </div>
-            {collectionLabel(token.collection) && (
-              <span className="shrink-0 inline-flex items-center rounded-full bg-white/10 px-1.5 py-[1px] text-[9px] font-semibold leading-none text-white/50">
-                {collectionLabel(token.collection)}
-              </span>
-            )}
           </div>
           <div className="text-[11px] text-white/40 mt-0.5 tabular-nums">
             <PriceDataFormatter
@@ -196,11 +191,6 @@ const TokenListTableRow = ({
                   <span className="text-white/40 text-[.85em] mr-0.5">#</span>
                   {token.symbol || token.name}
                 </div>
-                {collectionLabel(token.collection) && (
-                  <span className="shrink-0 inline-flex items-center rounded-full bg-white/10 px-1.5 py-[1px] text-[9px] font-semibold leading-none text-white/50">
-                    {collectionLabel(token.collection)}
-                  </span>
-                )}
               </div>
               {token.name && token.symbol && token.name !== token.symbol && (
                 <div className="text-[11px] text-white/40 truncate leading-3 mt-0.5">

--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -685,8 +685,8 @@ const CreateTokenView = () => {
                         <span>
                           {t('trending.createToken.charactersCount', { count: tokenName.length, max: 20 })}
                         </span>
-                        <span className="opacity-80">
-                          {nameStatus === 'invalid' ? t('trending.createToken.invalidCharacters') : t('trending.createToken.allowedCharsHint')}
+                        <span className="opacity-80" dir="auto">
+                          {nameStatus === 'invalid' ? t('trending.createToken.invalidCharacters') : (selectedCollection?.description || t('trending.createToken.allowedCharsHint'))}
                         </span>
                       </div>
                     </div>

--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -2,6 +2,7 @@
 import LivePriceFormatter from '@/features/shared/components/LivePriceFormatter';
 import { Decimal } from '@/libs/decimal';
 import { calculateBuyPriceWithAffiliationFee, calculateTokensFromAE, toDecimals } from '@/utils/bondingCurve';
+import { collectionLabel } from '@/utils/collection';
 import { toAe } from '@aeternity/aepp-sdk';
 import BigNumber from 'bignumber.js';
 import { useAtom } from 'jotai';
@@ -636,7 +637,7 @@ const CreateTokenView = () => {
                                     selected ? 'text-white' : 'text-white/90'
                                   }`}
                                 >
-                                  {collection.name}
+                                  {collectionLabel(collection.name)}
                                 </span>
                               </button>
                             );

--- a/src/features/trending/views/TokenList.tsx
+++ b/src/features/trending/views/TokenList.tsx
@@ -8,6 +8,8 @@ import {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useCommunityFactory } from '@/hooks/useCommunityFactory';
+import { collectionLabel } from '@/utils/collection';
 import { TokensService } from '../../../api/generated';
 import LatestTransactionsCarousel from '../../../components/Trendminer/LatestTransactionsCarousel';
 import {
@@ -108,6 +110,8 @@ const TokenList = () => {
   const qFromUrl = searchParams.get(EXPLORE_SEARCH_QUERY_KEY)?.trim() ?? '';
   const [orderBy, setOrderBy] = useState<OrderByOption>(SORT.trendingScore);
   const [orderDirection, setOrderDirection] = useState<'ASC' | 'DESC'>('DESC');
+  const [collection, setCollection] = useState<string>('all');
+  const { activeFactoryCollections, loadFactorySchema } = useCommunityFactory();
   const [activeTab, setActiveTab] = useState<SearchTab>('tokens');
   const [searchInput, setSearchInput] = useState(qFromUrl);
   const [searchTerm, setSearchTerm] = useState(qFromUrl);
@@ -133,6 +137,18 @@ const TokenList = () => {
     { title: t('tokenList.sortOldest'), value: SORT.oldest },
     { title: t('tokenList.sortHoldersCount'), value: SORT.holdersCount },
   ], [t]);
+
+  const collectionOptions = useMemo((): SelectOptions<string> => [
+    { title: t('tokenList.collectionAll'), value: 'all' },
+    ...activeFactoryCollections.map((c: any) => ({ title: collectionLabel(c.name), value: c.name })),
+  ], [t, activeFactoryCollections]);
+
+  // Ensure the factory schema (and its collections) is loaded for the filter.
+  useEffect(() => {
+    if (!activeFactoryCollections.length) {
+      loadFactorySchema().catch(() => {});
+    }
+  }, [activeFactoryCollections.length, loadFactorySchema]);
 
   const getFallbackSubtitle = useCallback((tab: SearchTab) => {
     if (tab === 'tokens') return t('tokenList.fallbackTokens');
@@ -194,6 +210,7 @@ const TokenList = () => {
     queryFn: ({ pageParam = 1 }) => TokensService.listAll({
       orderBy: orderByMapped as any,
       orderDirection: finalOrderDirection,
+      collection: collection === 'all' ? undefined : collection,
       limit: 20,
       page: pageParam,
     }),
@@ -207,6 +224,7 @@ const TokenList = () => {
       orderBy,
       orderByMapped,
       finalOrderDirection,
+      collection,
       activeTab,
       hasSearch,
     ],
@@ -604,6 +622,22 @@ const TokenList = () => {
                         </SelectContent>
                       </Select>
                     </div>
+                    {activeFactoryCollections.length > 0 && (
+                      <div className="w-full sm:w-auto sm:flex-shrink-0">
+                        <Select value={collection} onValueChange={setCollection}>
+                          <SelectTrigger className="h-10 w-full rounded-lg border border-white/10 bg-white/[0.06] px-2 py-2 text-xs text-white transition-all duration-300 hover:bg-white/[0.08] focus:outline-none focus:border-[#1161FE] sm:min-w-[140px]">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent className="bg-gray-900 border-white/10">
+                            {collectionOptions.map((option) => (
+                              <SelectItem key={option.value} value={option.value} className="text-white hover:bg-white/10 text-xs">
+                                {option.title}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
                   </div>
                   <Link
                     to="/trends/create"

--- a/src/features/trending/views/TokenList.tsx
+++ b/src/features/trending/views/TokenList.tsx
@@ -210,7 +210,7 @@ const TokenList = () => {
     queryFn: ({ pageParam = 1 }) => TokensService.listAll({
       orderBy: orderByMapped as any,
       orderDirection: finalOrderDirection,
-      collection: collection === 'all' ? undefined : collection,
+      collection,
       limit: 20,
       page: pageParam,
     }),

--- a/src/features/trending/views/TokenSaleDetails.tsx
+++ b/src/features/trending/views/TokenSaleDetails.tsx
@@ -15,6 +15,7 @@ import {
   useEffect, useMemo, useRef, useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { collectionLabel } from '@/utils/collection';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { cn } from '@/lib/utils';
@@ -477,6 +478,14 @@ const TokenSaleDetails = () => {
                     </h1>
 
                     <div className="flex items-center gap-2 flex-wrap">
+                      {collectionLabel((token as any)?.collection) && (
+                        <Badge
+                          variant="secondary"
+                          className="bg-white/10 text-white/70 text-xs font-medium px-2.5 py-1 rounded-full border-0"
+                        >
+                          {collectionLabel((token as any)?.collection)}
+                        </Badge>
+                      )}
                       {tokenDoesNotExist ? (
                         <Badge
                           variant="secondary"

--- a/src/features/trending/views/__tests__/TokenList.test.tsx
+++ b/src/features/trending/views/__tests__/TokenList.test.tsx
@@ -40,6 +40,13 @@ vi.mock('../../../../api/generated', () => ({
   },
 }));
 
+vi.mock('@/hooks/useCommunityFactory', () => ({
+  useCommunityFactory: () => ({
+    activeFactoryCollections: [],
+    loadFactorySchema: vi.fn().mockResolvedValue({ collections: {} }),
+  }),
+}));
+
 vi.mock('../../../../seo/Head', () => ({
   Head: () => null,
 }));

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1567,7 +1567,8 @@
       "noLeaderboard": "لا تتوفر بيانات لوحة الصدارة في الوقت الحالي.",
       "popularPostsTitle": "المنشورات الشائعة",
       "popularPostsSubtitle": "ما يتحدث عنه المجتمع أكثر من غيره.",
-      "noPopularPosts": "لا تتوفر منشورات شائعة في الوقت الحالي."
+      "noPopularPosts": "لا تتوفر منشورات شائعة في الوقت الحالي.",
+      "collectionAll": "الكل"
     },
     "createToken": {
       "oops": "عذرًا!",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1567,7 +1567,8 @@
       "noLeaderboard": "Derzeit sind keine Bestenlisten-Daten verfügbar.",
       "popularPostsTitle": "Beliebte Beiträge",
       "popularPostsSubtitle": "Worüber die Community am meisten spricht.",
-      "noPopularPosts": "Derzeit sind keine beliebten Beiträge verfügbar."
+      "noPopularPosts": "Derzeit sind keine beliebten Beiträge verfügbar.",
+      "collectionAll": "Alle"
     },
     "createToken": {
       "oops": "Hoppla!",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -186,8 +186,7 @@
       "xCallbackGoToProfile": "Go to profile",
       "transactionFailed": "Transaction failed",
       "copiedExclaim": "Copied!",
-      "xCallbackUnlinkSuccess": "X account unlinked successfully.",
-      "xCallbackGoToProfile": "Go to profile"
+      "xCallbackUnlinkSuccess": "X account unlinked successfully."
     },
     "portfolio": {
       "portfolioValue": "Portfolio Value",
@@ -1664,7 +1663,8 @@
       "noLeaderboard": "No leaderboard data is available right now.",
       "popularPostsTitle": "Popular Posts",
       "popularPostsSubtitle": "What the community is talking about the most.",
-      "noPopularPosts": "No popular posts are available right now."
+      "noPopularPosts": "No popular posts are available right now.",
+      "collectionAll": "All"
     },
     "createToken": {
       "oops": "Oops!",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1567,7 +1567,8 @@
       "noLeaderboard": "Aucune donnée de classement n'est disponible pour le moment.",
       "popularPostsTitle": "Posts populaires",
       "popularPostsSubtitle": "Ce dont la communauté parle le plus.",
-      "noPopularPosts": "Aucun post populaire n'est disponible pour le moment."
+      "noPopularPosts": "Aucun post populaire n'est disponible pour le moment.",
+      "collectionAll": "Tout"
     },
     "createToken": {
       "oops": "Oups !",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1567,7 +1567,8 @@
       "noLeaderboard": "目前没有可用的排行榜数据。",
       "popularPostsTitle": "热门帖子",
       "popularPostsSubtitle": "社区讨论最多的话题。",
-      "noPopularPosts": "目前没有可用的热门帖子。"
+      "noPopularPosts": "目前没有可用的热门帖子。",
+      "collectionAll": "全部"
     },
     "createToken": {
       "oops": "哎呀！",

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -7,6 +7,8 @@
 const COLLECTION_LABEL_OVERRIDES: Record<string, string> = {
   WORDS: 'English',
   CHINESE: 'Chinese',
+  RUSSIAN: 'Russian',
+  ARABIC: 'Arabic',
 };
 
 /** Extract the collection name from a full id ("NAME-ak_…") or pass a name through. */

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -1,0 +1,23 @@
+// Display helpers for token collections.
+//
+// On-chain a token's `collection` is the full id `"<NAME>-ak_<deployer>"`
+// (e.g. "WORDS-ak_2X6…"). The UI shows the NAME, with a few human-facing
+// overrides (e.g. the "WORDS" collection is presented as "English").
+
+const COLLECTION_LABEL_OVERRIDES: Record<string, string> = {
+  WORDS: 'English',
+  CHINESE: 'Chinese',
+};
+
+/** Extract the collection name from a full id ("NAME-ak_…") or pass a name through. */
+export function collectionName(idOrName?: string | null): string {
+  if (!idOrName) return '';
+  return idOrName.split('-ak_')[0];
+}
+
+/** Human-facing label for a collection id or name (applies display overrides). */
+export function collectionLabel(idOrName?: string | null): string {
+  const name = collectionName(idOrName);
+  if (!name) return '';
+  return COLLECTION_LABEL_OVERRIDES[name.toUpperCase()] ?? name;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly UI and an optional list API query parameter; no auth or payment logic changes.
> 
> **Overview**
> Adds **collection-aware browsing and labeling** across trending token flows, driven by factory schema collections and a shared display helper.
> 
> The explore **Tokenized Trends** list now includes a **collection filter** (when factory collections exist): options come from `useCommunityFactory`, labels use `collectionLabel`, and the chosen value is sent to `TokensService.listAll` as the `collection` query param (cache key updated). **Create token** uses the same labels in the collection picker and shows the selected collection’s **description** as the allowed-character hint (with `dir="auto"` for RTL scripts). **Token detail** shows a **collection badge** next to the title when `token.collection` is present.
> 
> New **`collectionLabel` / `collectionName`** in `utils/collection` strip `NAME-ak_…` ids and map names like `WORDS` → “English”. Generated API client widens `collection` on `listAll` from a fixed union to **`string`**. Tests: governance URLs follow **`CONFIG.GOVERNANCE_API_URL`**; `TokenList` mocks **`useCommunityFactory`**. Locales add **`tokenList.collectionAll`**; **en** removes a duplicate `xCallbackGoToProfile` key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e06e913fddd7f72c8a23381bc6594633913685c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->