### PR TITLE
style(hero-banner): row layout for banner graphic cards to reduce slide height

### DIFF
--- a/src/components/hero-banner/BannerGraphics.tsx
+++ b/src/components/hero-banner/BannerGraphics.tsx
@@ -93,14 +93,16 @@ export const SignalGraphic = () => (
         <span className="bmini__sub">Tokenized signal</span>
       </div>
     </div>
-    <div className="bmini__priceline">
-      <span className="bmini__price">$1.24</span>
-      <span className="bmini__delta bmini__delta--up">
-        +8.2%
-        ↗
-      </span>
+    <div className="bmini__graphrow">
+      <div className="bmini__priceline">
+        <span className="bmini__price">$1.24</span>
+        <span className="bmini__delta bmini__delta--up">
+          +8.2%
+          ↗
+        </span>
+      </div>
+      <Sparkline id="sig" />
     </div>
-    <Sparkline id="sig" />
     <div className="bmini__row">
       <span className="bmini__chip">Bonding curve</span>
       <span className="bmini__chip">Live</span>
@@ -118,14 +120,16 @@ export const TreasuryGraphic = () => (
         <span className="bmini__sub">Treasury</span>
       </div>
     </div>
-    <div className="bmini__priceline">
-      <span className="bmini__price">$128.4k</span>
-      <span className="bmini__delta bmini__delta--up">+37.8%</span>
-    </div>
-    <div className="bmini__flow">
-      <span className="bmini__flow-tag">Fees</span>
-      <span className="bmini__flow-arrow">→</span>
-      <span className="bmini__flow-tag bmini__flow-tag--gr">Treasury</span>
+    <div className="bmini__graphrow">
+      <div className="bmini__priceline">
+        <span className="bmini__price">$128.4k</span>
+        <span className="bmini__delta bmini__delta--up">+37.8%</span>
+      </div>
+      <div className="bmini__flow">
+        <span className="bmini__flow-tag">Fees</span>
+        <span className="bmini__flow-arrow">→</span>
+        <span className="bmini__flow-tag bmini__flow-tag--gr">Treasury</span>
+      </div>
     </div>
     <div className="bmini__row">
       <span className="bmini__stat-k">Creator payouts</span>
@@ -144,14 +148,16 @@ export const MarketGraphic = () => (
         <span className="bmini__sub">Hashtag market</span>
       </div>
     </div>
-    <div className="bmini__priceline">
-      <span className="bmini__price">$0.84</span>
-      <span className="bmini__delta bmini__delta--up">
-        +24.6%
-        ↗
-      </span>
+    <div className="bmini__graphrow">
+      <div className="bmini__priceline">
+        <span className="bmini__price">$0.84</span>
+        <span className="bmini__delta bmini__delta--up">
+          +24.6%
+          ↗
+        </span>
+      </div>
+      <Sparkline id="mkt" />
     </div>
-    <Sparkline id="mkt" />
     <div className="bmini__stats">
       <div className="bmini__stat">
         <span className="bmini__stat-k">Holders</span>

--- a/src/components/hero-banner/banner-graphics.css
+++ b/src/components/hero-banner/banner-graphics.css
@@ -59,16 +59,18 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  /* Lay the platforms out in a row (wrapping when tight) instead of a tall
+     vertical stack, so the Availability slide stays as short as the others. */
   display: flex;
-  flex-direction: column;
+  flex-flow: row wrap;
   gap: 6px;
 }
 
 .bmini__list-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  justify-content: flex-start;
+  gap: 6px;
   padding: 6px 9px;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.04);
@@ -154,6 +156,34 @@
   width: 100%;
   height: 36px;
   display: block;
+}
+
+/* Graph slides (Signal, Market): sit the sparkline in a row beside the price
+   instead of stacking it underneath, so the card is one row shorter. */
+.bmini__graphrow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.bmini__graphrow .bmini__priceline {
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.bmini__graphrow .bmini__spark {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 40px;
+}
+
+.bmini__graphrow .bmini__flow {
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .bmini__row {

--- a/src/components/hero-banner/banner.styles.css
+++ b/src/components/hero-banner/banner.styles.css
@@ -174,7 +174,7 @@ html.ios-webkit .hero-banner--ios-safe .bmini {
   max-width: 920px;
   width: 100%;
   margin: 0 auto;
-  padding: clamp(8px, 2vw, 20px) clamp(24px, 5vw, 56px);
+  padding: clamp(8px, 2vw, 20px) clamp(16px, 3vw, 32px);
   display: flex;
   align-items: center;
   position: relative;
@@ -183,7 +183,7 @@ html.ios-webkit .hero-banner--ios-safe .bmini {
 
 .banner-layout__top {
   display: flex;
-  gap: clamp(20px, 4vw, 44px);
+  gap: clamp(16px, 2.5vw, 28px);
   align-items: center;
   width: 100%;
 }


### PR DESCRIPTION
Lay the graph beside the price instead of stacking it underneath, and
flow the Availability platforms (iOS / Android / AI) in a row instead of
a vertical list, so every banner slide's graphic card is shorter.

- Signal & Market slides: wrap the price line + sparkline in a
  `.bmini__graphrow` flex row (sparkline fills the remaining width).
- Treasury slide: row the fee->treasury flow beside the price for parity.
- Availability slide: `.bmini__list` becomes a wrapping row of platform
  pills instead of a tall vertical stack.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014CL8tgZcYddKug2pHh1rw8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and markup in the hero banner; no logic, data, or auth changes.
> 
> **Overview**
> Shortens hero carousel **graphic cards** so slides stay more consistent in height.
> 
> **Signal** and **Market** slides put price/delta and the sparkline in a horizontal **`.bmini__graphrow`** instead of stacking the chart under the price. **Treasury** uses the same row so the Fees→Treasury flow sits beside the headline numbers. **Availability** lays iOS / Android / AI platform pills in a **wrapping row** rather than a tall vertical list.
> 
> **`.banner-layout`** horizontal padding and the gap between copy and the card are tightened slightly to match the shorter cards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac94a599da091472217ac52483247e6555b86013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/634/) — updated Wed, 22 Jul 2026 21:19:47 GMT