### PR TITLE
fix: show the date info on token graph

### DIFF
--- a/src/features/dex/components/charts/TokenPricePerformance.tsx
+++ b/src/features/dex/components/charts/TokenPricePerformance.tsx
@@ -71,7 +71,8 @@ const TokenPricePerformance = ({
     if (!chartContainerRef.current) return () => {};
 
     const chart = createChart(chartContainerRef.current, {
-      height: 400,
+      width: chartContainerRef.current.clientWidth,
+      height: chartContainerRef.current.clientHeight,
       layout: {
         background: { type: ColorType.Solid, color: 'transparent' },
         textColor: '#ffffff',
@@ -103,11 +104,13 @@ const TokenPricePerformance = ({
 
     chartRef.current = chart;
 
-    // Handle resize
+    // Handle resize - keep both width and height in sync with the container so
+    // the time (date) axis is never clipped by the card's fixed height/padding.
     const handleResize = () => {
       if (chartContainerRef.current && chart) {
         chart.applyOptions({
           width: chartContainerRef.current.clientWidth,
+          height: chartContainerRef.current.clientHeight,
         });
       }
     };

--- a/src/features/dex/components/charts/TokenPricePerformance.tsx
+++ b/src/features/dex/components/charts/TokenPricePerformance.tsx
@@ -294,12 +294,15 @@ const TokenPricePerformance = ({
     }
 
     // Create new series based on chart type
+    const precision = ['TVL', 'Fees', 'Volume'].includes(selectedChart.type) ? 2 : 6;
     const seriesOptions = {
       color: 'rgb(0, 255, 157)',
       priceFormat: {
         type: 'price' as const,
-        precision: ['TVL', 'Fees', 'Volume'].includes(selectedChart.type) ? 2 : 6,
-        minMove: 0.01,
+        precision,
+        // minMove must match the precision, otherwise tiny token prices
+        // (e.g. 0.00005) get rounded to the nearest 0.01 and render as 0.000000.
+        minMove: 1 / 10 ** precision,
       },
     };
 


### PR DESCRIPTION
fixes #265 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI/chart display fixes in TokenPricePerformance with no auth, API, or data-model changes.
> 
> **Overview**
> Fixes the DEX **token price chart** so the **time/date axis stays visible** and **very small prices** render correctly.
> 
> The lightweight-charts instance no longer uses a hard-coded **400px** height. It is sized from the chart container’s **width and height**, and **resize** updates both dimensions so the bottom time scale is not clipped inside the padded card.
> 
> **Price scale** formatting now sets **`minMove` to `1 / 10^precision`** (2 decimals for TVL/Fees/Volume, 6 for price charts) instead of a fixed **0.01**, so values like **0.00005** are not rounded away on the axis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e72e56766c5c01a4df1bb0748fde81e77cc36b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/611/) — updated Tue, 23 Jun 2026 11:33:53 GMT