### PR TITLE
fix: show correct dex info

### DIFF
--- a/src/features/dex/components/charts/TokenPricePerformance.tsx
+++ b/src/features/dex/components/charts/TokenPricePerformance.tsx
@@ -6,9 +6,11 @@ import {
 } from 'lightweight-charts';
 import { useTranslation } from 'react-i18next';
 import AppSelect, { Item as AppSelectItem } from '@/components/inputs/AppSelect';
+import { formatFractionalPrice } from '@/utils/common';
 import AeButton from '../../../../components/AeButton';
 import { getGraph } from '../../../../libs/dexBackend';
 import { AeCard } from '../../../../components/ui/ae-card';
+import { Decimal } from '../../../../libs/decimal';
 
 interface ChartType {
   type: string;
@@ -37,6 +39,15 @@ type TimeFrame = keyof typeof TIME_FRAMES;
 
 const BAR_CHART_TYPES = ['TVL', 'Volume', 'Fees', 'Locked'];
 
+// Price series can hold values far below the axis' fixed step (e.g. 0.0000001032),
+// which lightweight-charts' fixed-precision formatter renders as a flat
+// "0.0000000". Reuse the same compressed-zeros style used for the token's own
+// price ("0.0 (7) 1032") so tiny prices stay distinguishable on axis/crosshair.
+const formatChartPrice = (price: number): string => {
+  const formatted = formatFractionalPrice(Decimal.from(price));
+  return formatted.value ?? formatted.number;
+};
+
 const TokenPricePerformance = ({
   availableGraphTypes,
   initialChart,
@@ -54,14 +65,20 @@ const TokenPricePerformance = ({
   const [selectedTimeFrame, setSelectedTimeFrame] = useState<TimeFrame>(initialTimeFrame as TimeFrame);
   const [selectedChart, setSelectedChart] = useState<ChartType>(initialChart);
   const [loading, setLoading] = useState(false);
+  // Tracks whether the currently selected timeframe actually has points to plot,
+  // so the "No data" overlay reflects what's on screen rather than the raw,
+  // pre-filter response.
+  const [hasPlottedData, setHasPlottedData] = useState(false);
   const [chartData, setChartData] = useState<{
     labels: number[];
     data: number[];
     graphType: string;
+    unit: string | null;
   }>({
     labels: [],
     data: [],
     graphType: '',
+    unit: null,
   });
 
   const isBarChart = BAR_CHART_TYPES.includes(selectedChart.type);
@@ -229,14 +246,24 @@ const TokenPricePerformance = ({
   }, []);
 
   const updateChartData = useCallback(() => {
-    if (!seriesRef.current || !chartData.labels.length) return;
+    if (!seriesRef.current || !chartData.labels.length) {
+      setHasPlottedData(false);
+      // Clear any series carried over from a previous chart type/timeframe so
+      // the canvas actually goes empty behind the "No data" overlay.
+      seriesRef.current?.setData([]);
+      return;
+    }
 
-    const now = Date.now() / 1000;
     const timeFrameHours = TIME_FRAMES[selectedTimeFrame];
-    const minTime = timeFrameHours === Infinity ? 0 : now - (timeFrameHours * 3600);
+
+    // lightweight-charts rejects series values outside ±(MAX_SAFE_INTEGER/100)
+    // and throws, which crashes the whole page. Degenerate DEX data (e.g. a
+    // dust-state transaction in a near-empty pool) can yield absurd prices like
+    // 5e17, so drop out-of-range / non-finite points instead of plotting them.
+    const CHART_VALUE_LIMIT = 90071992547409.91;
 
     // Convert data format - TradingView expects Unix timestamps in seconds
-    const rawData = chartData.labels
+    const valuePoints = chartData.labels
       .map((timestamp, index) => {
         // Ensure timestamp is in seconds (not milliseconds)
         const timeInSeconds = timestamp > 1e10 ? Math.floor(timestamp / 1000) : timestamp;
@@ -245,6 +272,20 @@ const TokenPricePerformance = ({
           value: Number(chartData.data[index]) || 0,
         };
       })
+      .filter(
+        (item) => Number.isFinite(item.value) && Math.abs(item.value) < CHART_VALUE_LIMIT,
+      );
+
+    // Anchor the visible window to the most recent available data point instead
+    // of the wall-clock now. Otherwise a token whose latest trade is older than
+    // the selected window (e.g. a 1Y window for a token last traded 13 months
+    // ago) filters out every point and renders an empty chart.
+    const latestTime = valuePoints.length
+      ? valuePoints.reduce((max, item) => (item.time > max ? item.time : max), valuePoints[0].time)
+      : Date.now() / 1000;
+    const minTime = timeFrameHours === Infinity ? 0 : latestTime - (timeFrameHours * 3600);
+
+    const rawData = valuePoints
       .filter((item) => timeFrameHours === Infinity || item.time >= minTime)
       .sort((a, b) => a.time - b.time); // Ensure data is sorted by time
 
@@ -269,6 +310,8 @@ const TokenPricePerformance = ({
       }
     });
 
+    setHasPlottedData(formattedData.length > 0);
+
     if (formattedData.length > 0) {
       seriesRef.current.setData(formattedData);
 
@@ -276,6 +319,10 @@ const TokenPricePerformance = ({
       if (chartRef.current) {
         chartRef.current.timeScale().fitContent();
       }
+    } else {
+      // Clear any series left over from a previous timeframe/chart type so the
+      // canvas matches the (empty) "No data" state.
+      seriesRef.current.setData([]);
     }
   }, [chartData, selectedTimeFrame]);
 
@@ -297,13 +344,26 @@ const TokenPricePerformance = ({
     const precision = ['TVL', 'Fees', 'Volume'].includes(selectedChart.type) ? 2 : 6;
     const seriesOptions = {
       color: 'rgb(0, 255, 157)',
-      priceFormat: {
-        type: 'price' as const,
-        precision,
-        // minMove must match the precision, otherwise tiny token prices
-        // (e.g. 0.00005) get rounded to the nearest 0.01 and render as 0.000000.
-        minMove: 1 / 10 ** precision,
-      },
+      priceFormat: selectedChart.type === 'Price'
+        ? {
+          // Custom formatter keeps sub-step prices readable instead of rounding
+          // them to a flat "0.0000000" (see formatChartPrice). The formatter
+          // receives the raw price, so the crosshair stays exact regardless of
+          // minMove. Keep minMove at 1e-9 (not 1e-18): the tick builder computes
+          // price / minMove, and a 1e-18 step overflows MAX_SAFE_INTEGER for
+          // ordinary prices (0.25 / 1e-18 = 2.5e17), which NaNs the price scale
+          // and renders nothing. 1e-9 still resolves very small prices.
+          type: 'custom' as const,
+          formatter: formatChartPrice,
+          minMove: 1 / 10 ** 9,
+        }
+        : {
+          type: 'price' as const,
+          precision,
+          // minMove must match the precision, otherwise tiny token prices
+          // (e.g. 0.00005) get rounded to the nearest 0.01 and render as 0.000000.
+          minMove: 1 / 10 ** precision,
+        },
     };
 
     if (isBarChart) {
@@ -343,11 +403,28 @@ const TokenPricePerformance = ({
           labels: result.labels?.map((l: any) => Number(l)) || [],
           data: result.data?.map((d: any) => Number(d)) || [],
           graphType: result.graphType || selectedChart.type,
+          unit: result.unit ?? null,
+        });
+      } else {
+        // getGraph returns null for chart types the backend has no series for
+        // (e.g. TVL/Fees/Locked). Without resetting here, chartData keeps the
+        // previous selection's points and the canvas would keep rendering the
+        // old series (e.g. Price) under the new selection with no "No data" overlay.
+        setChartData({
+          labels: [],
+          data: [],
+          graphType: selectedChart.type,
+          unit: null,
         });
       }
     } catch (error) {
       console.error('Failed to fetch chart data:', error);
-      setChartData({ labels: [], data: [], graphType: selectedChart.type });
+      setChartData({
+        labels: [],
+        data: [],
+        graphType: selectedChart.type,
+        unit: null,
+      });
     } finally {
       setLoading(false);
     }
@@ -366,10 +443,27 @@ const TokenPricePerformance = ({
     setSelectedChart(chartType);
   };
 
-  const showNoData = !chartData.data.length || chartData.data.every((d) => d === 0);
+  // Reflect what's actually plotted for the selected timeframe, not the raw
+  // pre-filter response — otherwise a window that filters out every point would
+  // render a blank canvas with no overlay.
+  const showNoData = !loading && !hasPlottedData;
 
   return (
     <div className={`${className}`}>
+      {/* Denomination — make the price chart's unit explicit, and clearly warn
+          when the series is NOT in AE (the token has no AE pool, so 0.25 here
+          means 0.25 of another token, not 0.25 AE). */}
+      {selectedChart.type === 'Price' && chartData.unit && (
+        <div
+          className={`mb-2 text-xs font-medium ${
+            chartData.unit === 'ae' ? 'text-white/50' : 'text-amber-400'
+          }`}
+        >
+          {chartData.unit === 'ae'
+            ? 'Price in AE'
+            : `Price in ${chartData.unit} — no AE pool, so this is not an AE price`}
+        </div>
+      )}
       {/* Chart Type Selector */}
       {availableGraphTypes.length > 1 && (
         <div className="flex gap-2 mb-3">
@@ -426,7 +520,7 @@ const TokenPricePerformance = ({
         )}
 
         {/* No Data Overlay */}
-        {showNoData && !loading && (
+        {showNoData && (
           <div className="absolute inset-0 flex justify-center items-center text-3xl text-muted-foreground">
             {t('tokenPricePerformance.noData')}
           </div>

--- a/src/libs/__tests__/dexBackend.test.ts
+++ b/src/libs/__tests__/dexBackend.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAllTokens,
+  getGraph,
+  getHistory,
+  getListedTokens,
+  getPairs,
+  getSwapRoutes,
+} from '../dexBackend';
+
+/** Mock global fetch, routing canned JSON by URL substring. */
+function mockFetch(routes: Array<{ match: string; body: any; ok?: boolean }>) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      calls.push(url);
+      const route = routes.find((r) => url.includes(r.match));
+      if (!route) throw new Error(`unexpected fetch: ${url}`);
+      return {
+        ok: route.ok ?? true,
+        json: async () => route.body,
+      } as any;
+    }),
+  );
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('dexBackend adapters (superhero-api)', () => {
+  it('getListedTokens unwraps items and projects the 4 fields', async () => {
+    const calls = mockFetch([
+      {
+        match: 'dex/tokens?listed=true',
+        body: {
+          items: [
+            {
+              address: 'ct_a',
+              name: 'Alpha',
+              symbol: 'AAA',
+              decimals: 18,
+              listed: true,
+              price: { ae: 1 },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const result = await getListedTokens();
+
+    expect(calls[0]).toContain('/api/dex/tokens?listed=true');
+    expect(result).toEqual([
+      { address: 'ct_a', name: 'Alpha', symbol: 'AAA', decimals: 18 },
+    ]);
+  });
+
+  it('getAllTokens flattens nested price + summary into the legacy shape', async () => {
+    mockFetch([
+      {
+        match: 'dex/tokens?limit=100',
+        body: {
+          items: [
+            {
+              address: 'ct_a',
+              name: 'Alpha',
+              symbol: 'AAA',
+              decimals: 18,
+              pairs_count: 5,
+              price: { ae: 0.5, usd: 1.25 },
+              summary: {
+                total_volume: { usd: 9999 },
+                change: {
+                  '24h': { volume: { usd: 100 }, percentage: '3.5' },
+                },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const [t] = (await getAllTokens())!;
+
+    expect(t.priceUsd).toBe('1.25');
+    expect(t.pairs).toBe(5);
+    expect(t.priceChangeDay).toBe('3.5');
+    expect(t.volumeUsdDay).toBe('100');
+    expect(t.volumeUsdAll).toBe('9999');
+  });
+
+  it('getPairs flattens tokens to addresses, computes TVL, and derives synchronized', async () => {
+    mockFetch([
+      {
+        match: 'dex/pairs?limit=100',
+        body: {
+          items: [
+            {
+              address: 'ct_pair',
+              transactions_count: 7,
+              reserve0: '2000000000000000000', // 2 tokens @ 18dp
+              reserve1: '5000000', // 5 tokens @ 6dp
+              token0: {
+                address: 'ct_0',
+                symbol: 'AAA',
+                decimals: 18,
+                price: { usd: 3 },
+              },
+              token1: {
+                address: 'ct_1',
+                symbol: 'BBB',
+                decimals: 6,
+                price: { usd: 2 },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const [p] = (await getPairs(false))!;
+
+    expect(p.token0).toBe('ct_0');
+    expect(p.token1).toBe('ct_1');
+    expect(p.token0Symbol).toBe('AAA');
+    expect(p.transactions).toBe(7);
+    expect(p.synchronized).toBe(true);
+    // 2*3 + 5*2 = 16
+    expect(p.tvlUsd).toBe('16');
+  });
+
+  it('getAllTokens walks every page reported by meta.totalPages', async () => {
+    const mkToken = (address: string) => ({
+      address, name: address, symbol: address, decimals: 18, price: { ae: 1 },
+    });
+    const calls = mockFetch([
+      {
+        match: 'page=1',
+        body: { items: [mkToken('ct_a'), mkToken('ct_b')], meta: { totalPages: 3 } },
+      },
+      {
+        match: 'page=2',
+        body: { items: [mkToken('ct_c')], meta: { totalPages: 3 } },
+      },
+      {
+        match: 'page=3',
+        body: { items: [mkToken('ct_d')], meta: { totalPages: 3 } },
+      },
+    ]);
+
+    const result = (await getAllTokens())!;
+
+    expect(calls).toHaveLength(3);
+    expect(result.map((t) => t.address)).toEqual(['ct_a', 'ct_b', 'ct_c', 'ct_d']);
+  });
+
+  it('getPairs stops paginating on a short page when meta is absent', async () => {
+    const mkPair = (address: string) => ({
+      address,
+      token0: { address: 'ct_0', symbol: 'AAA', decimals: 18 },
+      token1: { address: 'ct_1', symbol: 'BBB', decimals: 18 },
+    });
+    // Page 1 is full (100 items) so a second page is requested; page 2 is short,
+    // so pagination stops there (no meta to rely on).
+    const calls = mockFetch([
+      {
+        match: 'page=1',
+        body: { items: Array.from({ length: 100 }, (_, i) => mkPair(`ct_${i}`)) },
+      },
+      {
+        match: 'page=2',
+        body: { items: [mkPair('ct_last')] },
+      },
+    ]);
+
+    const result = (await getPairs(false))!;
+
+    expect(calls).toHaveLength(2);
+    expect(result).toHaveLength(101);
+  });
+
+  it('getSwapRoutes passes the legacy route shape through unchanged', async () => {
+    const routes = [
+      [
+        {
+          address: 'ct_pair',
+          synchronized: true,
+          token0: 'ct_0',
+          token1: 'ct_1',
+          liquidityInfo: {
+            totalSupply: '300',
+            reserve0: '100',
+            reserve1: '200',
+          },
+        },
+      ],
+    ];
+    const calls = mockFetch([{ match: 'dex/swap-routes/', body: routes }]);
+
+    const result = await getSwapRoutes('ct_0', 'ct_1');
+
+    expect(calls[0]).toContain('/api/dex/swap-routes/ct_0/ct_1');
+    expect(result).toEqual(routes);
+  });
+
+  it('getGraph maps Price candles to {labels,data} and returns null for TVL', async () => {
+    mockFetch([
+      {
+        match: 'dex/tokens/ct_a/history',
+        body: [
+          {
+            timeClose: '2025-01-01T01:00:00.000Z',
+            quote: { close: '1.5', volume: 10 },
+          },
+          {
+            timeClose: '2025-01-01T02:00:00.000Z',
+            quote: { close: '1.8', volume: 20 },
+          },
+        ],
+      },
+    ]);
+
+    const price = await getGraph({
+      graphType: 'Price',
+      timeFrame: '1W',
+      tokenAddress: 'ct_a',
+    });
+    expect(price?.data).toEqual([1.5, 1.8]);
+    expect(price?.labels).toEqual([
+      new Date('2025-01-01T01:00:00.000Z').getTime(),
+      new Date('2025-01-01T02:00:00.000Z').getTime(),
+    ]);
+
+    // TVL has no data source on the new backend.
+    const tvl = await getGraph({
+      graphType: 'TVL',
+      timeFrame: '1W',
+      tokenAddress: 'ct_a',
+    });
+    expect(tvl).toBeNull();
+  });
+
+  it('getHistory maps swaps, derives in/out, and sends since as from_date', async () => {
+    const since = Date.parse('2025-01-01T00:00:00.000Z');
+    const calls = mockFetch([
+      {
+        match: 'dex/transactions',
+        body: {
+          items: [
+            {
+              tx_hash: 'th_x',
+              tx_type: 'swap_exact_tokens_for_tokens',
+              account_address: 'ak_a',
+              created_at: '2025-01-02T00:00:00.000Z',
+              pair: {
+                address: 'ct_pair',
+                token0: { address: 'ct_0', symbol: 'AAA', decimals: 18 },
+                token1: { address: 'ct_1', symbol: 'WAE', decimals: 18 },
+              },
+              swap_info: {
+                amount0In: '1000000000000000000',
+                amount1In: '0',
+                amount0Out: '0',
+                amount1Out: '2000000000000000000',
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const [tx] = (await getHistory({ limit: 100, since, type: 'swap' }))!;
+
+    expect(calls[0]).toContain('from_date=2025-01-01T00%3A00%3A00.000Z');
+    expect(tx.txHash).toBe('th_x');
+    expect(tx.type).toBe('swap');
+    expect(tx.tokenInSymbol).toBe('AAA');
+    expect(tx.tokenOutSymbol).toBe('WAE');
+    expect(tx.amountIn).toBe('1');
+    expect(tx.amountOut).toBe('2');
+  });
+
+  it('getHistory filters by legacy category client-side', async () => {
+    mockFetch([
+      {
+        match: 'dex/transactions',
+        body: {
+          items: [
+            {
+              tx_hash: 'th_swap',
+              tx_type: 'swap_exact_tokens_for_tokens',
+              created_at: '2025-01-02T00:00:00.000Z',
+              pair: {
+                address: 'ct_pair',
+                token0: { address: 'ct_0', symbol: 'AAA', decimals: 18 },
+                token1: { address: 'ct_1', symbol: 'WAE', decimals: 18 },
+              },
+              swap_info: { amount0In: '1', amount1Out: '1' },
+            },
+            {
+              tx_hash: 'th_add',
+              tx_type: 'add_liquidity',
+              created_at: '2025-01-02T00:00:00.000Z',
+              pair: {
+                address: 'ct_pair',
+                token0: { address: 'ct_0', symbol: 'AAA', decimals: 18 },
+                token1: { address: 'ct_1', symbol: 'WAE', decimals: 18 },
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    const result = (await getHistory({ type: 'add' }))!;
+
+    expect(result).toHaveLength(1);
+    expect(result[0].txHash).toBe('th_add');
+    expect(result[0].type).toBe('add');
+  });
+
+  it('returns null on a non-ok response', async () => {
+    mockFetch([{ match: 'dex/tokens?limit=100', body: {}, ok: false }]);
+    expect(await getAllTokens()).toBeNull();
+  });
+});

--- a/src/libs/dexBackend.ts
+++ b/src/libs/dexBackend.ts
@@ -1,33 +1,209 @@
+import BigNumber from 'bignumber.js';
 import { CONFIG } from '../config';
 
-function pickDexBackendUrl(): string | null {
-  const explicit = CONFIG.DEX_BACKEND_URL;
-  if (explicit) return explicit;
-  const isTestnet = CONFIG.NETWORK === 'ae_uat';
-  const mainnet = CONFIG.MAINNET_DEX_BACKEND_URL;
-  const testnetBackend = CONFIG.TESTNET_DEX_BACKEND_URL;
-  return (isTestnet ? testnetBackend : mainnet) ?? null;
+/**
+ * DEX data client.
+ *
+ * Historically this hit the standalone "dex-backend" service (CONFIG.DEX_BACKEND_URL).
+ * It now talks to the unified superhero-api (CONFIG.SUPERHERO_API_URL, the same base
+ * the generated OpenAPI client uses) under the `/api/dex/*` routes, and adapts the
+ * new (paginated, nested) responses back into the flat shapes the existing
+ * consumers expect — so callers (usePairList, useTokenList, useTransactionList,
+ * useSwapQuote, TokenDetail, AddTokens, TokenPricePerformance) keep working
+ * unchanged.
+ *
+ * Resilience matches the old behaviour: every call resolves to `null` (or an empty
+ * adaptation) on error/timeout rather than throwing, so callers' `data || []`
+ * fallbacks still hold.
+ */
+
+function apiBaseUrl(): string {
+  const base = CONFIG.SUPERHERO_API_URL;
+  if (!base) return '';
+  return base.endsWith('/') ? base.slice(0, -1) : base;
 }
 
-async function safeFetch<T>(url: string, { timeoutMs = 2000 }: { timeoutMs?: number } = {}): Promise<T | null> {
-  const baseUrl = pickDexBackendUrl();
-  if (!baseUrl) return null;
-  const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-  const fullUrl = `${base}${url.startsWith('/') ? '' : '/'}${url}`;
+async function apiGet<T>(
+  path: string,
+  { timeoutMs = 8000 }: { timeoutMs?: number } = {},
+): Promise<T | null> {
+  const base = apiBaseUrl();
+  if (!base) return null;
+  const fullUrl = `${base}/api/${path.startsWith('/') ? path.slice(1) : path}`;
 
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const resp = await fetch(fullUrl, { signal: controller.signal });
-    const body = await resp.json();
     if (!resp.ok) return null;
-    return body as T;
+    return (await resp.json()) as T;
   } catch {
     return null;
   } finally {
     clearTimeout(id);
   }
 }
+
+// ---- shared types (loose; the new API returns richer objects) ----
+
+interface PageMeta {
+  currentPage?: number;
+  totalPages?: number;
+  totalItems?: number;
+  itemsPerPage?: number;
+  itemCount?: number;
+}
+
+interface PaginatedResponse<T> {
+  items?: T[];
+  meta?: PageMeta;
+}
+
+/**
+ * Fetches every page of a paginated `/dex/*` list and concatenates the items.
+ *
+ * The old dex-backend list calls returned the full set in one shot; the new API
+ * caps each response (default 100), so a single request silently drops anything
+ * past the first page. This walks all pages instead.
+ *
+ * - Stops at `meta.totalPages` when the server reports it, otherwise stops as
+ *   soon as a page comes back shorter than `pageSize` (end reached).
+ * - `maxPages` is a hard safety backstop against a runaway loop.
+ * - Preserves the module's null-on-error contract only for a failed *first*
+ *   page; a failure part-way through returns the items gathered so far rather
+ *   than discarding a nearly complete list.
+ */
+async function apiGetAllPages<T>(
+  path: string,
+  { pageSize = 100, maxPages = 100 }: { pageSize?: number; maxPages?: number } = {},
+): Promise<T[] | null> {
+  const sep = path.includes('?') ? '&' : '?';
+  const items: T[] = [];
+
+  for (let page = 1; page <= maxPages; page += 1) {
+    // Pages must be fetched in order to read each page's meta before the next.
+    // eslint-disable-next-line no-await-in-loop
+    const res = await apiGet<PaginatedResponse<T>>(
+      `${path}${sep}limit=${pageSize}&page=${page}`,
+    );
+    if (!res?.items) {
+      return page === 1 ? null : items;
+    }
+    items.push(...res.items);
+
+    const { totalPages } = res.meta ?? {};
+    if (totalPages != null) {
+      if (page >= totalPages) break;
+    } else if (res.items.length < pageSize) {
+      break;
+    }
+  }
+
+  return items;
+}
+
+interface ApiPrice {
+  ae?: number;
+  usd?: number;
+  [currency: string]: number | undefined;
+}
+
+interface ApiPeriodChange {
+  volume?: ApiPrice;
+  percentage?: string;
+}
+
+interface ApiTokenSummary {
+  total_volume?: ApiPrice;
+  change?: Record<'24h' | '7d' | '30d', ApiPeriodChange | undefined>;
+}
+
+interface ApiDexToken {
+  address: string;
+  name: string;
+  symbol: string;
+  decimals: number;
+  pairs_count?: number;
+  is_ae?: boolean;
+  listed?: boolean;
+  price?: ApiPrice;
+  summary?: ApiTokenSummary;
+}
+
+interface ApiPair {
+  address: string;
+  token0: ApiDexToken;
+  token1: ApiDexToken;
+  transactions_count?: number;
+  reserve0?: string;
+  reserve1?: string;
+  total_supply?: string;
+  summary?: {
+    total_volume?: ApiPrice;
+    change?: Record<'24h' | '7d' | '30d', ApiPeriodChange | undefined>;
+  };
+}
+
+interface ApiPairTransaction {
+  tx_hash: string;
+  account_address?: string;
+  pair: ApiPair;
+  tx_type: string;
+  swap_info?: {
+    amount0In?: string;
+    amount1In?: string;
+    amount0Out?: string;
+    amount1Out?: string;
+    to?: string;
+  } | null;
+  created_at: string;
+}
+
+interface ApiCandle {
+  timeOpen: string;
+  timeClose: string;
+  quote: {
+    convertedTo: string;
+    open: string;
+    high: string;
+    low: string;
+    close: string;
+    volume: number;
+  };
+}
+
+// ---- helpers ----
+
+const num = (v: unknown): number => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+const str = (v: unknown): string | undefined => (
+  v === undefined || v === null ? undefined : String(v)
+);
+
+const human = (raw: unknown, decimals = 18): BigNumber => new BigNumber(String(raw ?? '0')).shiftedBy(-decimals);
+
+/** Reserve-priced TVL in USD for a pair, computed from reserves × token USD prices. */
+function pairTvlUsd(pair: ApiPair): string | undefined {
+  const p0 = pair.token0?.price?.usd;
+  const p1 = pair.token1?.price?.usd;
+  if (p0 == null && p1 == null) return undefined;
+  const tvl0 = human(pair.reserve0, pair.token0?.decimals ?? 18).multipliedBy(
+    p0 ?? 0,
+  );
+  const tvl1 = human(pair.reserve1, pair.token1?.decimals ?? 18).multipliedBy(
+    p1 ?? 0,
+  );
+  return tvl0.plus(tvl1).toString();
+}
+
+function isSynchronized(pair: ApiPair): boolean {
+  return num(pair.reserve0) > 0 && num(pair.reserve1) > 0;
+}
+
+// ---- adapters / public API (signatures unchanged) ----
 
 type ListedToken = {
   address: string;
@@ -37,35 +213,243 @@ type ListedToken = {
 };
 
 export async function getListedTokens(): Promise<ListedToken[] | null> {
-  return safeFetch<ListedToken[]>('tokens/listed');
+  const items = await apiGetAllPages<ApiDexToken>('dex/tokens?listed=true');
+  if (!items) return null;
+  return items.map((t) => ({
+    address: t.address,
+    name: t.name,
+    symbol: t.symbol,
+    decimals: t.decimals,
+  }));
+}
+
+function adaptToken(t: ApiDexToken): Record<string, any> {
+  const change = t.summary?.change;
+  return {
+    address: t.address,
+    symbol: t.symbol,
+    name: t.name,
+    decimals: t.decimals,
+    listed: t.listed,
+    pairs: t.pairs_count ?? 0,
+    priceAe: str(t.price?.ae),
+    priceUsd: str(t.price?.usd),
+    // No per-token TVL on the new backend (only aggregated volume); left undefined.
+    tvlUsd: undefined,
+    priceChangeDay: str(change?.['24h']?.percentage),
+    priceChangeWeek: str(change?.['7d']?.percentage),
+    priceChangeMonth: str(change?.['30d']?.percentage),
+    volumeUsdDay: str(change?.['24h']?.volume?.usd),
+    volumeUsdWeek: str(change?.['7d']?.volume?.usd),
+    volumeUsdMonth: str(change?.['30d']?.volume?.usd),
+    volumeUsdAll: str(t.summary?.total_volume?.usd),
+  };
 }
 
 export async function getAllTokens(): Promise<any[] | null> {
-  return safeFetch<any[]>('tokens');
+  const items = await apiGetAllPages<ApiDexToken>('dex/tokens');
+  if (!items) return null;
+  return items.map(adaptToken);
 }
 
 export async function getTokenWithUsd(tokenId: string): Promise<any | null> {
-  return safeFetch<any>(`tokens/${tokenId}`);
+  const t = await apiGet<ApiDexToken>(
+    `dex/tokens/${encodeURIComponent(tokenId)}`,
+  );
+  if (!t) return null;
+  return {
+    ...adaptToken(t),
+    // `totalReserve` (token reserves summed across pools) has no equivalent on
+    // the new backend; surface an empty string so the UI renders blank rather
+    // than crashing.
+    totalReserve: '',
+  };
+}
+
+function adaptPair(p: ApiPair): Record<string, any> {
+  return {
+    address: p.address,
+    token0: p.token0?.address,
+    token1: p.token1?.address,
+    token0Symbol: p.token0?.symbol,
+    token1Symbol: p.token1?.symbol,
+    transactions: p.transactions_count ?? 0,
+    synchronized: isSynchronized(p),
+    tvlUsd: pairTvlUsd(p),
+    volume24h: str(p.summary?.change?.['24h']?.volume?.usd),
+    volumeUsdAll: str(p.summary?.total_volume?.usd),
+  };
 }
 
 export async function getPairs(onlyListed = false): Promise<any[] | null> {
-  return safeFetch<any[]>(`pairs?only-listed=${onlyListed ? 'true' : 'false'}`);
+  // The new /dex/pairs endpoint has no `only-listed` query filter, so replicate
+  // the legacy semantics (both tokens listed) client-side when requested.
+  const all = await apiGetAllPages<ApiPair>('dex/pairs');
+  if (!all) return null;
+  const items = onlyListed
+    ? all.filter((p) => p.token0?.listed && p.token1?.listed)
+    : all;
+  return items.map(adaptPair);
 }
 
 export async function getPairsByTokenUsd(tokenId: string): Promise<any[] | null> {
-  return safeFetch<any[]>(`pairs?token=${encodeURIComponent(tokenId)}`);
+  const items = await apiGetAllPages<ApiPair>(
+    `dex/pairs?token_address=${encodeURIComponent(tokenId)}`,
+  );
+  if (!items) return null;
+  return items.map(adaptPair);
 }
 
-export async function getSwapRoutes(tokenA: string, tokenB: string): Promise<any[][] | null> {
-  return safeFetch<any[][]>(`swap-routes/${tokenA}/${tokenB}`);
+export async function getSwapRoutes(
+  tokenA: string,
+  tokenB: string,
+): Promise<any[][] | null> {
+  // The new /dex/swap-routes endpoint already returns the legacy route shape
+  // (address-form tokens + `synchronized` + `liquidityInfo`), so no adaptation
+  // is needed.
+  return apiGet<any[][]>(
+    `dex/swap-routes/${encodeURIComponent(tokenA)}/${encodeURIComponent(tokenB)}`,
+  );
 }
 
-export async function getGraph(params: Record<string, any>): Promise<any | null> {
-  const qs = new URLSearchParams(params as any).toString();
-  return safeFetch<any>(`graph?${qs}`);
+const TIME_FRAME_TO_HISTORY: Record<
+  string,
+  { interval: number; limit: number }
+> = {
+  '1H': { interval: 60, limit: 60 },
+  '1D': { interval: 900, limit: 96 },
+  '1W': { interval: 3600, limit: 168 },
+  '1M': { interval: 14400, limit: 180 },
+  '1Y': { interval: 86400, limit: 365 },
+  MAX: { interval: 86400, limit: 1000 },
+};
+
+/**
+ * Adapts the legacy `/graph` endpoint to the new OHLCV history endpoints.
+ *
+ * Supported: graphType Price and Volume, derived from price candles
+ * (token-level via /dex/tokens/:addr/history, pair-level via
+ * /dex/pairs/:addr/history). graphType TVL / Fees / Locked have NO data source
+ * on the new backend and resolve to null (the chart shows no series for them).
+ */
+export async function getGraph(
+  params: Record<string, any>,
+): Promise<any | null> {
+  const graphType = String(params.graphType ?? 'Price');
+  const timeFrame = String(params.timeFrame ?? 'MAX');
+  const { interval, limit } = TIME_FRAME_TO_HISTORY[timeFrame]
+    ?? TIME_FRAME_TO_HISTORY.MAX;
+
+  const valueFor = (candle: ApiCandle): number => {
+    if (graphType === 'Volume') return num(candle.quote.volume);
+    // Price (default): use the candle close.
+    return num(candle.quote.close);
+  };
+
+  if (graphType !== 'Price' && graphType !== 'Volume') {
+    // TVL / Fees / Locked time-series are not produced by the new backend.
+    return null;
+  }
+
+  const query = `interval=${interval}&limit=${limit}`;
+  let candles: ApiCandle[] | null = null;
+  if (params.tokenAddress) {
+    candles = await apiGet<ApiCandle[]>(
+      `dex/tokens/${encodeURIComponent(params.tokenAddress)}/history?${query}`,
+    );
+  } else if (params.pairAddress) {
+    candles = await apiGet<ApiCandle[]>(
+      `dex/pairs/${encodeURIComponent(params.pairAddress)}/history?${query}`,
+    );
+  }
+  if (!candles) return null;
+
+  // The denomination the series is priced in ('ae' or another token's symbol
+  // when the token has no AE pool). Surfaced so the UI can label the axis and
+  // avoid implying an AE price where there isn't one.
+  const unit = candles[candles.length - 1]?.quote?.convertedTo ?? null;
+
+  return {
+    graphType,
+    timeFrame,
+    unit,
+    labels: candles.map((c) => new Date(c.timeClose).getTime()),
+    data: candles.map(valueFor),
+  };
 }
 
-export async function getHistory(params: Record<string, any>): Promise<any[] | null> {
-  const qs = new URLSearchParams(params as any).toString();
-  return safeFetch<any[]>(`history?${qs}`);
+/** Map an on-chain DEX function name to the legacy category used by the UI. */
+function txCategory(txType: string): 'swap' | 'add' | 'remove' | string {
+  if (txType?.startsWith('swap')) return 'swap';
+  if (txType === 'add_liquidity') return 'add';
+  if (txType === 'remove_liquidity') return 'remove';
+  return txType;
+}
+
+function adaptTransaction(tx: ApiPairTransaction): Record<string, any> {
+  const category = txCategory(tx.tx_type);
+  const token0 = tx.pair?.token0;
+  const token1 = tx.pair?.token1;
+
+  let tokenInSymbol: string | undefined;
+  let tokenOutSymbol: string | undefined;
+  let amountIn: string | undefined;
+  let amountOut: string | undefined;
+
+  if (category === 'swap' && tx.swap_info) {
+    const token0IsInput = num(tx.swap_info.amount0In) > 0;
+    if (token0IsInput) {
+      tokenInSymbol = token0?.symbol;
+      tokenOutSymbol = token1?.symbol;
+      amountIn = human(tx.swap_info.amount0In, token0?.decimals).toString();
+      amountOut = human(tx.swap_info.amount1Out, token1?.decimals).toString();
+    } else {
+      tokenInSymbol = token1?.symbol;
+      tokenOutSymbol = token0?.symbol;
+      amountIn = human(tx.swap_info.amount1In, token1?.decimals).toString();
+      amountOut = human(tx.swap_info.amount0Out, token0?.decimals).toString();
+    }
+  }
+
+  return {
+    txHash: tx.tx_hash,
+    type: category,
+    event: tx.tx_type,
+    senderAccount: tx.account_address,
+    pairAddress: tx.pair?.address,
+    token0Symbol: token0?.symbol,
+    token1Symbol: token1?.symbol,
+    tokenInSymbol,
+    tokenOutSymbol,
+    amountIn,
+    amountOut,
+    microBlockTime: tx.created_at,
+  };
+}
+
+export async function getHistory(
+  params: Record<string, any>,
+): Promise<any[] | null> {
+  const limit = params.limit ?? 100;
+  const query = new URLSearchParams();
+  query.set('limit', String(limit));
+  query.set('order_by', 'created_at');
+  query.set('order_direction', 'DESC');
+  // The legacy `since` is epoch ms; the new endpoint filters by an ISO date.
+  if (params.since != null) {
+    query.set('from_date', new Date(Number(params.since)).toISOString());
+  }
+
+  const res = await apiGet<PaginatedResponse<ApiPairTransaction>>(
+    `dex/transactions?${query.toString()}`,
+  );
+  if (!res?.items) return null;
+
+  let items = res.items.map(adaptTransaction);
+  // The new endpoint filters tx_type by exact on-chain function name, not by the
+  // legacy 'swap'|'add'|'remove' category, so apply the category filter here.
+  if (params.type && params.type !== 'all') {
+    items = items.filter((tx) => tx.type === params.type);
+  }
+  return items;
 }

--- a/src/views/TokenDetail.tsx
+++ b/src/views/TokenDetail.tsx
@@ -201,9 +201,16 @@ export default function TokenDetail() {
                   {t('explore.price')}
                 </div>
                 <div className="text-2xl font-extrabold text-white mb-1 font-mono">
-                  <PriceDataFormatter
-                    priceData={tokenDetails?.price}
-                  />
+                  {tokenDetails && tokenDetails.price?.ae == null ? (
+                    <span
+                      className="text-base font-semibold text-white/50"
+                      title="This token has no liquidity pool against AE, so an AE price can't be determined."
+                    >
+                      No AE price
+                    </span>
+                  ) : (
+                    <PriceDataFormatter priceData={tokenDetails?.price} />
+                  )}
                 </div>
                 {tokenDetails?.summary?.change?.[selectedPeriod]
                   ?.percentage && (
@@ -481,9 +488,9 @@ export default function TokenDetail() {
                     marginBottom: 2,
                   }}
                 >
-                  {circulatingSupply ? (
+                  {circulatingSupply && tokenDetails?.price?.ae != null ? (
                     <>
-                      {circulatingSupply.mul(Decimal.from(tokenDetails?.price?.ae || 0)).shorten()}
+                      {circulatingSupply.mul(Decimal.from(tokenDetails.price.ae)).shorten()}
                       {' '}
                       AE
                     </>
@@ -541,8 +548,6 @@ export default function TokenDetail() {
                 availableGraphTypes={[
                   { type: 'Price', text: t('explore.price') },
                   { type: 'Volume', text: t('explore.volume') },
-                  { type: 'TVL', text: t('explore.tvl') },
-                  { type: 'Fees', text: t('explore.fees') },
                 ]}
                 initialChart={{ type: 'Price', text: t('explore.price') }}
                 initialTimeFrame="1Y"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broad DEX data path change (all explore/swap/chart consumers) with client-side adaptation; chart and null-handling changes reduce crash/wrong-display risk but regressions in mapping or pagination could affect listings and swaps.
> 
> **Overview**
> **Routes all DEX list/graph/history calls through superhero-api** (`CONFIG.SUPERHERO_API_URL` + `/api/dex/*`) instead of the old dex-backend, with adapters that flatten paginated/nested responses into the legacy shapes existing hooks and views already expect. List endpoints now **walk all pages**; **Price/Volume** charts come from token/pair OHLCV history; **TVL / Fees / Locked** graph TD return **null** (no backend source). History swaps map on-chain tx types to legacy categories and apply category filters client-side.
> 
> **Token price performance** gets several correctness fixes: timeframe windows anchor to the **latest candle** (not wall-clock now), out-of-range/degenerate points are dropped so lightweight-charts cannot crash the page, **“No data”** reflects what is actually plotted and stale series are cleared when fetch fails or filters empty the window. **Price** uses a **custom axis/crosshair formatter** for tiny values and shows a **unit banner** when the quote is not in AE.
> 
> **Token detail** shows **“No AE price”** and skips AE market cap when there is no AE pool, and drops **TVL/Fees** from the performance chart selector (only Price + Volume).
> 
> Adds **Vitest coverage** for the new dexBackend adapters (pagination, mapping, null on errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d3ae788525ee804a45dea07660526f69a6fabf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/615/) — updated Thu, 09 Jul 2026 08:36:19 GMT