### PR TITLE
feat(nav): move Earn Rewards to mobile header, add Chat to bottom nav

### DIFF
--- a/src/components/layout/app-header/MobileAppHeader.tsx
+++ b/src/components/layout/app-header/MobileAppHeader.tsx
@@ -4,8 +4,9 @@ import {
 } from '@/components/ui/ae-dropdown-menu';
 import { DEFAULT_PAST_TIMEFRAME } from '@/utils/constants';
 import { formatNumber } from '@/utils/number';
+import { TRENDING_ENABLED } from '@/config';
 import { useQuery } from '@tanstack/react-query';
-import { LogOut, User } from 'lucide-react';
+import { Gift, LogOut, User } from 'lucide-react';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
@@ -135,6 +136,16 @@ const MobileAppHeader = () => {
               <HeaderLogo className="h-7 w-auto" />
             </Link>
             <div className="flex-grow" />
+            {TRENDING_ENABLED && (
+              <Link
+                to="/trends/invite"
+                className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-lg text-[var(--standard-font-color)] transition-colors duration-200 hover:bg-white/10 no-underline hover:no-underline"
+                style={{ textDecoration: 'none' }}
+                aria-label={t('nav.earnRewards')}
+              >
+                <Gift className="h-5 w-5" aria-hidden="true" />
+              </Link>
+            )}
             <NotificationBell />
             {activeAccount ? (
               <DropdownMenu>

--- a/src/components/layout/app-header/navigationItems.ts
+++ b/src/components/layout/app-header/navigationItems.ts
@@ -1,6 +1,6 @@
 import { TRENDING_ENABLED } from '@/config';
 import {
-  Home, Search, ArrowLeftRight, Gift, LucideIcon, User, Vote, Landmark,
+  Home, Search, ArrowLeftRight, Gift, LucideIcon, User, Vote, Landmark, MessageCircle,
 } from 'lucide-react';
 
 export interface NavigationItem {
@@ -46,6 +46,13 @@ const REFER_EARN_ITEM: NavigationItem = {
   icon: Gift,
 };
 
+const CHAT_ITEM: NavigationItem = {
+  id: 'chat',
+  labelKey: 'nav.chat',
+  path: '/chat',
+  icon: MessageCircle,
+};
+
 const GET_AE_ITEM: NavigationItem = {
   id: 'get-ae',
   labelKey: 'nav.getAe',
@@ -80,7 +87,7 @@ export const getMobileFooterNavigationItems = (
 ): NavigationItem[] => [
   HOME_ITEM,
   ...(TRENDING_ENABLED ? [EXPLORE_ITEM] : []),
-  ...(TRENDING_ENABLED ? [REFER_EARN_ITEM] : []),
+  CHAT_ITEM,
   {
     id: 'account',
     labelKey: 'nav.superheroId',

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1127,6 +1127,7 @@
       "earnRewards": "اكسب المكافآت",
       "getAe": "احصل على AE",
       "superheroId": "معرّف Superhero",
+      "chat": "الدردشة",
       "account": "الحساب"
     },
     "transactionNotification": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1127,6 +1127,7 @@
       "earnRewards": "Prämien verdienen",
       "getAe": "AE erhalten",
       "superheroId": "SuperheroID",
+      "chat": "Chat",
       "account": "Konto"
     },
     "transactionNotification": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1134,6 +1134,7 @@
       "earnRewards": "Earn Rewards",
       "getAe": "Get AE",
       "superheroId": "SuperheroID",
+      "chat": "Chat",
       "account": "Account"
     },
     "transactionNotification": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1127,6 +1127,7 @@
       "earnRewards": "Gagner des récompenses",
       "getAe": "Obtenir des AE",
       "superheroId": "SuperheroID",
+      "chat": "Discussion",
       "account": "Compte"
     },
     "transactionNotification": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1127,6 +1127,7 @@
       "earnRewards": "赚取奖励",
       "getAe": "获取 AE",
       "superheroId": "Superhero ID",
+      "chat": "聊天",
       "account": "账户"
     },
     "transactionNotification": {


### PR DESCRIPTION
Mobile PWA layout only. The bottom-nav slot vacated by Earn Rewards now holds a Chat entry to /chat; Earn Rewards moves to a Gift icon before the notification bell in the mobile header, kept behind the same TRENDING_ENABLED gate the prior Earn Rewards entry used. The Chat entry is independent of trending, so it is not gated. Adds common.nav.chat to all five locales.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only mobile nav and copy changes; no auth, payments, or routing logic beyond existing `/chat` and invite paths.
> 
> **Overview**
> **Mobile navigation** is reorganized for the PWA layout: **Earn Rewards** leaves the bottom bar and appears as a **Gift** icon in the mobile header (before notifications), still gated by `TRENDING_ENABLED` and linking to `/trends/invite`.
> 
> The freed footer slot is filled by a **Chat** entry (`/chat`, `MessageCircle` icon) that is **always shown**—not tied to trending. Desktop/sidebar nav via `getNavigationItems` is unchanged; only `getMobileFooterNavigationItems` swaps refer-earn for chat.
> 
> Adds **`common.nav.chat`** in ar, de, en, fr, and zh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c302187f60f1843b13ce9e6954e8cd8dbdd3e6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/647/) — updated Mon, 10 Aug 2026 07:42:19 GMT