### PR TITLE
Add graphics, icons, animations and page redesigns

### DIFF
--- a/src/components/hero-banner/PageSpaceHero.tsx
+++ b/src/components/hero-banner/PageSpaceHero.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import SpaceEffects from './SpaceEffects';
+import './banner.styles.css';
+import './page-space-hero.css';
+
+interface PageSpaceHeroProps {
+  children: React.ReactNode;
+  className?: string;
+  /** Colour of the two nova bursts — pick one that suits the page accent. */
+  supernovaColor?: string;
+  /** Drop the heavier compositor layers (used automatically on iOS WebKit). */
+  reduced?: boolean;
+}
+
+/**
+ * A self-contained hero panel that reuses the expanded home-banner's cosmic
+ * backdrop (drifting stars, aurora ribbon, nova bursts, orbiting-token planet
+ * and signal grid) behind arbitrary page content. Unlike the carousel, it does
+ * not tone the effects down, so the graphics read clearly on standalone pages.
+ */
+const PageSpaceHero = ({
+  children,
+  className = '',
+  supernovaColor = 'rgba(122,92,255,.55)',
+  reduced = false,
+}: PageSpaceHeroProps) => {
+  const isIOSWebKit = React.useMemo(() => {
+    if (typeof document === 'undefined') return false;
+    return document.documentElement.classList.contains('ios-webkit');
+  }, []);
+
+  return (
+    <div className={`page-space-hero ${isIOSWebKit ? 'page-space-hero--ios-safe' : ''} ${className}`}>
+      <SpaceEffects supernovaColor={supernovaColor} reduced={reduced || isIOSWebKit} />
+      <div className="page-space-hero__content">{children}</div>
+    </div>
+  );
+};
+
+export default PageSpaceHero;

--- a/src/components/hero-banner/page-space-hero.css
+++ b/src/components/hero-banner/page-space-hero.css
@@ -1,0 +1,31 @@
+/* Standalone hero panel that hosts the shared cosmic <SpaceEffects> backdrop.
+   Mirrors the expanded hero banner's framing so pages that opt in feel part of
+   the same visual family. The `.banner-*` effect classes and their keyframes
+   come from banner.styles.css (imported alongside this file). */
+
+.page-space-hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    radial-gradient(120% 120% at 15% 0%, rgba(122, 92, 255, 0.18), rgba(0, 0, 0, 0) 55%),
+    radial-gradient(120% 120% at 100% 100%, rgba(0, 229, 255, 0.12), rgba(0, 0, 0, 0) 55%),
+    linear-gradient(135deg, rgba(18, 14, 38, 0.85), rgba(10, 10, 15, 0.75));
+  /* Isolate so the star repaints and blend modes stay inside the panel. */
+  isolation: isolate;
+}
+
+/* Content sits above .banner-space (z-index 0) and its children (z-index 1). */
+.page-space-hero__content {
+  position: relative;
+  z-index: 4;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page-space-hero {
+    background:
+      radial-gradient(120% 120% at 15% 0%, rgba(122, 92, 255, 0.14), rgba(0, 0, 0, 0) 55%),
+      linear-gradient(135deg, rgba(18, 14, 38, 0.85), rgba(10, 10, 15, 0.75));
+  }
+}

--- a/src/components/onboarding/RewardsOnboarding.tsx
+++ b/src/components/onboarding/RewardsOnboarding.tsx
@@ -58,12 +58,12 @@ const RewardsOnboarding = ({ variant = 'feed', className }: RewardsOnboardingPro
   return (
     <div
       className={cn(
-        'relative overflow-hidden rounded-2xl border border-cyan-500/20 bg-gradient-to-br from-cyan-500/10 to-blue-500/5 backdrop-blur-xl',
+        'relative overflow-hidden rounded-2xl border border-cyan-500/20 bg-gradient-to-br from-cyan-500/10 to-blue-500/5 backdrop-blur-xl animate-scaleIn hover-lift',
         isRail ? 'p-4' : 'p-5 md:p-6',
         className,
       )}
     >
-      <div className="absolute -top-16 -right-16 h-32 w-32 rounded-full bg-cyan-500/10 blur-3xl" aria-hidden />
+      <div className="absolute -top-16 -right-16 h-32 w-32 rounded-full bg-cyan-500/10 blur-3xl animate-float" aria-hidden />
       <div className="relative">
         <div className="mb-3 flex items-center gap-2">
           <span className="inline-flex items-center gap-1.5 rounded-full border border-cyan-500/25 bg-cyan-500/15 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-cyan-300">
@@ -112,9 +112,16 @@ const RewardsOnboarding = ({ variant = 'feed', className }: RewardsOnboardingPro
 
         <div className="mb-3 h-1.5 w-full overflow-hidden rounded-full bg-white/10">
           <div
-            className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-blue-500 transition-all duration-700 ease-out"
-            style={{ width: `${progressPct}%` }}
-          />
+            className="h-full rounded-full bg-gradient-to-r from-cyan-400 to-blue-500 transition-all duration-700 ease-out relative"
+            style={{
+              width: `${progressPct}%`,
+              animation: progressPct > 0 ? 'progressFill 1s ease-out' : 'none',
+            }}
+          >
+            {progressPct > 0 && (
+              <div className="absolute inset-0 bg-white/20 animate-shimmer" />
+            )}
+          </div>
         </div>
         <p className="mb-3 text-[11px] text-white/40">
           {t('onboarding.progress', { done: doneCount, total })}
@@ -123,10 +130,10 @@ const RewardsOnboarding = ({ variant = 'feed', className }: RewardsOnboardingPro
         <button
           type="button"
           onClick={handleContinue}
-          className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-500 px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/25"
+          className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-500 px-4 py-2.5 text-sm font-semibold text-white transition-all duration-200 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/25 hover-lift group"
         >
           {ctaLabel}
-          <span className="text-base">→</span>
+          <span className="text-base group-hover:animate-bounce">→</span>
         </button>
       </div>
     </div>

--- a/src/features/trending/components/Invitation/CollectRewardsCard.tsx
+++ b/src/features/trending/components/Invitation/CollectRewardsCard.tsx
@@ -262,11 +262,11 @@ const CollectRewardsCard = () => {
       {/* Header */}
       <div className="flex items-start justify-between gap-3 mb-5">
         <div className="w-10 h-10 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center flex-shrink-0 animate-pulseGlow">
-          <TrophyIcon className="w-5 h-5 text-cyan-400 animate-float" />
+          <TrophyIcon className="w-5 h-5 text-cyan-400" />
         </div>
         {isEligibleForRewards && (
           <div className="animate-bounce">
-            <StarIcon className="w-6 h-6 text-yellow-400 animate-sparkle" />
+            <StarIcon className="w-6 h-6 text-yellow-400" />
           </div>
         )}
       </div>

--- a/src/features/trending/components/Invitation/CollectRewardsCard.tsx
+++ b/src/features/trending/components/Invitation/CollectRewardsCard.tsx
@@ -9,6 +9,9 @@ import { getAffiliationTreasury } from '@/libs/affiliation';
 import { Decimal } from '@/libs/decimal';
 import LivePriceFormatter from '@/features/shared/components/LivePriceFormatter';
 import Spinner from '@/components/Spinner';
+import TrophyIcon from '@/svg/iconTrophy.svg?react';
+import StarIcon from '@/svg/iconStar.svg?react';
+import CelebrationIcon from '@/svg/iconCelebration.svg?react';
 
 const MIN_INVITEES = 4;
 const MIN_SPENT_AE = 10;
@@ -252,19 +255,23 @@ const CollectRewardsCard = () => {
   }, [collectingReward, thresholdReached, accumulatedRewardsAe, t]);
 
   return (
-    <div className="bg-[#0d1117]/10 backdrop-blur-lg border border-white/10 rounded-2xl p-6 md:p-8 relative overflow-hidden">
+    <div className="bg-[#0d1117]/10 backdrop-blur-lg border border-white/10 rounded-2xl p-6 md:p-8 relative overflow-hidden animate-scaleIn hover-lift">
+      {/* Animated background glow */}
+      <div className="absolute -top-20 -right-20 w-40 h-40 bg-cyan-500/10 rounded-full blur-3xl animate-float" />
+
       {/* Header */}
       <div className="flex items-start justify-between gap-3 mb-5">
-        <div className="w-10 h-10 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center flex-shrink-0">
-          <svg className="w-5 h-5 text-cyan-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="10" />
-            <path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8" />
-            <path d="M12 18V6" />
-          </svg>
+        <div className="w-10 h-10 rounded-xl bg-white/5 border border-white/10 flex items-center justify-center flex-shrink-0 animate-pulseGlow">
+          <TrophyIcon className="w-5 h-5 text-cyan-400 animate-float" />
         </div>
+        {isEligibleForRewards && (
+          <div className="animate-bounce">
+            <StarIcon className="w-6 h-6 text-yellow-400 animate-sparkle" />
+          </div>
+        )}
       </div>
 
-      <h3 className="m-0 text-xl md:text-2xl font-bold text-white mb-2">
+      <h3 className="m-0 text-xl md:text-2xl font-bold text-white mb-2 animate-slideDown">
         {t('collectRewards.title')}
       </h3>
 
@@ -300,9 +307,16 @@ const CollectRewardsCard = () => {
             </div>
             <div className="w-full h-1.5 bg-white/10 rounded-full overflow-hidden">
               <div
-                className="h-full bg-cyan-500 rounded-full transition-all duration-700 ease-out"
-                style={{ width: `${progressPercentage}%` }}
-              />
+                className="h-full bg-cyan-500 rounded-full transition-all duration-700 ease-out relative"
+                style={{
+                  width: `${progressPercentage}%`,
+                  animation: progressPercentage > 0 ? 'progressFill 1s ease-out' : 'none',
+                }}
+              >
+                {progressPercentage > 0 && (
+                  <div className="absolute inset-0 bg-white/20 animate-shimmer" />
+                )}
+              </div>
             </div>
             <div className="font-medium text-white/40 text-xs">
               {thresholdReached
@@ -334,9 +348,16 @@ const CollectRewardsCard = () => {
                     </div>
                     <div className="mt-2 h-1.5 bg-white/10 rounded-full overflow-hidden">
                       <div
-                        className={`h-full rounded-full ${item.reached ? 'bg-emerald-400' : 'bg-cyan-500'}`}
-                        style={{ width: `${item.progressPct}%` }}
-                      />
+                        className={`h-full rounded-full relative ${item.reached ? 'bg-emerald-400' : 'bg-cyan-500'}`}
+                        style={{
+                          width: `${item.progressPct}%`,
+                          animation: item.progressPct > 0 ? 'progressFill 1s ease-out' : 'none',
+                        }}
+                      >
+                        {item.progressPct > 0 && (
+                          <div className="absolute inset-0 bg-white/20 animate-shimmer" />
+                        )}
+                      </div>
                     </div>
                   </div>
                 ))}
@@ -373,12 +394,19 @@ const CollectRewardsCard = () => {
               type="button"
               onClick={onCollectReward}
               disabled={collectingReward || !isEligibleForRewards}
-              className={`w-full p-3 md:p-4 text-sm font-semibold uppercase tracking-wider rounded-lg transition-all duration-200 ${isEligibleForRewards
-                ? 'bg-cyan-500 hover:bg-cyan-400 text-white hover:-translate-y-0.5 hover:shadow-lg hover:shadow-cyan-500/25'
+              className={`w-full p-3 md:p-4 text-sm font-semibold uppercase tracking-wider rounded-lg transition-all duration-200 relative overflow-hidden group ${isEligibleForRewards
+                ? 'bg-gradient-to-r from-cyan-500 to-blue-500 hover:from-cyan-400 hover:to-blue-400 text-white hover:-translate-y-0.5 hover:shadow-lg hover:shadow-cyan-500/25 animate-pulseGlow'
                 : 'opacity-50 cursor-not-allowed bg-white/5 text-white/30'
               }`}
             >
-              {collectButtonContent}
+              <span className="relative z-10 flex items-center justify-center gap-2">
+                {isEligibleForRewards && <CelebrationIcon className="w-5 h-5 animate-sparkle" />}
+                {collectButtonContent}
+                {isEligibleForRewards && <TrophyIcon className="w-5 h-5 group-hover:animate-bounce" />}
+              </span>
+              {isEligibleForRewards && (
+                <div className="absolute inset-0 bg-gradient-to-r from-cyan-600 to-blue-600 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+              )}
             </button>
           </div>
         </div>

--- a/src/features/trending/components/Invitation/RewardsProgram.tsx
+++ b/src/features/trending/components/Invitation/RewardsProgram.tsx
@@ -5,6 +5,10 @@ import { cn } from '../../../../lib/utils';
 import { useXPostingReward } from '../../../../hooks/useXPostingReward';
 import { useAeSdk } from '../../../../hooks/useAeSdk';
 import { openXComposeIntent } from '../../../../utils/openXLink';
+import {
+  Gift, CheckCircle2, Check, AlertTriangle, Lock, Loader2,
+  ArrowRight, Target, PartyPopper, RefreshCw, Clock, UserCheck, Send,
+} from 'lucide-react';
 import TrophyIcon from '../../../../svg/iconTrophy.svg?react';
 import FlameIcon from '../../../../svg/iconFlame.svg?react';
 import CelebrationIcon from '../../../../svg/iconCelebration.svg?react';
@@ -64,8 +68,8 @@ const RewardsProgram = () => {
   const totalEarned = (isOnboardingPaid ? 50 : 0) + rewardedPostCount * tierAe;
 
   const verifySteps = [
-    { text: t('rewardsProgram.milestone1.step1'), done: isXLinked },
-    { text: t('rewardsProgram.milestone1.step2'), done: isOnboardingPaid },
+    { text: t('rewardsProgram.milestone1.step1'), done: isXLinked, Icon: UserCheck },
+    { text: t('rewardsProgram.milestone1.step2'), done: isOnboardingPaid, Icon: Send },
   ];
   const verifyDone = verifySteps.filter((s) => s.done).length;
   const verifyTotal = verifySteps.length;
@@ -109,6 +113,12 @@ const RewardsProgram = () => {
   const showCheckButton = isXLinked;
   const checkButtonDisabled = !canCheck || checkLoading || !activeAccount;
 
+  const renderCheckIcon = () => {
+    if (checkLoading) return <Loader2 className="w-4 h-4 animate-spin" />;
+    if (!canCheck && nextCheckAt) return <Clock className="w-4 h-4" />;
+    return <RefreshCw className="w-4 h-4" />;
+  };
+
   return (
     <div className="mb-10">
 
@@ -128,7 +138,7 @@ const RewardsProgram = () => {
               <h2 className="text-2xl md:text-3xl font-bold text-white m-0">
                 {t('rewardsProgram.aeEarned', { amount: totalEarned })}
               </h2>
-              <span className="text-3xl animate-bounce">🎉</span>
+              <PartyPopper className="w-8 h-8 text-emerald-400 animate-bounce" />
             </div>
             <p className="text-sm text-white/50 m-0 max-w-lg animate-fadeIn animate-delay-200">
               {t('rewardsProgram.rewardsSentAutomatically')}
@@ -140,7 +150,7 @@ const RewardsProgram = () => {
       {/* Error Banner */}
       {error && (
         <div className="mb-6 flex items-center gap-3 px-5 py-3 rounded-xl bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
-          <span>⚠</span>
+          <AlertTriangle className="w-4 h-4 flex-shrink-0" />
           {error}
         </div>
       )}
@@ -165,18 +175,23 @@ const RewardsProgram = () => {
                     : 'bg-gradient-to-r from-cyan-500/20 to-blue-500/20 text-cyan-300 border border-cyan-500/25',
                 )}
               >
-                <span className="text-base">{verifyStatus === 'completed' ? '✅' : '🎁'}</span>
+                {verifyStatus === 'completed'
+                  ? <CheckCircle2 className="w-4 h-4" />
+                  : <Gift className="w-4 h-4" />}
                 {t('rewardsProgram.milestone1.earnBadge')}
               </span>
             </div>
             <div className="mb-4">
               <span
                 className={cn(
-                  'inline-block text-[10px] font-bold tracking-widest uppercase px-2.5 py-1 rounded-full',
+                  'inline-flex items-center gap-1 text-[10px] font-bold tracking-widest uppercase px-2.5 py-1 rounded-full',
                   verifyStatus === 'completed' && 'bg-emerald-500/20 text-emerald-400',
                   verifyStatus === 'in_progress' && 'bg-cyan-500/15 text-cyan-400',
                 )}
               >
+                {verifyStatus === 'completed'
+                  ? <CheckCircle2 className="w-3 h-3" />
+                  : <Loader2 className="w-3 h-3 animate-spin" />}
                 {verifyStatus === 'completed' ? t('rewardsProgram.status.completed') : t('rewardsProgram.status.inProgress')}
               </span>
             </div>
@@ -220,10 +235,11 @@ const RewardsProgram = () => {
                         step.done ? 'bg-emerald-500/30 text-emerald-400' : 'bg-white/5 border border-white/10 text-white/50',
                       )}
                     >
-                      {step.done ? '✓' : i + 1}
+                      {step.done ? <Check className="w-4 h-4" /> : i + 1}
                     </div>
-                    <div className={cn('leading-relaxed text-sm flex-1 min-w-0 pt-0.5', step.done ? 'text-emerald-300/80' : 'text-white/80')}>
-                      {step.text}
+                    <div className={cn('leading-relaxed text-sm flex-1 min-w-0 pt-0.5 flex items-start gap-2', step.done ? 'text-emerald-300/80' : 'text-white/80')}>
+                      <step.Icon className={cn('w-4 h-4 flex-shrink-0 mt-0.5', step.done ? 'text-emerald-400/70' : 'text-cyan-400/70')} />
+                      <span className="flex-1 min-w-0">{step.text}</span>
                     </div>
                   </div>
                 ))}
@@ -247,6 +263,7 @@ const RewardsProgram = () => {
                 </div>
               </div>
               <div className="flex items-center gap-2 flex-wrap">
+                <Target className={cn('w-5 h-5', verifyCompleted ? 'text-emerald-400' : 'text-cyan-400/80')} />
                 <span className="text-2xl font-bold text-white">{verifyDone}</span>
                 <span className="text-sm text-white/30">
                   /
@@ -259,7 +276,7 @@ const RewardsProgram = () => {
                     className="ml-auto inline-flex items-center gap-2 px-5 py-2.5 rounded-xl text-white text-sm font-semibold transition-all duration-200 hover:-translate-y-0.5 bg-gradient-to-r from-cyan-500 to-blue-500 hover:from-cyan-400 hover:to-blue-400 hover:shadow-lg hover:shadow-cyan-500/25"
                   >
                     {verifyActionLabel}
-                    <span className="text-base">→</span>
+                    <ArrowRight className="w-4 h-4" />
                   </button>
                 )}
                 {!verifyCompleted && showCheckButton && (
@@ -275,6 +292,7 @@ const RewardsProgram = () => {
                         : 'bg-white/10 text-white/70 hover:bg-white/15 hover:text-white',
                     )}
                   >
+                    {renderCheckIcon()}
                     {checkLabel(checkLoading, !canCheck, nextCheckAt, t)}
                   </button>
                 )}
@@ -312,19 +330,24 @@ const RewardsProgram = () => {
                     : 'bg-gradient-to-r from-cyan-500/20 to-blue-500/20 text-cyan-300 border border-cyan-500/25',
                 )}
               >
-                <span className="text-base">{postStatus === 'completed' ? '✅' : '🎁'}</span>
+                {postStatus === 'completed'
+                  ? <CheckCircle2 className="w-4 h-4" />
+                  : <Gift className="w-4 h-4" />}
                 {t('rewardsProgram.milestone2.earnBadge')}
               </span>
             </div>
             <div className="mb-4">
               <span
                 className={cn(
-                  'inline-block text-[10px] font-bold tracking-widest uppercase px-2.5 py-1 rounded-full',
+                  'inline-flex items-center gap-1 text-[10px] font-bold tracking-widest uppercase px-2.5 py-1 rounded-full',
                   postStatus === 'completed' && 'bg-emerald-500/20 text-emerald-400',
                   postStatus === 'in_progress' && 'bg-cyan-500/15 text-cyan-400',
                   postStatus === 'locked' && 'bg-white/10 text-white/40',
                 )}
               >
+                {postStatus === 'completed' && <CheckCircle2 className="w-3 h-3" />}
+                {postStatus === 'in_progress' && <Loader2 className="w-3 h-3 animate-spin" />}
+                {postStatus === 'locked' && <Lock className="w-3 h-3" />}
                 {postStatus === 'completed' && t('rewardsProgram.status.completed')}
                 {postStatus === 'in_progress' && t('rewardsProgram.status.inProgress')}
                 {postStatus === 'locked' && t('rewardsProgram.status.locked')}
@@ -367,7 +390,9 @@ const RewardsProgram = () => {
                       : 'bg-gradient-to-r from-cyan-500/20 to-blue-500/20 text-cyan-300 border border-cyan-500/25',
                   )}
                 >
-                  <span className="text-base">{postStatus === 'completed' ? '✅' : '🎁'}</span>
+                  {postStatus === 'completed'
+                  ? <CheckCircle2 className="w-4 h-4" />
+                  : <Gift className="w-4 h-4" />}
                   {t('rewardsProgram.milestone2.streakBadge')}
                 </span>
               </div>
@@ -398,6 +423,7 @@ const RewardsProgram = () => {
                 </div>
               </div>
               <div className="flex items-center gap-2 flex-wrap">
+                <Target className={cn('w-5 h-5', postCompleted ? 'text-emerald-400' : 'text-cyan-400/80')} />
                 <span className="text-2xl font-bold text-white">{rewardedPostCount}</span>
                 <span className="text-sm text-white/30">
                   /
@@ -417,7 +443,7 @@ const RewardsProgram = () => {
                       )}
                     >
                       {linkLoading ? t('rewardsProgram.milestone2.openingWallet') : t('rewardsProgram.milestone2.postOnX')}
-                      {!linkLoading && <span className="text-base">→</span>}
+                      {!linkLoading && <ArrowRight className="w-4 h-4" />}
                     </button>
                     {showCheckButton && (
                       <button

--- a/src/features/trending/components/Invitation/RewardsProgram.tsx
+++ b/src/features/trending/components/Invitation/RewardsProgram.tsx
@@ -5,6 +5,9 @@ import { cn } from '../../../../lib/utils';
 import { useXPostingReward } from '../../../../hooks/useXPostingReward';
 import { useAeSdk } from '../../../../hooks/useAeSdk';
 import { openXComposeIntent } from '../../../../utils/openXLink';
+import TrophyIcon from '../../../../svg/iconTrophy.svg?react';
+import FlameIcon from '../../../../svg/iconFlame.svg?react';
+import CelebrationIcon from '../../../../svg/iconCelebration.svg?react';
 
 const POST_TOTAL = 10;
 const STREAK_TOTAL = 10;
@@ -111,19 +114,23 @@ const RewardsProgram = () => {
 
       {/* Earnings Summary Banner */}
       {totalEarned > 0 && (
-        <div className="mb-8 bg-gradient-to-br from-emerald-500/10 to-cyan-500/5 backdrop-blur-xl border border-emerald-500/20 rounded-2xl p-6 md:p-8 relative overflow-hidden">
-          <div className="absolute -top-20 -right-20 w-40 h-40 bg-emerald-500/10 rounded-full blur-3xl" />
+        <div className="mb-8 bg-gradient-to-br from-emerald-500/10 to-cyan-500/5 backdrop-blur-xl border border-emerald-500/20 rounded-2xl p-6 md:p-8 relative overflow-hidden animate-celebrationPop animate-glowPulse">
+          <div className="absolute -top-20 -right-20 w-40 h-40 bg-emerald-500/10 rounded-full blur-3xl animate-float" />
+          <div className="absolute top-4 right-4">
+            <TrophyIcon className="w-12 h-12 text-emerald-400 animate-bounce" />
+          </div>
           <div className="relative">
-            <span className="inline-block text-xs font-bold tracking-wider uppercase px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 mb-4">
+            <span className="inline-block text-xs font-bold tracking-wider uppercase px-3 py-1 rounded-full bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 mb-4 animate-shimmer">
+              <CelebrationIcon className="inline w-4 h-4 mr-1 animate-sparkle" />
               {t('rewardsProgram.rewardsEarnedBadge')}
             </span>
-            <div className="flex items-center gap-4 mb-3">
+            <div className="flex items-center gap-4 mb-3 animate-slideUp">
               <h2 className="text-2xl md:text-3xl font-bold text-white m-0">
                 {t('rewardsProgram.aeEarned', { amount: totalEarned })}
               </h2>
-              <span className="text-3xl">🎉</span>
+              <span className="text-3xl animate-bounce">🎉</span>
             </div>
-            <p className="text-sm text-white/50 m-0 max-w-lg">
+            <p className="text-sm text-white/50 m-0 max-w-lg animate-fadeIn animate-delay-200">
               {t('rewardsProgram.rewardsSentAutomatically')}
             </p>
           </div>
@@ -143,8 +150,8 @@ const RewardsProgram = () => {
         {/* Milestone 1: Link X Account & Post */}
         <div
           className={cn(
-            'bg-[#0d1117]/10 backdrop-blur-xl border rounded-2xl relative overflow-hidden transition-all duration-300 p-6 md:p-8',
-            verifyStatus === 'completed' && 'border-emerald-500/30',
+            'bg-[#0d1117]/10 backdrop-blur-xl border rounded-2xl relative overflow-hidden transition-all duration-300 p-6 md:p-8 animate-scaleIn hover-lift',
+            verifyStatus === 'completed' && 'border-emerald-500/30 animate-glowPulse',
             verifyStatus === 'in_progress' && 'border-cyan-500/20',
           )}
         >
@@ -225,11 +232,18 @@ const RewardsProgram = () => {
                 <div className="w-full h-2 bg-white/10 rounded-full overflow-hidden">
                   <div
                     className={cn(
-                      'h-full rounded-full transition-all duration-700 ease-out',
+                      'h-full rounded-full transition-all duration-700 ease-out relative',
                       verifyStatus === 'completed' ? 'bg-emerald-400' : 'bg-gradient-to-r from-cyan-400 to-blue-500',
                     )}
-                    style={{ width: `${verifyProgressPct}%` }}
-                  />
+                    style={{
+                      width: `${verifyProgressPct}%`,
+                      animation: verifyProgressPct > 0 ? 'progressFill 1s ease-out' : 'none',
+                    }}
+                  >
+                    {verifyProgressPct > 0 && (
+                      <div className="absolute inset-0 bg-white/20 animate-shimmer" />
+                    )}
+                  </div>
                 </div>
               </div>
               <div className="flex items-center gap-2 flex-wrap">
@@ -266,11 +280,10 @@ const RewardsProgram = () => {
                 )}
               </div>
               {verifyStatus === 'completed' && (
-                <div className="mt-4 inline-flex items-center gap-2 text-sm text-emerald-400 font-medium">
-                  <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                  </svg>
+                <div className="mt-4 inline-flex items-center gap-2 text-sm text-emerald-400 font-medium animate-celebrationPop">
+                  <TrophyIcon className="w-5 h-5 animate-bounce" />
                   {t('rewardsProgram.milestone1.complete')}
+                  <CelebrationIcon className="w-4 h-4 animate-sparkle" />
                 </div>
               )}
               {statusLoading && !rewardData && (
@@ -283,8 +296,8 @@ const RewardsProgram = () => {
         {/* Milestone 2: Post on X & Earn */}
         <div
           className={cn(
-            'bg-[#0d1117]/10 backdrop-blur-xl border rounded-2xl relative overflow-hidden transition-all duration-300 p-6 md:p-8',
-            postStatus === 'completed' && 'border-emerald-500/30',
+            'bg-[#0d1117]/10 backdrop-blur-xl border rounded-2xl relative overflow-hidden transition-all duration-300 p-6 md:p-8 animate-scaleIn animate-delay-100 hover-lift',
+            postStatus === 'completed' && 'border-emerald-500/30 animate-glowPulse',
             postStatus === 'in_progress' && 'border-cyan-500/20',
             postStatus === 'locked' && 'border-white/10 opacity-80',
           )}
@@ -360,7 +373,8 @@ const RewardsProgram = () => {
               </div>
 
               {streakDays > 0 && (
-                <p className="text-xs text-cyan-300/70 text-right mb-2">
+                <p className="text-xs text-cyan-300/70 text-right mb-2 flex items-center gap-1 justify-end animate-slideDown">
+                  <FlameIcon className="w-4 h-4 text-orange-400 animate-float" />
                   {t('rewardsProgram.milestone2.currentStreak', { days: streakDays, total: STREAK_TOTAL })}
                 </p>
               )}
@@ -369,11 +383,18 @@ const RewardsProgram = () => {
                 <div className="w-full h-2 bg-white/10 rounded-full overflow-hidden">
                   <div
                     className={cn(
-                      'h-full rounded-full transition-all duration-700 ease-out',
+                      'h-full rounded-full transition-all duration-700 ease-out relative',
                       postStatus === 'completed' ? 'bg-emerald-400' : 'bg-gradient-to-r from-cyan-400 to-blue-500',
                     )}
-                    style={{ width: `${postProgressPct}%` }}
-                  />
+                    style={{
+                      width: `${postProgressPct}%`,
+                      animation: postProgressPct > 0 ? 'progressFill 1s ease-out' : 'none',
+                    }}
+                  >
+                    {postProgressPct > 0 && (
+                      <div className="absolute inset-0 bg-white/20 animate-shimmer" />
+                    )}
+                  </div>
                 </div>
               </div>
               <div className="flex items-center gap-2 flex-wrap">
@@ -421,11 +442,10 @@ const RewardsProgram = () => {
                 {t('rewardsProgram.milestone2.streakInfo')}
               </p>
               {postStatus === 'completed' && (
-                <div className="mt-4 inline-flex items-center gap-2 text-sm text-emerald-400 font-medium">
-                  <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                  </svg>
+                <div className="mt-4 inline-flex items-center gap-2 text-sm text-emerald-400 font-medium animate-celebrationPop success-celebration">
+                  <TrophyIcon className="w-5 h-5 animate-bounce" />
                   {t('rewardsProgram.milestone2.complete', { amount: rewardedPostCount * tierAe })}
+                  <CelebrationIcon className="w-4 h-4 animate-sparkle" />
                 </div>
               )}
             </div>

--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -592,7 +592,7 @@ const CreateTokenView = () => {
 
           <div className="flex flex-col xl:flex-row gap-6 xl:items-start xl:justify-between">
             <div className="w-full xl:w-[620px] xl:flex-shrink-0 xl:order-2 animate-scaleIn animate-delay-200">
-              <div className="bg-white/5 rounded-[16px] md:rounded-[24px] border border-white/10 backdrop-blur-xl py-3 px-2 md:p-6 shadow-2xl hover-glow transition-all duration-300" style={{ background: 'linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02))' }}>
+              <div className="bg-[#0d1117]/10 backdrop-blur-xl border border-cyan-500/20 rounded-2xl relative transition-all duration-300 p-5 md:p-8 shadow-2xl hover-lift">
                 {!activeFactorySchema ? (
                   <div className="space-y-4">
                     <div className="animate-pulse">
@@ -899,9 +899,9 @@ const CreateTokenView = () => {
             </div>
 
             {/* Explainer */}
-            <div className="min-w-0 flex-1 md:pt-2 xl:order-1">
+            <div className="min-w-0 flex-1 xl:order-1">
               <div className="xl:text-left">
-                <div className="mt-8 md:mt-12 bg-white/5 border border-white/10 rounded-2xl p-6 backdrop-blur-xl hover-lift animate-scaleIn animate-delay-300">
+                <div className="mt-8 md:mt-12 xl:mt-0 bg-[#0d1117]/10 backdrop-blur-xl border border-cyan-500/20 rounded-2xl relative overflow-hidden transition-all duration-300 p-6 md:p-8 hover-lift animate-scaleIn animate-delay-300">
                   <h3 className="text-xl font-bold text-white mb-4 bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift">
                     {t('trending.createToken.explainer.title')}
                   </h3>

--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -18,6 +18,9 @@ import {
 } from '@/features/transaction-notification';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import {
+  TrendingUp, Sigma, Landmark, Coins,
+} from 'lucide-react';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { createCommunity } from '../libs/createCommunity';
 import Spinner from '../../../components/Spinner';

--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -901,51 +901,114 @@ const CreateTokenView = () => {
               </div>
             </div>
 
-            {/* Explainer */}
+            {/* Explainer - Step by Step Guide */}
             <div className="min-w-0 flex-1 xl:order-1">
               <div className="xl:text-left">
                 <div className="mt-8 md:mt-12 xl:mt-0 bg-[#0d1117]/10 backdrop-blur-xl border border-cyan-500/20 rounded-2xl relative overflow-hidden transition-all duration-300 p-6 md:p-8 hover-lift animate-scaleIn animate-delay-300">
-                  <h3 className="text-xl font-bold text-white mb-4 bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift">
+                  <h3 className="text-xl font-bold text-white mb-6 bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift">
                     {t('trending.createToken.explainer.title')}
                   </h3>
-                  <div className="space-y-4 text-white/80 text-sm leading-relaxed">
-                    <div>
-                      <h4 className="font-semibold text-white mb-2">{t('trending.createToken.explainer.priceDiscoveryTitle')}</h4>
-                      <p>{t('trending.createToken.explainer.priceDiscoveryBody')}</p>
+                  
+                  {/* Step-by-step flow */}
+                  <div className="space-y-4">
+                    {/* Step 1: Price Discovery */}
+                    <div className="flex gap-4 items-start p-4 rounded-xl bg-gradient-to-r from-cyan-500/10 to-blue-500/5 border border-cyan-500/20">
+                      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-cyan-500/20 flex items-center justify-center border border-cyan-500/30">
+                        <TrendingUp className="w-5 h-5 text-cyan-400" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-2">
+                          <span className="text-xs font-bold tracking-wider uppercase px-2 py-0.5 rounded-full bg-cyan-500/20 text-cyan-300 border border-cyan-400/30">
+                            Step 1
+                          </span>
+                          <h4 className="font-semibold text-white">{t('trending.createToken.explainer.priceDiscoveryTitle')}</h4>
+                        </div>
+                        <p className="text-white/70 text-sm leading-relaxed">{t('trending.createToken.explainer.priceDiscoveryBody')}</p>
+                      </div>
                     </div>
-                    <div>
-                      <h4 className="font-semibold text-white mb-2">{t('trending.createToken.explainer.mathTitle')}</h4>
-                      <p className="mb-2">
-                        {t('trending.createToken.explainer.formulaIntro')}
-                        {' '}
-                        <code className="bg-white/10 px-2 py-1 rounded text-xs font-mono">price = k × supply²</code>
-                      </p>
-                      <p className="mb-2">
-                        {t('trending.createToken.explainer.whereLabel')}
-                        {' '}
-                        <code className="bg-white/10 px-2 py-1 rounded text-xs font-mono">k</code>
-                        {' '}
-                        {t('trending.createToken.explainer.constantAnd')}
-                        {' '}
-                        <code className="bg-white/10 px-2 py-1 rounded text-xs font-mono">supply</code>
-                        {' '}
-                        {t('trending.createToken.explainer.supplyDescription')}
-                      </p>
-                      <p>{t('trending.createToken.explainer.thisMeans')}</p>
-                      <ul className="list-disc list-inside mt-2 space-y-1 ml-4">
-                        <li>{t('trending.createToken.explainer.bullet1')}</li>
-                        <li>{t('trending.createToken.explainer.bullet2')}</li>
-                        <li>{t('trending.createToken.explainer.bullet3')}</li>
-                        <li>{t('trending.createToken.explainer.bullet4')}</li>
-                      </ul>
+
+                    {/* Step 2: Bonding Curve Math */}
+                    <div className="flex gap-4 items-start p-4 rounded-xl bg-gradient-to-r from-purple-500/10 to-pink-500/5 border border-purple-500/20">
+                      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-purple-500/20 flex items-center justify-center border border-purple-500/30">
+                        <Sigma className="w-5 h-5 text-purple-400" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-2">
+                          <span className="text-xs font-bold tracking-wider uppercase px-2 py-0.5 rounded-full bg-purple-500/20 text-purple-300 border border-purple-400/30">
+                            Step 2
+                          </span>
+                          <h4 className="font-semibold text-white">{t('trending.createToken.explainer.mathTitle')}</h4>
+                        </div>
+                        <div className="space-y-3 text-white/70 text-sm leading-relaxed">
+                          <p>
+                            {t('trending.createToken.explainer.formulaIntro')}
+                            {' '}
+                            <code className="bg-white/10 px-2 py-1 rounded text-xs font-mono">price = k × supply²</code>
+                          </p>
+                          <p>
+                            {t('trending.createToken.explainer.whereLabel')}
+                            {' '}
+                            <code className="bg-white/10 px-2 py-1 rounded text-xs font-mono">k</code>
+                            {' '}
+                            {t('trending.createToken.explainer.constantAnd')}
+                            {' '}
+                            <code className="bg-white/10 px-2 py-1 rounded text-xs font-mono">supply</code>
+                            {' '}
+                            {t('trending.createToken.explainer.supplyDescription')}
+                          </p>
+                          <p className="font-medium text-white/80">{t('trending.createToken.explainer.thisMeans')}</p>
+                          <div className="space-y-2 pl-4 border-l-2 border-purple-500/30">
+                            <p className="flex items-start gap-2">
+                              <span className="text-purple-400 flex-shrink-0 mt-0.5">•</span>
+                              <span>{t('trending.createToken.explainer.bullet1')}</span>
+                            </p>
+                            <p className="flex items-start gap-2">
+                              <span className="text-purple-400 flex-shrink-0 mt-0.5">•</span>
+                              <span>{t('trending.createToken.explainer.bullet2')}</span>
+                            </p>
+                            <p className="flex items-start gap-2">
+                              <span className="text-purple-400 flex-shrink-0 mt-0.5">•</span>
+                              <span>{t('trending.createToken.explainer.bullet3')}</span>
+                            </p>
+                            <p className="flex items-start gap-2">
+                              <span className="text-purple-400 flex-shrink-0 mt-0.5">•</span>
+                              <span>{t('trending.createToken.explainer.bullet4')}</span>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                    <div>
-                      <h4 className="font-semibold text-white mb-2">{t('trending.createToken.explainer.daoTreasuryTitle')}</h4>
-                      <p>{t('trending.createToken.explainer.daoTreasuryBody')}</p>
+
+                    {/* Step 3: DAO Treasury */}
+                    <div className="flex gap-4 items-start p-4 rounded-xl bg-gradient-to-r from-orange-500/10 to-amber-500/5 border border-orange-500/20">
+                      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-orange-500/20 flex items-center justify-center border border-orange-500/30">
+                        <Landmark className="w-5 h-5 text-orange-400" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-2">
+                          <span className="text-xs font-bold tracking-wider uppercase px-2 py-0.5 rounded-full bg-orange-500/20 text-orange-300 border border-orange-400/30">
+                            Step 3
+                          </span>
+                          <h4 className="font-semibold text-white">{t('trending.createToken.explainer.daoTreasuryTitle')}</h4>
+                        </div>
+                        <p className="text-white/70 text-sm leading-relaxed">{t('trending.createToken.explainer.daoTreasuryBody')}</p>
+                      </div>
                     </div>
-                    <div>
-                      <h4 className="font-semibold text-white mb-2">{t('trending.createToken.explainer.feesTitle')}</h4>
-                      <p>{t('trending.createToken.explainer.feesBody')}</p>
+
+                    {/* Step 4: Fees */}
+                    <div className="flex gap-4 items-start p-4 rounded-xl bg-gradient-to-r from-emerald-500/10 to-teal-500/5 border border-emerald-500/20">
+                      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-emerald-500/20 flex items-center justify-center border border-emerald-500/30">
+                        <Coins className="w-5 h-5 text-emerald-400" />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-2">
+                          <span className="text-xs font-bold tracking-wider uppercase px-2 py-0.5 rounded-full bg-emerald-500/20 text-emerald-300 border border-emerald-400/30">
+                            Step 4
+                          </span>
+                          <h4 className="font-semibold text-white">{t('trending.createToken.explainer.feesTitle')}</h4>
+                        </div>
+                        <p className="text-white/70 text-sm leading-relaxed">{t('trending.createToken.explainer.feesBody')}</p>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -901,7 +901,7 @@ const CreateTokenView = () => {
               </div>
             </div>
 
-            {/* Explainer - Step by Step Guide */}
+            {/* Explainer guide */}
             <div className="min-w-0 flex-1 xl:order-1">
               <div className="xl:text-left">
                 <div className="mt-8 md:mt-12 xl:mt-0 bg-[#0d1117]/10 backdrop-blur-xl border border-cyan-500/20 rounded-2xl relative overflow-hidden transition-all duration-300 p-6 md:p-8 hover-lift animate-scaleIn animate-delay-300">
@@ -909,34 +909,30 @@ const CreateTokenView = () => {
                     {t('trending.createToken.explainer.title')}
                   </h3>
                   
-                  {/* Step-by-step flow */}
+                  {/* Explainer flow */}
                   <div className="space-y-4">
-                    {/* Step 1: Price Discovery */}
+                    {/*  1: Price Discovery */}
                     <div className="flex gap-4 items-start p-4 rounded-xl bg-gradient-to-r from-cyan-500/10 to-blue-500/5 border border-cyan-500/20">
                       <div className="flex-shrink-0 w-10 h-10 rounded-full bg-cyan-500/20 flex items-center justify-center border border-cyan-500/30">
                         <TrendingUp className="w-5 h-5 text-cyan-400" />
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-2">
-                          <span className="text-xs font-bold tracking-wider uppercase px-2 py-0.5 rounded-full bg-cyan-500/20 text-cyan-300 border border-cyan-400/30">
-                            Step 1
-                          </span>
+                          
                           <h4 className="font-semibold text-white">{t('trending.createToken.explainer.priceDiscoveryTitle')}</h4>
                         </div>
                         <p className="text-white/70 text-sm leading-relaxed">{t('trending.createToken.explainer.priceDiscoveryBody')}</p>
                       </div>
                     </div>
 
-                    {/* Step 2: Bonding Curve Math */}
+                    {/*  2: Bonding Curve Math */}
                     <div className="flex gap-4 items-start p-4 rounded-xl bg-gradient-to-r from-purple-500/10 to-pink-500/5 border border-purple-500/20">
                       <div className="flex-shrink-0 w-10 h-10 rounded-full bg-purple-500/20 flex items-center justify-center border border-purple-500/30">
                         <Sigma className="w-5 h-5 text-purple-400" />
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-2">
-                          <span className="text-xs font-bold tracking-wider uppercase px-2 py-0.5 rounded-full bg-purple-500/20 text-purple-300 border border-purple-400/30">
-                            Step 2
-                          </span>
+                          
                           <h4 className="font-semibold text-white">{t('trending.createToken.explainer.mathTitle')}</h4>
                         </div>
                         <div className="space-y-3 text-white/70 text-sm leading-relaxed">
@@ -979,32 +975,28 @@ const CreateTokenView = () => {
                       </div>
                     </div>
 
-                    {/* Step 3: DAO Treasury */}
+                    {/*  3: DAO Treasury */}
                     <div className="flex gap-4 items-start p-4 rounded-xl bg-gradient-to-r from-orange-500/10 to-amber-500/5 border border-orange-500/20">
                       <div className="flex-shrink-0 w-10 h-10 rounded-full bg-orange-500/20 flex items-center justify-center border border-orange-500/30">
                         <Landmark className="w-5 h-5 text-orange-400" />
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-2">
-                          <span className="text-xs font-bold tracking-wider uppercase px-2 py-0.5 rounded-full bg-orange-500/20 text-orange-300 border border-orange-400/30">
-                            Step 3
-                          </span>
+                          
                           <h4 className="font-semibold text-white">{t('trending.createToken.explainer.daoTreasuryTitle')}</h4>
                         </div>
                         <p className="text-white/70 text-sm leading-relaxed">{t('trending.createToken.explainer.daoTreasuryBody')}</p>
                       </div>
                     </div>
 
-                    {/* Step 4: Fees */}
+                    {/*  4: Fees */}
                     <div className="flex gap-4 items-start p-4 rounded-xl bg-gradient-to-r from-emerald-500/10 to-teal-500/5 border border-emerald-500/20">
                       <div className="flex-shrink-0 w-10 h-10 rounded-full bg-emerald-500/20 flex items-center justify-center border border-emerald-500/30">
                         <Coins className="w-5 h-5 text-emerald-400" />
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2 mb-2">
-                          <span className="text-xs font-bold tracking-wider uppercase px-2 py-0.5 rounded-full bg-emerald-500/20 text-emerald-300 border border-emerald-400/30">
-                            Step 4
-                          </span>
+                         
                           <h4 className="font-semibold text-white">{t('trending.createToken.explainer.feesTitle')}</h4>
                         </div>
                         <p className="text-white/70 text-sm leading-relaxed">{t('trending.createToken.explainer.feesBody')}</p>

--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -23,6 +23,8 @@ import { createCommunity } from '../libs/createCommunity';
 import Spinner from '../../../components/Spinner';
 import VerifiedIcon from '../../../svg/verifiedUrl.svg?react';
 import NotVerifiedIcon from '../../../svg/notVerifiedUrl.svg?react';
+import RocketIcon from '../../../svg/iconRocket.svg?react';
+import SparkleIcon from '../../../svg/iconSparkle.svg?react';
 import { SuperheroApi } from '../../../api/backend';
 import AeButton from '../../../components/AeButton';
 import { ConnectWalletButton } from '../../../components/ConnectWalletButton';
@@ -486,18 +488,22 @@ const CreateTokenView = () => {
 
   if (loading) {
     return (
-      <div className="max-w-[min(1536px,100%)] mx-auto min-h-screen bg-gradient-to-b from-gray-900 to-black text-white">
+      <div className="max-w-[min(1536px,100%)] mx-auto min-h-screen text-white">
         <div className="p-6">
-          <div className="animate-pulse">
-            <div className="h-8 bg-gray-700 rounded w-1/3 mb-4" />
-            <div className="h-4 bg-gray-700 rounded w-2/3 mb-8" />
+          <div className="stagger-children">
+            <div className="h-8 bg-gradient-to-r from-gray-700 to-gray-600 rounded w-1/3 mb-4 animate-shimmer" />
+            <div className="h-4 bg-gradient-to-r from-gray-700 to-gray-600 rounded w-2/3 mb-8 animate-shimmer" />
             <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
               <div className="space-y-4">
-                {['row-1', 'row-2', 'row-3', 'row-4', 'row-5'].map((rowKey) => (
-                  <div key={rowKey} className="h-16 bg-gray-700 rounded" />
+                {['row-1', 'row-2', 'row-3', 'row-4', 'row-5'].map((rowKey, idx) => (
+                  <div
+                    key={rowKey}
+                    className="h-16 bg-gradient-to-r from-gray-700 to-gray-600 rounded animate-shimmer"
+                    style={{ animationDelay: `${idx * 100}ms` }}
+                  />
                 ))}
               </div>
-              <div className="h-96 bg-gray-700 rounded" />
+              <div className="h-96 bg-gradient-to-r from-gray-700 to-gray-600 rounded animate-shimmer" />
             </div>
           </div>
         </div>
@@ -549,9 +555,14 @@ const CreateTokenView = () => {
         size="lg"
         type="submit"
         disabled={isCreating || !canSubmitName}
-        className="w-full bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 border-0 shadow-lg hover:shadow-xl transition-all duration-300 h-12 md:h-14 py-3"
+        className="w-full bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 border-0 shadow-lg hover:shadow-xl transition-all duration-300 h-12 md:h-14 py-3 relative overflow-hidden group hover-lift"
       >
-        {t('trending.createToken.submit.createToken')}
+        <span className="relative z-10 flex items-center justify-center gap-2">
+          {!isCreating && <RocketIcon className="w-5 h-5 group-hover:animate-bounce" />}
+          {t('trending.createToken.submit.createToken')}
+          {!isCreating && <SparkleIcon className="w-4 h-4 animate-sparkle" />}
+        </span>
+        <div className="absolute inset-0 bg-gradient-to-r from-purple-600 to-pink-600 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
       </AeButton>
     );
   };
@@ -560,24 +571,24 @@ const CreateTokenView = () => {
     <div className="max-w-[min(1536px,100%)] mx-auto min-h-screen text-white px-2 md:px-4">
       <div className="rounded-[24px] mt-2 mb-6 mx-0 md:mx-4">
         <div className="max-w-[1400px] mx-auto p-0 md:px-6 md:pb-6 md:pt-3">
-          <div className="xl:hidden px-2 pt-2 pb-2 text-center">
-            <h3 className="text-2xl md:text-4xl font-bold leading-tight text-white mb-3">
+          <div className="xl:hidden px-2 pt-2 pb-2 text-center animate-fadeIn">
+            <h3 className="text-2xl md:text-4xl font-bold leading-tight text-white mb-3 animate-slideDown">
               {t('trending.createToken.hero.line1')}
               <br />
               {t('trending.createToken.hero.line2')}
               <br />
-              <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift">
                 {t('trending.createToken.hero.line3')}
               </span>
             </h3>
-            <p className="hidden md:block text-white/75 text-base leading-relaxed">
+            <p className="hidden md:block text-white/75 text-base leading-relaxed animate-slideUp animate-delay-200">
               {t('trending.createToken.hero.subtitle')}
             </p>
           </div>
 
           <div className="flex flex-col xl:flex-row gap-6 xl:items-start xl:justify-between">
-            <div className="w-full xl:w-[620px] xl:flex-shrink-0 xl:order-2">
-              <div className="bg-white/5 rounded-[16px] md:rounded-[24px] border border-white/10 backdrop-blur-xl py-3 px-2 md:p-6 shadow-2xl" style={{ background: 'linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02))' }}>
+            <div className="w-full xl:w-[620px] xl:flex-shrink-0 xl:order-2 animate-scaleIn animate-delay-200">
+              <div className="bg-white/5 rounded-[16px] md:rounded-[24px] border border-white/10 backdrop-blur-xl py-3 px-2 md:p-6 shadow-2xl hover-glow transition-all duration-300" style={{ background: 'linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02))' }}>
                 {!activeFactorySchema ? (
                   <div className="space-y-4">
                     <div className="animate-pulse">
@@ -886,23 +897,23 @@ const CreateTokenView = () => {
             {/* Explainer */}
             <div className="min-w-0 flex-1 md:pt-2 xl:order-1">
               <div className="xl:text-left">
-                <div className="hidden xl:block mb-6">
-                  <div className="text-5xl font-bold leading-tight text-white mb-4">
+                <div className="hidden xl:block mb-6 animate-fadeIn">
+                  <div className="text-5xl font-bold leading-tight text-white mb-4 animate-slideDown">
                     {t('trending.createToken.hero.line1')}
                     <br />
                     {t('trending.createToken.hero.line2')}
                     <br />
-                    <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent">
+                    <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift inline-block">
                       {t('trending.createToken.hero.line3')}
                     </span>
                   </div>
-                  <p className="text-white/75 text-lg leading-relaxed">
+                  <p className="text-white/75 text-lg leading-relaxed animate-slideUp animate-delay-200">
                     {t('trending.createToken.hero.subtitle')}
                   </p>
                 </div>
 
-                <div className="mt-8 md:mt-12 bg-white/5 border border-white/10 rounded-2xl p-6 backdrop-blur-xl">
-                  <h3 className="text-xl font-bold text-white mb-4 bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent">
+                <div className="mt-8 md:mt-12 bg-white/5 border border-white/10 rounded-2xl p-6 backdrop-blur-xl hover-lift animate-scaleIn animate-delay-300">
+                  <h3 className="text-xl font-bold text-white mb-4 bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift">
                     {t('trending.createToken.explainer.title')}
                   </h3>
                   <div className="space-y-4 text-white/80 text-sm leading-relaxed">

--- a/src/features/trending/views/CreateTokenView.tsx
+++ b/src/features/trending/views/CreateTokenView.tsx
@@ -25,6 +25,7 @@ import VerifiedIcon from '../../../svg/verifiedUrl.svg?react';
 import NotVerifiedIcon from '../../../svg/notVerifiedUrl.svg?react';
 import RocketIcon from '../../../svg/iconRocket.svg?react';
 import SparkleIcon from '../../../svg/iconSparkle.svg?react';
+import PageSpaceHero from '../../../components/hero-banner/PageSpaceHero';
 import { SuperheroApi } from '../../../api/backend';
 import AeButton from '../../../components/AeButton';
 import { ConnectWalletButton } from '../../../components/ConnectWalletButton';
@@ -571,20 +572,23 @@ const CreateTokenView = () => {
     <div className="max-w-[min(1536px,100%)] mx-auto min-h-screen text-white px-2 md:px-4">
       <div className="rounded-[24px] mt-2 mb-6 mx-0 md:mx-4">
         <div className="max-w-[1400px] mx-auto p-0 md:px-6 md:pb-6 md:pt-3">
-          <div className="xl:hidden px-2 pt-2 pb-2 text-center animate-fadeIn">
-            <h3 className="text-2xl md:text-4xl font-bold leading-tight text-white mb-3 animate-slideDown">
+          <PageSpaceHero
+            className="mb-6 px-6 py-10 md:px-10 md:py-14 text-center xl:text-left"
+            supernovaColor="rgba(255,94,188,.5)"
+          >
+            <h3 className="text-3xl md:text-5xl font-bold leading-tight text-white mb-3 animate-slideDown">
               {t('trending.createToken.hero.line1')}
               <br />
               {t('trending.createToken.hero.line2')}
               <br />
-              <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift">
+              <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift inline-block">
                 {t('trending.createToken.hero.line3')}
               </span>
             </h3>
-            <p className="hidden md:block text-white/75 text-base leading-relaxed animate-slideUp animate-delay-200">
+            <p className="text-white/75 text-base md:text-lg leading-relaxed animate-slideUp animate-delay-200 max-w-2xl mx-auto xl:mx-0">
               {t('trending.createToken.hero.subtitle')}
             </p>
-          </div>
+          </PageSpaceHero>
 
           <div className="flex flex-col xl:flex-row gap-6 xl:items-start xl:justify-between">
             <div className="w-full xl:w-[620px] xl:flex-shrink-0 xl:order-2 animate-scaleIn animate-delay-200">
@@ -897,21 +901,6 @@ const CreateTokenView = () => {
             {/* Explainer */}
             <div className="min-w-0 flex-1 md:pt-2 xl:order-1">
               <div className="xl:text-left">
-                <div className="hidden xl:block mb-6 animate-fadeIn">
-                  <div className="text-5xl font-bold leading-tight text-white mb-4 animate-slideDown">
-                    {t('trending.createToken.hero.line1')}
-                    <br />
-                    {t('trending.createToken.hero.line2')}
-                    <br />
-                    <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift inline-block">
-                      {t('trending.createToken.hero.line3')}
-                    </span>
-                  </div>
-                  <p className="text-white/75 text-lg leading-relaxed animate-slideUp animate-delay-200">
-                    {t('trending.createToken.hero.subtitle')}
-                  </p>
-                </div>
-
                 <div className="mt-8 md:mt-12 bg-white/5 border border-white/10 rounded-2xl p-6 backdrop-blur-xl hover-lift animate-scaleIn animate-delay-300">
                   <h3 className="text-xl font-bold text-white mb-4 bg-gradient-to-r from-purple-400 via-pink-400 to-orange-400 bg-clip-text text-transparent animate-gradientShift">
                     {t('trending.createToken.explainer.title')}

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -1,0 +1,327 @@
+/* Superhero Brand Animations */
+
+/* Fade in */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Slide up */
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Slide down */
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Scale in */
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Pulse glow */
+@keyframes pulseGlow {
+  0%, 100% {
+    box-shadow: 0 0 20px rgba(139, 92, 246, 0.3);
+  }
+  50% {
+    box-shadow: 0 0 40px rgba(139, 92, 246, 0.6);
+  }
+}
+
+/* Shimmer effect */
+@keyframes shimmer {
+  0% {
+    background-position: -1000px 0;
+  }
+  100% {
+    background-position: 1000px 0;
+  }
+}
+
+/* Bounce */
+@keyframes bounce {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+/* Spin */
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Float */
+@keyframes float {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-15px);
+  }
+}
+
+/* Progress fill */
+@keyframes progressFill {
+  from {
+    width: 0%;
+  }
+}
+
+/* Number counter */
+@keyframes countUp {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Confetti explosion */
+@keyframes confetti {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(100vh) rotate(720deg);
+    opacity: 0;
+  }
+}
+
+/* Trophy shine */
+@keyframes trophyShine {
+  0% {
+    transform: translateX(-100%) rotate(-45deg);
+  }
+  100% {
+    transform: translateX(200%) rotate(-45deg);
+  }
+}
+
+/* Gradient shift */
+@keyframes gradientShift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+/* Glow pulse for rewards */
+@keyframes glowPulse {
+  0%, 100% {
+    box-shadow: 0 0 15px rgba(59, 130, 246, 0.3), 0 0 30px rgba(139, 92, 246, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 30px rgba(59, 130, 246, 0.5), 0 0 60px rgba(139, 92, 246, 0.4);
+  }
+}
+
+/* Star sparkle */
+@keyframes sparkle {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(1.2);
+  }
+}
+
+/* Celebration pop */
+@keyframes celebrationPop {
+  0% {
+    transform: scale(0) rotate(0deg);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.2) rotate(180deg);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1) rotate(360deg);
+    opacity: 1;
+  }
+}
+
+/* Utility classes */
+.animate-fadeIn {
+  animation: fadeIn 0.5s ease-out;
+}
+
+.animate-slideUp {
+  animation: slideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.animate-slideDown {
+  animation: slideDown 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.animate-scaleIn {
+  animation: scaleIn 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.animate-bounce {
+  animation: bounce 1s ease-in-out infinite;
+}
+
+.animate-spin {
+  animation: spin 1s linear infinite;
+}
+
+.animate-float {
+  animation: float 3s ease-in-out infinite;
+}
+
+.animate-pulseGlow {
+  animation: pulseGlow 2s ease-in-out infinite;
+}
+
+.animate-shimmer {
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.1),
+    transparent
+  );
+  background-size: 200% 100%;
+  animation: shimmer 2s infinite;
+}
+
+.animate-gradientShift {
+  background-size: 200% 200%;
+  animation: gradientShift 3s ease infinite;
+}
+
+.animate-glowPulse {
+  animation: glowPulse 2s ease-in-out infinite;
+}
+
+.animate-sparkle {
+  animation: sparkle 1.5s ease-in-out infinite;
+}
+
+.animate-celebrationPop {
+  animation: celebrationPop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+/* Delay utilities */
+.animate-delay-100 {
+  animation-delay: 100ms;
+}
+
+.animate-delay-200 {
+  animation-delay: 200ms;
+}
+
+.animate-delay-300 {
+  animation-delay: 300ms;
+}
+
+.animate-delay-400 {
+  animation-delay: 400ms;
+}
+
+.animate-delay-500 {
+  animation-delay: 500ms;
+}
+
+/* Stagger children */
+.stagger-children > * {
+  animation: slideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.stagger-children > *:nth-child(1) { animation-delay: 0ms; }
+.stagger-children > *:nth-child(2) { animation-delay: 100ms; }
+.stagger-children > *:nth-child(3) { animation-delay: 200ms; }
+.stagger-children > *:nth-child(4) { animation-delay: 300ms; }
+.stagger-children > *:nth-child(5) { animation-delay: 400ms; }
+.stagger-children > *:nth-child(6) { animation-delay: 500ms; }
+
+/* Hover effects */
+.hover-lift {
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1), 
+              box-shadow 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.hover-lift:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+.hover-glow {
+  transition: box-shadow 0.3s ease;
+}
+
+.hover-glow:hover {
+  box-shadow: 0 0 30px rgba(139, 92, 246, 0.5);
+}
+
+.hover-scale {
+  transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.hover-scale:hover {
+  transform: scale(1.05);
+}
+
+/* Success celebration */
+.success-celebration {
+  position: relative;
+  overflow: hidden;
+}
+
+.success-celebration::before {
+  content: '🎉';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  font-size: 3rem;
+  animation: celebrationPop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+  pointer-events: none;
+}

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -3,6 +3,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import './animations.css';
+
 @layer base {
   :root {
     --background: 220 10% 3.9%;

--- a/src/svg/iconCelebration.svg
+++ b/src/svg/iconCelebration.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M11 2L9 9 2 11l7 2 2 7 2-7 7-2-7-2-2-7z" opacity="0.8"/>
+  <circle cx="6" cy="6" r="2"/>
+  <circle cx="18" cy="6" r="1.5"/>
+  <circle cx="18" cy="18" r="2"/>
+  <circle cx="6" cy="18" r="1.5"/>
+</svg>

--- a/src/svg/iconFlame.svg
+++ b/src/svg/iconFlame.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5z"/>
+</svg>

--- a/src/svg/iconRocket.svg
+++ b/src/svg/iconRocket.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/>
+  <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/>
+  <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/>
+  <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/>
+</svg>

--- a/src/svg/iconSparkle.svg
+++ b/src/svg/iconSparkle.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M12 0l2.4 7.2h7.6l-6 4.8 2.4 7.2-6-4.8-6 4.8 2.4-7.2-6-4.8h7.6z"/>
+  <path d="M18 6l1.2 3.6h3.8l-3 2.4 1.2 3.6-3-2.4-3 2.4 1.2-3.6-3-2.4h3.8z" opacity="0.7"/>
+</svg>

--- a/src/svg/iconStar.svg
+++ b/src/svg/iconStar.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
+</svg>

--- a/src/svg/iconTrophy.svg
+++ b/src/svg/iconTrophy.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6"/>
+  <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18"/>
+  <path d="M4 22h16"/>
+  <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22"/>
+  <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22"/>
+  <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z"/>
+</svg>

--- a/src/views/Trendminer/Invite.tsx
+++ b/src/views/Trendminer/Invite.tsx
@@ -12,6 +12,7 @@ import {
   RewardsProgram,
 } from '../../features/trending/components/Invitation';
 import Shell from '../../components/layout/Shell';
+import PageSpaceHero from '../../components/hero-banner/PageSpaceHero';
 import { useAeSdk } from '../../hooks';
 
 export default function Invite() {
@@ -29,7 +30,10 @@ export default function Invite() {
     <Shell>
       <div className="mx-auto px-4 py-2">
         {/* Hero */}
-        <div className="mb-8 py-2">
+        <PageSpaceHero
+          className="mb-8 px-6 py-10 md:px-10 md:py-14"
+          supernovaColor="rgba(0,229,255,.5)"
+        >
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-extrabold m-0 leading-tight">
             <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-transparent">
               {t('inviteView.heroBrand')}
@@ -37,8 +41,7 @@ export default function Invite() {
             </span>
             <span className="text-white">{t('inviteView.heroRewards')}</span>
           </h1>
-
-        </div>
+        </PageSpaceHero>
         {/* ========== NEW: Superhero Rewards Program ========== */}
         <RewardsProgram />
 


### PR DESCRIPTION
## 🎨 Overview

Adds modern animations, new icon graphics, and visual enhancements to key pages in the Superhero application, following the Superhero brand design system.

This is a direct (non-fork) replacement for #637, which came from a fork and could not access CI secrets — so its `build`/`screenshots`/preview-deploy jobs failed with `Username and password required` and no preview link was produced. This PR runs from a branch in the main repo, restoring secret access, and additionally fixes the lint errors and removes the committed `.backup` files.

## ✨ Changes

### New Animation System (`src/styles/animations.css`)
- Reusable keyframe library (fadeIn, slideUp, pulseGlow, shimmer, bounce, float, confetti, trophyShine, gradientShift, …) plus hover utilities (hover-lift, hover-glow, hover-scale). Wired through `tailwind.css`.

### New SVG Icons (`src/svg/`)
- iconTrophy, iconStar, iconSparkle, iconRocket, iconFlame, iconCelebration.

### Page enhancements (presentation only)
- **CreateTokenView** — shimmer loading states, animated gradient hero text, hover glow on form card, rocket/sparkle icons on the submit CTA, entrance animations.
- **RewardsProgram** — celebration animation on rewards earned, floating trophy with bounce, progress bars with fill + shimmer, flame icon on streaks.
- **CollectRewardsCard** — floating trophy with pulse glow, star icon when eligible, animated invitee progress bars, richer collect button.
- **RewardsOnboarding** — scale-in card entrance, shimmer progress bar, button hover lift.

No changes to reward eligibility, treasury calls, or navigation logic.

## 🔧 CI fixes vs. #637
- Fixed 14 ESLint errors (`no-trailing-spaces`, `comma-dangle`) across the touched components.
- Removed the committed `*.backup` files that inflated the original diff.
- Verified locally: `npm run lint` → 0 errors, `npm run build` → success.

Closes/replaces #637.

---
_Generated by [Claude Code](https://claude.ai/code/session_0133HVvDquM6D7vTCQUx6221)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI changes across trending/rewards views; reward and treasury behavior are untouched, though the new always-on animations are not globally gated by prefers-reduced-motion beyond PageSpaceHero’s static background tweak.
> 
> **Overview**
> Introduces a reusable **`PageSpaceHero`** wrapper that puts the home banner’s **`SpaceEffects`** cosmic backdrop behind arbitrary page content (with configurable nova color and automatic iOS WebKit “reduced” mode), and adopts it on **Invite** and **Create Token** heroes in place of plain gradient headers.
> 
> Adds a global **`animations.css`** library (entrance, shimmer, progress fill, hover-lift, celebration utilities) imported from **`tailwind.css`**, plus new brand SVG icons (trophy, star, rocket, etc.).
> 
> **Rewards / onboarding surfaces** gain motion and iconography: **`RewardsProgram`** and **`CollectRewardsCard`** swap emoji/inline SVG for Lucide and custom icons, animated progress bars, and richer CTAs; **`RewardsOnboarding`** gets matching entrance/hover/shimmer treatment. **`CreateTokenView`** is restyled with the space hero, shimmer skeleton loading, animated submit CTA, cyan-bordered form card, and a stepped explainer layout with Lucide section icons—**no deploy or eligibility logic changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6b27ffb96b99eab6abb72ce95c158970240df0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/639/) — updated Mon, 03 Aug 2026 23:51:58 GMT