### PR TITLE
refactor: parse post content correctly

### DIFF
--- a/src/features/social/components/ReplyToFeedItem.tsx
+++ b/src/features/social/components/ReplyToFeedItem.tsx
@@ -10,11 +10,13 @@ import { AspectMedia } from '@/components/AspectMedia';
 import { PostDto, PostsService } from '../../../api/generated';
 import { linkify } from '../../../utils/linkify';
 import { formatAddress } from '../../../utils/address';
+import { mergedCollectionNameCharsPattern } from '../../../utils/collectionNameChars';
 import { BlockchainInfoPopover } from './BlockchainInfoPopover';
 import InlineCopyButton from './InlineCopyButton';
 import SharePopover from './SharePopover';
 import PostTipButton from './PostTipButton';
 import { useWallet } from '../../../hooks';
+import { useCommunityFactory } from '../../../hooks/useCommunityFactory';
 import { useStorePostSenderChainNames } from '../../../hooks/useChainName';
 import { compactTime, fullTimestamp } from '../../../utils/time';
 import { useCompactFeedItemLayout } from './useCompactFeedItemLayout';
@@ -94,6 +96,18 @@ const ReplyToFeedItem = memo(({
   const displayName = (profileDisplayNames?.[authorAddress] ?? chainNames?.[authorAddress] ?? '').trim();
   const hasDisplayName = Boolean(displayName);
   const { containerRef, isCompact } = useCompactFeedItemLayout(item.tx_hash ? 700 : 620);
+
+  // Token collections (WORDS/Chinese/Arabic/Russian/...) drive which characters a hashtag's
+  // token name may contain. Loaded once and reused so new collections the backend adds are
+  // picked up automatically, with no changes needed here.
+  const { activeFactoryCollections, loadFactorySchema } = useCommunityFactory();
+  useEffect(() => {
+    if (!activeFactoryCollections.length) loadFactorySchema().catch(() => {});
+  }, [activeFactoryCollections.length, loadFactorySchema]);
+  const hashtagAllowedChars = useMemo(
+    () => mergedCollectionNameCharsPattern(activeFactoryCollections),
+    [activeFactoryCollections],
+  );
 
   const parentId = useParentId(item);
   const [parent, setParent] = useState<PostDto | null>(null);
@@ -398,6 +412,7 @@ const ReplyToFeedItem = memo(({
                     ),
                     hashtagVariant: 'post-inline',
                     trendMentions: (parent as any)?.trend_mentions,
+                    hashtagAllowedChars,
                   })}
               </div>
               <div className="mt-1 text-[11px] text-white/70">{t('showPost')}</div>
@@ -412,6 +427,7 @@ const ReplyToFeedItem = memo(({
               ),
               hashtagVariant: 'post-inline',
               trendMentions: (item as any)?.trend_mentions,
+              hashtagAllowedChars,
             })}
           </div>
 

--- a/src/features/social/components/TokenCreatedActivityItem.tsx
+++ b/src/features/social/components/TokenCreatedActivityItem.tsx
@@ -1,12 +1,16 @@
-import { memo, useMemo, useCallback } from 'react';
+import {
+  memo, useMemo, useCallback, useEffect,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AddressAvatarWithChainName } from '@/@components/Address/AddressAvatarWithChainName';
 import { linkify } from '../../../utils/linkify';
 import { useWallet } from '../../../hooks';
+import { useCommunityFactory } from '../../../hooks/useCommunityFactory';
 import type { PostDto } from '../../../api/generated';
 import { compactTime } from '../../../utils/time';
 import { formatAddress } from '../../../utils/address';
+import { mergedCollectionNameCharsPattern } from '../../../utils/collectionNameChars';
 // SharePopover removed from activity row per design
 
 interface TokenCreatedActivityItemProps {
@@ -53,6 +57,18 @@ const TokenCreatedActivityItem = memo(({
   const tokenName = useTokenName(item);
   const tokenLink = tokenName ? `/trends/tokens/${tokenName}` : undefined;
 
+  // Token collections (WORDS/Chinese/Arabic/Russian/...) drive which characters a hashtag's
+  // token name may contain. Loaded once and reused so new collections the backend adds are
+  // picked up automatically, with no changes needed here.
+  const { activeFactoryCollections, loadFactorySchema } = useCommunityFactory();
+  useEffect(() => {
+    if (!activeFactoryCollections.length) loadFactorySchema().catch(() => {});
+  }, [activeFactoryCollections.length, loadFactorySchema]);
+  const hashtagAllowedChars = useMemo(
+    () => mergedCollectionNameCharsPattern(activeFactoryCollections),
+    [activeFactoryCollections],
+  );
+
   const onOpen = useCallback(() => {
     if (tokenLink) navigate(tokenLink);
   }, [navigate, tokenLink]);
@@ -82,7 +98,7 @@ const TokenCreatedActivityItem = memo(({
             <span className="text-white/70 shrink-0">{t('created')}</span>
             {tokenName && (
               <span className="truncate max-w-[24ch] text-white/90">
-                {linkify(`#${tokenName}`, { hashtagVariant: 'post-inline' })}
+                {linkify(`#${tokenName}`, { hashtagVariant: 'post-inline', hashtagAllowedChars })}
               </span>
             )}
             <span className="text-white/50 shrink-0">·</span>

--- a/src/utils/__tests__/collectionNameChars.test.ts
+++ b/src/utils/__tests__/collectionNameChars.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { allowedNameCharsToPattern, mergedCollectionNameCharsPattern } from '../collectionNameChars';
+import type { ICollectionData } from '../types';
+
+// Mirrors the shape returned by the BCL factory contract for NETWORK_ID_MAINNET.
+const WORDS: ICollectionData = {
+  id: 'WORDS-ak_2X6puZgdPKcfjSVdUGs2bvsvkbsCLN8XbKQwSVtqLUBc3518bi',
+  name: 'WORDS',
+  allowed_name_length: '20',
+  allowed_name_chars: [
+    { SingleChar: [45] },
+    { CharRangeFromTo: [48, 57] },
+    { CharRangeFromTo: [65, 90] },
+  ],
+  description: 'Allowed: A–Z, 0–9, and -',
+};
+
+const CHINESE: ICollectionData = {
+  id: 'CHINESE-ak_2vmVWHYLRaqdoyLdWEUBi1NodQ3MA1bFuqqRe9A5DgNv3qoDuV',
+  name: 'CHINESE',
+  allowed_name_length: '20',
+  allowed_name_chars: [
+    { SingleChar: [45] },
+    { CharRangeFromTo: [19968, 40959] },
+  ],
+  description: '允许：汉字和 -',
+};
+
+const ARABIC: ICollectionData = {
+  id: 'ARABIC-ak_2vmVWHYLRaqdoyLdWEUBi1NodQ3MA1bFuqqRe9A5DgNv3qoDuV',
+  name: 'ARABIC',
+  allowed_name_length: '20',
+  allowed_name_chars: [
+    { SingleChar: [45] },
+    { CharRangeFromTo: [1569, 1610] },
+  ],
+  description: 'المسموح به: الأحرف العربية و -',
+};
+
+const RUSSIAN: ICollectionData = {
+  id: 'RUSSIAN-ak_2vmVWHYLRaqdoyLdWEUBi1NodQ3MA1bFuqqRe9A5DgNv3qoDuV',
+  name: 'RUSSIAN',
+  allowed_name_length: '20',
+  allowed_name_chars: [
+    { SingleChar: [45] },
+    { SingleChar: [1025] },
+    { CharRangeFromTo: [1040, 1071] },
+  ],
+  description: 'Разрешено: А–Я, Ё и -',
+};
+
+describe('allowedNameCharsToPattern', () => {
+  it('converts SingleChar and CharRangeFromTo rules into a character-class body', () => {
+    expect(allowedNameCharsToPattern(WORDS.allowed_name_chars)).toBe('\\-0-9A-Z');
+  });
+
+  it('returns an empty string for missing/empty rules', () => {
+    expect(allowedNameCharsToPattern(undefined)).toBe('');
+    expect(allowedNameCharsToPattern([])).toBe('');
+  });
+});
+
+describe('mergedCollectionNameCharsPattern', () => {
+  it('merges every collection into one pattern usable inside a single character class', () => {
+    const pattern = mergedCollectionNameCharsPattern([WORDS, CHINESE, ARABIC, RUSSIAN]);
+    const regex = new RegExp(`^[A-Za-z0-9\\-${pattern}]+$`, 'u');
+
+    expect(regex.test('WORD-123')).toBe(true);
+    expect(regex.test('你好')).toBe(true);
+    expect(regex.test('مرحبا')).toBe(true);
+    expect(regex.test('ПРИВЕТ')).toBe(true);
+    expect(regex.test('Ё')).toBe(true);
+    // A character from no collection's alphabet at all.
+    expect(regex.test('こんにちは')).toBe(false);
+  });
+
+  it('accepts a Record (as returned by the factory schema) as well as an array', () => {
+    const asRecord = { [WORDS.id]: WORDS, [CHINESE.id]: CHINESE };
+    const pattern = mergedCollectionNameCharsPattern(asRecord);
+    const regex = new RegExp(`^[${pattern}]+$`, 'u');
+
+    expect(regex.test('你好-WORD')).toBe(true);
+  });
+
+  it('is a no-op (empty string) when there are no collections yet', () => {
+    expect(mergedCollectionNameCharsPattern([])).toBe('');
+    expect(mergedCollectionNameCharsPattern(undefined)).toBe('');
+    expect(mergedCollectionNameCharsPattern(null)).toBe('');
+  });
+});

--- a/src/utils/__tests__/linkify.test.tsx
+++ b/src/utils/__tests__/linkify.test.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import { linkify } from '../linkify';
+import { mergedCollectionNameCharsPattern } from '../collectionNameChars';
+import type { ICollectionData } from '../types';
+
+function renderLinkify(text: string, options?: Parameters<typeof linkify>[1]) {
+  return render(
+    <MemoryRouter>
+      <div data-testid="content">{linkify(text, options)}</div>
+    </MemoryRouter>,
+  );
+}
+
+// Mirrors the non-Latin BCL collections deployed on mainnet.
+const CHINESE_COLLECTION: ICollectionData = {
+  id: 'CHINESE-ak_2vmVWHYLRaqdoyLdWEUBi1NodQ3MA1bFuqqRe9A5DgNv3qoDuV',
+  name: 'CHINESE',
+  allowed_name_length: '20',
+  allowed_name_chars: [{ SingleChar: [45] }, { CharRangeFromTo: [19968, 40959] }],
+};
+const ARABIC_COLLECTION: ICollectionData = {
+  id: 'ARABIC-ak_2vmVWHYLRaqdoyLdWEUBi1NodQ3MA1bFuqqRe9A5DgNv3qoDuV',
+  name: 'ARABIC',
+  allowed_name_length: '20',
+  allowed_name_chars: [{ SingleChar: [45] }, { CharRangeFromTo: [1569, 1610] }],
+};
+const RUSSIAN_COLLECTION: ICollectionData = {
+  id: 'RUSSIAN-ak_2vmVWHYLRaqdoyLdWEUBi1NodQ3MA1bFuqqRe9A5DgNv3qoDuV',
+  name: 'RUSSIAN',
+  allowed_name_length: '20',
+  allowed_name_chars: [
+    { SingleChar: [45] },
+    { SingleChar: [1025] },
+    { CharRangeFromTo: [1040, 1071] },
+  ],
+};
+const BCL_COLLECTIONS = [CHINESE_COLLECTION, ARABIC_COLLECTION, RUSSIAN_COLLECTION];
+
+describe('linkify hashtag parsing', () => {
+  it('parses "#emoter.ai/" as the hashtag "#emoter" followed by plain text ".ai/"', () => {
+    renderLinkify("What's up people? #emoter.ai/ is the future :)");
+
+    const link = screen.getByRole('link', { name: '#emoter' });
+    expect(link).toHaveAttribute('href', '/trends/tokens/EMOTER');
+
+    // The dot-prefixed remainder must not be turned into an external link.
+    expect(screen.queryByRole('link', { name: /emoter\.ai/i })).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe(
+      "What's up people? #emoter.ai/ is the future :)",
+    );
+  });
+
+  it('does not allow dots inside the parsed token name', () => {
+    renderLinkify('check out #foo.bar.baz now');
+
+    expect(screen.getByRole('link', { name: '#foo' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /foo\.bar/i })).not.toBeInTheDocument();
+  });
+
+  it('links a plain hashtag to the uppercased trending tokens route', () => {
+    renderLinkify('gm #ROCK-N-ROLL fam');
+
+    const link = screen.getByRole('link', { name: '#ROCK-N-ROLL' });
+    expect(link).toHaveAttribute('href', '/trends/tokens/ROCK-N-ROLL');
+  });
+
+  it('parses multiple hashtags in the same message independently', () => {
+    renderLinkify('#one and #two are both tokens');
+
+    expect(screen.getByRole('link', { name: '#one' })).toHaveAttribute('href', '/trends/tokens/ONE');
+    expect(screen.getByRole('link', { name: '#two' })).toHaveAttribute('href', '/trends/tokens/TWO');
+  });
+
+  it('does not let an AENS-style suffix swallow the hashtag ("#foo.chain")', () => {
+    renderLinkify('shoutout #foo.chain today');
+
+    expect(screen.getByRole('link', { name: '#foo' })).toBeInTheDocument();
+    // ".chain" is not a known chain name here, so it should stay plain text, not
+    // be consumed by the AENS matcher as part of a stolen token.
+    expect(screen.getByTestId('content').textContent).toBe('shoutout #foo.chain today');
+  });
+
+  it('does not let an account-style suffix swallow the hashtag ("#ak_123abc")', () => {
+    renderLinkify('gm #ak_123abc gm');
+
+    expect(screen.getByRole('link', { name: '#ak' })).toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('gm #ak_123abc gm');
+  });
+
+  it('still linkifies ordinary URLs that are not preceded by a hashtag', () => {
+    renderLinkify('visit https://example.com/page#section for more');
+
+    const link = screen.getByRole('link', { name: /example\.com\/page/i });
+    expect(link).toHaveAttribute('href', 'https://example.com/page#section');
+  });
+
+  it('still linkifies bare domains that are not preceded by a hashtag', () => {
+    renderLinkify('the future is emoter.ai/ now');
+
+    expect(screen.getByRole('link', { name: /emoter\.ai/i })).toBeInTheDocument();
+  });
+
+  it('still linkifies known AENS names that are not preceded by a hashtag', () => {
+    renderLinkify('say hi to bob.chain', { knownChainNames: new Set(['bob.chain']) });
+
+    const link = screen.getByRole('link', { name: 'bob.chain' });
+    expect(link).toHaveAttribute('href', '/users/bob.chain');
+  });
+
+  it('still linkifies ak_ account mentions that are not preceded by a hashtag', () => {
+    renderLinkify('sent to ak_123abc456');
+
+    const link = screen.getByRole('link', { name: /ak_123abc456/i });
+    expect(link).toHaveAttribute('href', '/users/ak_123abc456');
+  });
+
+  it('treats a lone "#" with no following token characters as plain text', () => {
+    renderLinkify('price went up # nice');
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('price went up # nice');
+  });
+
+  it('links every hashtag in a run with no separator ("#one#two")', () => {
+    renderLinkify('gm #one#two gm');
+
+    expect(screen.getByRole('link', { name: '#one' })).toHaveAttribute('href', '/trends/tokens/ONE');
+    expect(screen.getByRole('link', { name: '#two' })).toHaveAttribute('href', '/trends/tokens/TWO');
+    expect(screen.getByTestId('content').textContent).toBe('gm #one#two gm');
+  });
+
+  it('links three chained hashtags with no separators ("#one#two#three")', () => {
+    renderLinkify('#one#two#three');
+
+    expect(screen.getByRole('link', { name: '#one' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '#two' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '#three' })).toBeInTheDocument();
+  });
+
+  it('links hashtags separated by punctuation with no space ("#one,#two")', () => {
+    renderLinkify('#one,#two');
+
+    expect(screen.getByRole('link', { name: '#one' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '#two' })).toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('#one,#two');
+  });
+
+  it('resumes hashtag parsing after an invalid dotted remainder ("#emoter.ai/#foo")', () => {
+    renderLinkify('#emoter.ai/#foo');
+
+    expect(screen.getByRole('link', { name: '#emoter' })).toHaveAttribute('href', '/trends/tokens/EMOTER');
+    expect(screen.getByRole('link', { name: '#foo' })).toHaveAttribute('href', '/trends/tokens/FOO');
+    expect(screen.getByTestId('content').textContent).toBe('#emoter.ai/#foo');
+  });
+
+  it('treats a stray leading "#" as inert text but still links a later valid tag ("##foo")', () => {
+    renderLinkify('##foo');
+
+    const link = screen.getByRole('link', { name: '#foo' });
+    expect(link).toHaveAttribute('href', '/trends/tokens/FOO');
+    expect(screen.getByTestId('content').textContent).toBe('##foo');
+  });
+
+  it('leaves a run with no valid token anywhere fully untouched ("#_bad_stuff")', () => {
+    renderLinkify('gm #_bad_stuff gm');
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('gm #_bad_stuff gm');
+  });
+
+  it('does not treat a URL fragment as a hashtag when chained after a real hashtag word', () => {
+    renderLinkify('see #emoter then visit https://example.com/page#section');
+
+    expect(screen.getByRole('link', { name: '#emoter' })).toBeInTheDocument();
+    const urlLink = screen.getByRole('link', { name: /example\.com\/page/i });
+    expect(urlLink).toHaveAttribute('href', 'https://example.com/page#section');
+    expect(screen.queryByRole('link', { name: '#section' })).not.toBeInTheDocument();
+  });
+});
+
+describe('linkify hashtag parsing — non-Latin BCL collections', () => {
+  const hashtagAllowedChars = mergedCollectionNameCharsPattern(BCL_COLLECTIONS);
+
+  it('does not link a non-Latin token name when no collection data is provided (pre-load default)', () => {
+    renderLinkify('gm #你好 gm');
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('gm #你好 gm');
+  });
+
+  it('links a Chinese token name once the Chinese collection is known', () => {
+    renderLinkify('gm #你好 gm', { hashtagAllowedChars });
+
+    const link = screen.getByRole('link', { name: '#你好' });
+    expect(link).toHaveAttribute('href', `/trends/tokens/${encodeURIComponent('你好')}`);
+  });
+
+  it('links an Arabic token name once the Arabic collection is known', () => {
+    renderLinkify('#مرحبا is trending', { hashtagAllowedChars });
+
+    expect(screen.getByRole('link', { name: '#مرحبا' })).toBeInTheDocument();
+  });
+
+  it('links an uppercase Russian token name (including Ё) once the Russian collection is known', () => {
+    renderLinkify('#ПРИВЕТЁ is trending', { hashtagAllowedChars });
+
+    expect(screen.getByRole('link', { name: '#ПРИВЕТЁ' })).toBeInTheDocument();
+  });
+
+  it('still stops a non-Latin token name at an invalid trailing character', () => {
+    renderLinkify('#你好.link is trending', { hashtagAllowedChars });
+
+    expect(screen.getByRole('link', { name: '#你好' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /你好\.link/i })).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('#你好.link is trending');
+  });
+
+  it('still links plain Latin hashtags when collection chars are provided alongside them', () => {
+    renderLinkify('gm #ROCK-N-ROLL and #你好', { hashtagAllowedChars });
+
+    expect(screen.getByRole('link', { name: '#ROCK-N-ROLL' })).toHaveAttribute('href', '/trends/tokens/ROCK-N-ROLL');
+    expect(screen.getByRole('link', { name: '#你好' })).toBeInTheDocument();
+  });
+
+  it('does not link characters that belong to no known collection', () => {
+    renderLinkify('gm #こんにちは gm', { hashtagAllowedChars });
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/src/utils/collectionNameChars.ts
+++ b/src/utils/collectionNameChars.ts
@@ -1,0 +1,37 @@
+import type { IAllowedNameChars, ICollectionData } from './types';
+
+// Escapes a single character for safe use inside a regex character class ([...]).
+function escapeForCharClass(char: string): string {
+  return char.replace(/[\\\]^-]/g, '\\$&');
+}
+
+/**
+ * Converts one collection's `allowed_name_chars` rules (as returned by the BCL factory
+ * contract) into a regex character-class body, e.g. "A-Z0-9\-" for the WORDS collection.
+ */
+export function allowedNameCharsToPattern(rules: IAllowedNameChars[] | undefined | null): string {
+  if (!rules?.length) return '';
+  return rules.map((rule) => {
+    if (rule.SingleChar) {
+      return rule.SingleChar.map((code) => escapeForCharClass(String.fromCodePoint(code))).join('');
+    }
+    if (rule.CharRangeFromTo) {
+      const [start, end] = rule.CharRangeFromTo;
+      return `${escapeForCharClass(String.fromCodePoint(start))}-${escapeForCharClass(String.fromCodePoint(end))}`;
+    }
+    return '';
+  }).join('');
+}
+
+/**
+ * Merges the `allowed_name_chars` of every collection the BCL factory currently reports
+ * (WORDS/English, Chinese, Arabic, Russian, and any collection added later) into a single
+ * regex character-class body. New collections are picked up automatically as soon as they
+ * appear in the factory schema — nothing here needs to change when the backend adds one.
+ */
+export function mergedCollectionNameCharsPattern(
+  collections: ICollectionData[] | Record<string, ICollectionData> | undefined | null,
+): string {
+  const list = Array.isArray(collections) ? collections : Object.values(collections || {});
+  return list.map((c) => allowedNameCharsToPattern(c?.allowed_name_chars)).join('');
+}

--- a/src/utils/linkify.tsx
+++ b/src/utils/linkify.tsx
@@ -18,8 +18,32 @@ const URL_REGEX = /((https?:\/\/)?[\w.-]+\.[a-z]{2,}(\/[\w\-._~:\/?#[\]@!$&'()*+
 const AENS_TAG_REGEX = /@?[a-z0-9-]+\.chain\b/gi;
 // Optional '@' followed by an account address starting with ak_
 const ACCOUNT_TAG_REGEX = /@?(ak_[A-Za-z0-9]+)/gi;
-// Hashtags like #TOKEN, #TREND-123, #ROCK-N-ROLL; allow letters, numbers, and dashes only
-const HASHTAG_REGEX = /#([A-Za-z0-9-]{1,50})/g;
+// A hashtag "word": '#' at the start of the text or right after whitespace (so we don't hijack
+// URL fragments like "example.com/page#section"), followed by the full run of non-whitespace
+// characters. Word-initial only — matches how hashtags are written in practice.
+const HASHTAG_WORD_REGEX = /(^|\s)#(\S+)/g;
+// Fallback token-name character class when no live collection data is available (e.g. before
+// the BCL factory schema has loaded): letters, numbers, and dashes only.
+const DEFAULT_HASHTAG_CHARS_PATTERN = 'A-Za-z0-9\\-';
+// Regexes are rebuilt per distinct `hashtagAllowedChars` pattern (collections load once and
+// rarely change), so a tiny cache avoids recompiling the same regex on every render.
+const hashtagTokenRegexCache = new Map<string, RegExp>();
+function getHashtagTokenRegex(extraCharsPattern?: string): RegExp {
+  const pattern = extraCharsPattern
+    ? `${DEFAULT_HASHTAG_CHARS_PATTERN}${extraCharsPattern}`
+    : DEFAULT_HASHTAG_CHARS_PATTERN;
+  let regex = hashtagTokenRegexCache.get(pattern);
+  if (!regex) {
+    // The token-name-valid prefix of a hashtag word. Notably excludes '.', so "#emoter.ai"
+    // only captures "emoter" as the token name — anything after the valid prefix (e.g. ".ai")
+    // is not a valid token and is left as plain, inert text. The 'u' flag makes the {1,50}
+    // length cap and the character class count by Unicode code point, not UTF-16 code unit,
+    // so multi-byte collection alphabets (Chinese, Arabic, Russian, ...) are handled correctly.
+    regex = new RegExp(`^[${pattern}]{1,50}`, 'u');
+    hashtagTokenRegexCache.set(pattern, regex);
+  }
+  return regex;
+}
 
 export function linkify(
   text: string,
@@ -27,10 +51,19 @@ export function linkify(
     knownChainNames?: Set<string>;
     hashtagVariant?: 'post-inline';
     trendMentions?: TrendMention[];
+    /**
+     * Regex character-class body (e.g. from `mergedCollectionNameCharsPattern`) covering the
+     * name characters allowed by every known BCL token collection, in addition to the default
+     * A-Z/0-9/'-'. Pass this so hashtag detection for non-Latin collections (Chinese, Arabic,
+     * Russian, and any collection added later) stays in sync with the live factory schema
+     * without requiring changes here.
+     */
+    hashtagAllowedChars?: string;
   },
 ): React.ReactNode[] {
   if (!text) return [];
   let raw = String(text);
+  const hashtagTokenRegex = getHashtagTokenRegex(options?.hashtagAllowedChars);
 
   // Decode HTML entities first (in case content is HTML-encoded)
   // Use a safe method that works in both browser and SSR contexts
@@ -66,32 +99,115 @@ export function linkify(
   // 5. Carriage return alone: \r -> \n
   raw = raw.replace(/\r/g, '\n');
 
+  // Renders a single '#token' as a link, per the `hashtagVariant` option. `keyPos` is the
+  // absolute offset of the '#' in `raw`, used to keep React keys unique across the whole text.
+  const renderHashtagNode = (tokenName: string, keyPos: number): React.ReactNode => (
+    options?.hashtagVariant === 'post-inline' ? (
+      <PostHashtagLink
+        tag={tokenName}
+        label={`#${tokenName}`}
+        trendMentions={options?.trendMentions}
+        variant="inline"
+        key={`hashtag-${tokenName}-${keyPos}`}
+      />
+    ) : (
+      <Link
+        to={`/trends/tokens/${encodeURIComponent(tokenName.toUpperCase())}`}
+        key={`hashtag-${tokenName}-${keyPos}`}
+        className="text-[var(--neon-teal)] underline-offset-2 hover:underline break-words"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {`#${tokenName}`}
+      </Link>
+    )
+  );
+
+  // Pass 0: Hashtags → router link to trending tokens page (/trends/tokens/<UPPERCASE>).
+  // Runs first (on the raw text) so that a hashtag's invalid trailing characters (e.g. the
+  // ".ai/" in "#emoter.ai/") are consumed here and marked inert, before the AENS/account/URL
+  // passes below get a chance to mistake them for a domain, chain name, or account mention.
+  //
+  // A single non-whitespace run can contain more than one hashtag with no separator between
+  // them (e.g. "#one#two", or a stray "##foo"), so the whole run (including the leading '#'
+  // that HASHTAG_WORD_REGEX matched separately) is walked char-by-char: each '#' followed by
+  // valid token characters becomes its own link, and any characters that aren't part of a
+  // valid token (e.g. ".ai/", or a '#' not followed by a valid token) are left as inert plain
+  // text until the next '#' is found, so parsing can resume from there.
+  const hashtagLinked: React.ReactNode[] = [];
+  let hLast = 0;
+  raw.replace(HASHTAG_WORD_REGEX, (m: string, lead: string, word: string, offset: number) => {
+    const hashStart = offset + lead.length;
+    const fullRun = `#${word}`;
+    let i = 0;
+    let matchedAny = false;
+    const nodes: React.ReactNode[] = [];
+    while (i < fullRun.length) {
+      const tokenMatch = fullRun[i] === '#'
+        ? fullRun.slice(i + 1).match(hashtagTokenRegex)
+        : null;
+      if (tokenMatch) {
+        nodes.push(renderHashtagNode(tokenMatch[0], hashStart + i));
+        i += 1 + tokenMatch[0].length;
+        matchedAny = true;
+      } else {
+        // Inert stretch: not a valid token start. Consume up to (not including) the next '#'
+        // so the loop can retry hashtag parsing from there.
+        let j = i + 1;
+        while (j < fullRun.length && fullRun[j] !== '#') j++;
+        const inertChunk = fullRun.slice(i, j);
+        // Wrapped so later passes (which skip non-string nodes) don't try to re-linkify it
+        // as a URL/AENS/account.
+        nodes.push(<React.Fragment key={`hashtag-rest-${hashStart + i}`}>{inertChunk}</React.Fragment>);
+        i = j;
+      }
+    }
+
+    if (!matchedAny) {
+      // No '#' in this run ever led to a valid token — not a hashtag, leave untouched for
+      // later passes to evaluate normally.
+      return m;
+    }
+
+    if (hashStart > hLast) hashtagLinked.push(raw.slice(hLast, hashStart));
+    hashtagLinked.push(...nodes);
+    hLast = offset + m.length;
+    return m;
+  });
+  if (hLast < raw.length) hashtagLinked.push(raw.slice(hLast));
+
   // Pass 1: Identify AENS mentions and turn them into profile links
   const aensLinked: React.ReactNode[] = [];
-  let last = 0;
-  raw.replace(AENS_TAG_REGEX, (match: string, offset: number) => {
-    if (offset > last) aensLinked.push(raw.slice(last, offset));
-    const name = match.startsWith('@') ? match.slice(1) : match; // strip optional '@'
-    const normalized = name.toLowerCase();
-    const isKnown = options?.knownChainNames?.has(normalized) ?? false;
-    if (isKnown) {
-      aensLinked.push(
-        <a
-          href={`/users/${name}`}
-          key={`aens-${name}-${offset}`}
-          className="text-[var(--neon-teal)] underline-offset-2 hover:underline break-words"
-        >
-          {match}
-        </a>,
-      );
-    } else {
-      // Unknown name → keep as plain text
-      aensLinked.push(match);
+  hashtagLinked.forEach((node, nodeIdx) => {
+    if (typeof node !== 'string') {
+      aensLinked.push(node);
+      return;
     }
-    last = offset + match.length;
-    return match;
+    const segment = node as string;
+    let last = 0;
+    segment.replace(AENS_TAG_REGEX, (match: string, offset: number) => {
+      if (offset > last) aensLinked.push(segment.slice(last, offset));
+      const name = match.startsWith('@') ? match.slice(1) : match; // strip optional '@'
+      const normalized = name.toLowerCase();
+      const isKnown = options?.knownChainNames?.has(normalized) ?? false;
+      if (isKnown) {
+        aensLinked.push(
+          <a
+            href={`/users/${name}`}
+            key={`aens-${name}-${nodeIdx}-${offset}`}
+            className="text-[var(--neon-teal)] underline-offset-2 hover:underline break-words"
+          >
+            {match}
+          </a>,
+        );
+      } else {
+        // Unknown name → keep as plain text
+        aensLinked.push(match);
+      }
+      last = offset + match.length;
+      return match;
+    });
+    if (last < segment.length) aensLinked.push(segment.slice(last));
   });
-  if (last < raw.length) aensLinked.push(raw.slice(last));
 
   // Pass 2a: Within remaining plain text segments, convert ak_ address mentions
   const accountLinked: React.ReactNode[] = [];
@@ -167,51 +283,13 @@ export function linkify(
     if (segLast < segment.length) urlLinkedParts.push(segment.slice(segLast));
   });
 
-  // Pass 3: Hashtags → router link to trending tokens page (/trends/tokens/<UPPERCASE>)
-  const finalParts: React.ReactNode[] = [];
-  urlLinkedParts.forEach((node, idx) => {
-    if (typeof node !== 'string') {
-      finalParts.push(node);
-      return;
-    }
-    const segment = node as string;
-    let last = 0;
-    segment.replace(HASHTAG_REGEX, (m: string, tag: string, off: number) => {
-      if (off > last) finalParts.push(segment.slice(last, off));
-      const target = `/trends/tokens/${tag.toUpperCase()}`;
-      finalParts.push(
-        options?.hashtagVariant === 'post-inline' ? (
-          <PostHashtagLink
-            tag={tag}
-            label={m}
-            trendMentions={options?.trendMentions}
-            variant="inline"
-            key={`hashtag-${tag}-${idx}-${off}`}
-          />
-        ) : (
-          <Link
-            to={target}
-            key={`hashtag-${tag}-${idx}-${off}`}
-            className="text-[var(--neon-teal)] underline-offset-2 hover:underline break-words"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {m}
-          </Link>
-        ),
-      );
-      last = off + m.length;
-      return m;
-    });
-    if (last < segment.length) finalParts.push(segment.slice(last));
-  });
-
   // Pass 4: Handle line breaks - split by \n and insert <br /> elements
   // Multiple consecutive line breaks collapse to a single line break
   const withLineBreaks: React.ReactNode[] = [];
   let brKeyCounter = 0; // Counter to ensure unique keys for <br /> elements
   let previousNodeWasNonString = false; // Track if previous node was a React element (link, etc.)
 
-  finalParts.forEach((node, idx) => {
+  urlLinkedParts.forEach((node, idx) => {
     if (typeof node !== 'string') {
       // Non-string node (link, etc.) - push it and mark that we had a non-string
       withLineBreaks.push(node);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared `linkify` used across social post rendering; behavior changes are extensive but covered by new tests and mainly fix incorrect linking rather than security-sensitive paths.
> 
> **Overview**
> **Post content linkification** is reworked so token hashtags are parsed correctly and stay aligned with on-chain BCL collection rules.
> 
> `linkify` now runs **hashtag detection first** (before URLs, `.chain` names, and `ak_` mentions). Hashtags only match after whitespace or at line start (avoiding URL fragments like `page#section`). Token names stop at invalid characters—e.g. `#emoter.ai/` links only `#emoter`, leaving `.ai/` as plain text so it is not turned into an external link. Chained tags (`#one#two`), dotted suffixes (`#foo.chain`), and similar edge cases are handled explicitly.
> 
> A new **`collectionNameChars`** helper builds a merged regex from each collection’s `allowed_name_chars` in the factory schema. **`ReplyToFeedItem`** and **`TokenCreatedActivityItem`** load that schema via `useCommunityFactory` and pass `hashtagAllowedChars` into `linkify`, so Chinese, Arabic, Russian, and future collections link without hardcoding alphabets. Before the schema loads, only Latin letters, digits, and dashes count as token characters.
> 
> Broad **unit tests** cover `collectionNameChars` and `linkify` hashtag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1de105d357096ed5910440824869cd5d996ee0f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/626/) — updated Tue, 14 Jul 2026 12:39:40 GMT