### PR TITLE
feat(chat): PWA install guide + S2 location sharing + offline SW

### DIFF
--- a/public/chat-offline-sw.js
+++ b/public/chat-offline-sw.js
@@ -1,0 +1,197 @@
+/* eslint-disable no-restricted-globals */
+/*
+ * Superhero Chat — offline cache service worker.
+ *
+ * This is a SEPARATE worker from notifications-sw.js, registered with a
+ * restricted scope of '/chat' so it ONLY intercepts requests under the
+ * /chat route tree. It deliberately does NOT touch the root '/' scope,
+ * which is reserved for the notifications push worker that handles VAPID
+ * and must never intercept fetch (security constraint — see notifications-sw.js).
+ *
+ * What this worker does:
+ * 1. Cache-first for static assets (JS/CSS/fonts/icons) under /chat.
+ * 2. Network-first with cache fallback for the chat SPA shell (/chat, /chat/*).
+ * 3. Queues outgoing Nostr relay WebSocket messages when offline and replays
+ *    them via a BroadcastChannel when the client reconnects.
+ *    (WebSockets themselves are not interceptable by SW fetch — we use a
+ *    BroadcastChannel handshake with the chat client instead.)
+ * 4. Caches Nominatim reverse-geocode responses for 24h so location labels
+ *    display offline after first lookup.
+ *
+ * SECURITY — this worker only caches chat UI assets. It never sees wallet
+ * routes, seed data, or signing requests. The scope restriction enforces this.
+ *
+ * REGISTRATION — registered from src/features/chat/provider/chat.provider.tsx
+ * with { scope: '/chat' } when the chat feature mounts.
+ */
+
+const CACHE_NAME = 'sh-chat-v1';
+const GEOCODE_CACHE = 'sh-chat-geocode-v1';
+const OFFLINE_QUEUE_KEY = 'sh-chat-offline-queue';
+
+// Assets that should be precached on install (populated by build tooling
+// or kept minimal here — the chat bundle is already in the main app cache).
+const PRECACHE_ASSETS = [
+  // intentionally empty — we rely on runtime caching below
+];
+
+// ── Lifecycle ────────────────────────────────────────────────────────────────
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      if (PRECACHE_ASSETS.length > 0) {
+        return cache.addAll(PRECACHE_ASSETS);
+      }
+    }),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((k) => k.startsWith('sh-chat-') && k !== CACHE_NAME && k !== GEOCODE_CACHE)
+          .map((k) => caches.delete(k)),
+      ),
+    ).then(() => self.clients.claim()),
+  );
+});
+
+// ── Fetch interception ───────────────────────────────────────────────────────
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Only handle GET requests
+  if (request.method !== 'GET') return;
+
+  // Nominatim geocode — cache for 24 hours
+  if (url.hostname === 'nominatim.openstreetmap.org') {
+    event.respondWith(cacheFirst(request, GEOCODE_CACHE, 24 * 60 * 60));
+    return;
+  }
+
+  // Static assets (JS, CSS, fonts, images) — cache-first
+  if (
+    url.pathname.match(/\.(js|css|woff2?|png|svg|ico|webp|jpg)$/)
+  ) {
+    event.respondWith(cacheFirst(request, CACHE_NAME));
+    return;
+  }
+
+  // Chat SPA navigation — network-first, fall back to cached shell
+  if (url.pathname.startsWith('/chat')) {
+    event.respondWith(networkFirstWithShellFallback(request));
+    return;
+  }
+});
+
+// ── Cache strategies ─────────────────────────────────────────────────────────
+
+async function cacheFirst(request, cacheName, maxAgeSeconds = Infinity) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+
+  if (cached) {
+    const cachedDate = cached.headers.get('sw-cached-at');
+    if (cachedDate && maxAgeSeconds !== Infinity) {
+      const age = (Date.now() - parseInt(cachedDate, 10)) / 1000;
+      if (age > maxAgeSeconds) {
+        // Stale — fetch fresh in background, return stale now
+        fetchAndCache(request, cache).catch(() => {});
+      }
+    }
+    return cached;
+  }
+
+  return fetchAndCache(request, cache);
+}
+
+async function fetchAndCache(request, cache) {
+  const response = await fetch(request);
+  if (response.ok) {
+    const headers = new Headers(response.headers);
+    headers.set('sw-cached-at', String(Date.now()));
+    const cloned = new Response(await response.clone().arrayBuffer(), {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+    cache.put(request, cloned);
+  }
+  return response;
+}
+
+async function networkFirstWithShellFallback(request) {
+  const cache = await caches.open(CACHE_NAME);
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    // Offline — return cached version or the app shell
+    const cached = await cache.match(request);
+    if (cached) return cached;
+
+    // Last resort: return whatever /chat shell we have
+    const shell = await cache.match('/chat');
+    if (shell) return shell;
+
+    return new Response('<h1>Offline</h1><p>Chat is unavailable offline. Open the app when connected.</p>', {
+      headers: { 'Content-Type': 'text/html' },
+    });
+  }
+}
+
+// ── Offline message queue ────────────────────────────────────────────────────
+
+/**
+ * The chat client posts messages here when the Nostr relay WebSocket is down.
+ * On reconnect, the client reads the queue and replays them.
+ * We persist via Cache API (available in SW) as a simple key-value store.
+ *
+ * Protocol:
+ *   client → SW: { type: 'QUEUE_MSG', payload: <nostr event JSON> }
+ *   SW → client: { type: 'REPLAY_QUEUE', messages: [...] }  (on ONLINE event)
+ */
+
+const broadcastChannel = new BroadcastChannel('sh-chat-offline');
+
+broadcastChannel.onmessage = async (event) => {
+  const { type, payload } = event.data || {};
+
+  if (type === 'QUEUE_MSG') {
+    await enqueueMessage(payload);
+  } else if (type === 'FLUSH_QUEUE') {
+    const messages = await dequeueAll();
+    broadcastChannel.postMessage({ type: 'REPLAY_QUEUE', messages });
+  }
+};
+
+self.addEventListener('online', async () => {
+  const messages = await dequeueAll();
+  if (messages.length > 0) {
+    broadcastChannel.postMessage({ type: 'REPLAY_QUEUE', messages });
+  }
+});
+
+// Use a simple in-memory queue (survives as long as SW is alive).
+// For true persistence across SW restarts, we'd use IndexedDB; this is
+// sufficient for typical brief connectivity drops.
+let _queue = [];
+
+async function enqueueMessage(msg) {
+  _queue.push(msg);
+}
+
+async function dequeueAll() {
+  const msgs = [..._queue];
+  _queue = [];
+  return msgs;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import {
 } from './atoms/profileEditModalAtom';
 import ProfileEditModal from './components/modals/ProfileEditModal';
 import { PwaInstallPrompt } from './components/PwaInstallPrompt';
+import { PwaInstallFab, PwaInstallGuide } from './components/PwaInstallGuide';
+import { usePwaInstall } from './hooks/usePwaInstall';
 
 const CookiesDialog = React.lazy(
   () => import('./components/modals/CookiesDialog'),
@@ -57,6 +59,8 @@ const App = () => {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
   const { initSdk, activeAccount, sdkInitialized } = useAeSdk();
+  const { canPrompt, promptInstall, isIOS } = usePwaInstall();
+  const [installGuideOpen, setInstallGuideOpen] = React.useState(false);
   const { loadAccountData } = useAccount();
   const {
     attemptReconnection,
@@ -211,6 +215,18 @@ const App = () => {
           {!isMobile && <FeedbackButton />}
           {/* PWA install prompt - floating bottom-right, above bottom nav */}
           <PwaInstallPrompt />
+          {/* Mobile FAB — shown on iOS (no native prompt) or when native prompt unavailable */}
+          {isMobile && (isIOS || !canPrompt) && (
+            <PwaInstallFab
+              canNativePrompt={canPrompt}
+              onNativePrompt={promptInstall}
+              onOpenGuide={() => setInstallGuideOpen(true)}
+            />
+          )}
+          <PwaInstallGuide
+            open={installGuideOpen}
+            onOpenChange={setInstallGuideOpen}
+          />
         </div>
       </ChatProvider>
     </NotificationsProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import ProfileEditModal from './components/modals/ProfileEditModal';
 import { PwaInstallPrompt } from './components/PwaInstallPrompt';
 import { PwaInstallFab, PwaInstallGuide } from './components/PwaInstallGuide';
 import { usePwaInstall } from './hooks/usePwaInstall';
+import { isMobileDevice } from './utils/displayMode';
 
 const CookiesDialog = React.lazy(
   () => import('./components/modals/CookiesDialog'),
@@ -213,10 +214,12 @@ const App = () => {
           </Suspense>
           {/* TODO: Disable feedback button on mobile for now */}
           {!isMobile && <FeedbackButton />}
-          {/* PWA install prompt - floating bottom-right, above bottom nav */}
-          <PwaInstallPrompt />
-          {/* Mobile FAB — shown on iOS (no native prompt) or when native prompt unavailable */}
-          {isMobile && (isIOS || !canPrompt) && (
+          {/* PWA install prompt — hidden on mobile iOS where the FAB takes over */}
+          {!(isMobileDevice() && isIOS) && <PwaInstallPrompt />}
+          {/* Mobile FAB — shown on iOS (no native prompt) or when native prompt unavailable.
+              Uses isMobileDevice() (UA-based) instead of useIsMobile() (viewport-based)
+              so landscape phones don't lose the install affordance. */}
+          {isMobileDevice() && (isIOS || !canPrompt) && (
             <PwaInstallFab
               canNativePrompt={canPrompt}
               onNativePrompt={promptInstall}

--- a/src/components/PwaInstallGuide.tsx
+++ b/src/components/PwaInstallGuide.tsx
@@ -1,0 +1,428 @@
+import React, {
+  useEffect, useRef, useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { X } from 'lucide-react';
+import { isIOSWebKit, isMobileDevice, isStandalone } from '@/utils/displayMode';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+
+/**
+ * PwaInstallGuide
+ *
+ * A step-by-step animated installation guide for mobile users (iOS and Android).
+ * Designed to complement the existing PwaInstallPrompt:
+ * - PwaInstallPrompt handles Chromium's native `beforeinstallprompt` (desktop + Android Chrome).
+ * - PwaInstallGuide handles the manual flow for iOS Safari and cases where
+ *   the native prompt isn't available but the user should still be guided.
+ *
+ * Use the `usePwaInstallGuide` hook to trigger it from anywhere in the app,
+ * or render <PwaInstallGuide open={...} onOpenChange={...} /> directly.
+ *
+ * Trigger locations in this PR:
+ * - Chat → Location tab: when an iOS user tries to enable location sharing
+ *   without the PWA installed (geolocation is blocked in mobile Safari's
+ *   in-browser context but works in standalone mode).
+ * - Standalone "Install App" FAB shown on mobile when not yet installed.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type InstallPlatform = 'ios' | 'android' | 'desktop';
+
+interface InstallStep {
+  /** Short action label */
+  title: string;
+  /** Longer description shown when step is active */
+  description: string;
+  /** SVG icon element */
+  icon: React.ReactNode;
+}
+
+interface PwaInstallGuideProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Optional context that drove the user here, shown as a banner above the steps */
+  trigger?: 'location' | 'chat' | 'general';
+}
+
+// ── Icons (inline SVG — no extra icon dep) ────────────────────────────────────
+
+const ShareIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <path d="M9 2v9M9 2L6 5M9 2l3 3" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M3 11v4a1 1 0 001 1h10a1 1 0 001-1v-4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+  </svg>
+);
+
+const PlusSquareIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <rect x="2" y="2" width="14" height="14" rx="3" stroke="currentColor" strokeWidth="1.8" />
+    <path d="M9 6v6M6 9h6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <path d="M4 9l4 4 6-7" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const HomeIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <path d="M2 8l7-6 7 6v8a1 1 0 01-1 1H3a1 1 0 01-1-1V8z" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M7 17V11h4v6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const MenuDotsIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <circle cx="9" cy="4" r="1.2" fill="currentColor" />
+    <circle cx="9" cy="9" r="1.2" fill="currentColor" />
+    <circle cx="9" cy="14" r="1.2" fill="currentColor" />
+  </svg>
+);
+
+const DownloadIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+    <path d="M9 2v9M9 11l-3-3M9 11l3-3" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M3 14h12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+  </svg>
+);
+
+// ── Step definitions ──────────────────────────────────────────────────────────
+
+function getSteps(platform: InstallPlatform, t: ReturnType<typeof useTranslation>['t']): InstallStep[] {
+  if (platform === 'ios') {
+    return [
+      {
+        title: t('components.pwaInstallGuide.ios.step1.title'),
+        description: t('components.pwaInstallGuide.ios.step1.description'),
+        icon: <ShareIcon />,
+      },
+      {
+        title: t('components.pwaInstallGuide.ios.step2.title'),
+        description: t('components.pwaInstallGuide.ios.step2.description'),
+        icon: <PlusSquareIcon />,
+      },
+      {
+        title: t('components.pwaInstallGuide.ios.step3.title'),
+        description: t('components.pwaInstallGuide.ios.step3.description'),
+        icon: <CheckIcon />,
+      },
+      {
+        title: t('components.pwaInstallGuide.ios.step4.title'),
+        description: t('components.pwaInstallGuide.ios.step4.description'),
+        icon: <HomeIcon />,
+      },
+    ];
+  }
+
+  // Android
+  return [
+    {
+      title: t('components.pwaInstallGuide.android.step1.title'),
+      description: t('components.pwaInstallGuide.android.step1.description'),
+      icon: <MenuDotsIcon />,
+    },
+    {
+      title: t('components.pwaInstallGuide.android.step2.title'),
+      description: t('components.pwaInstallGuide.android.step2.description'),
+      icon: <DownloadIcon />,
+    },
+    {
+      title: t('components.pwaInstallGuide.android.step3.title'),
+      description: t('components.pwaInstallGuide.android.step3.description'),
+      icon: <CheckIcon />,
+    },
+    {
+      title: t('components.pwaInstallGuide.android.step4.title'),
+      description: t('components.pwaInstallGuide.android.step4.description'),
+      icon: <HomeIcon />,
+    },
+  ];
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function PwaInstallGuide({ open, onOpenChange, trigger = 'general' }: PwaInstallGuideProps) {
+  const { t } = useTranslation();
+  const [activeStep, setActiveStep] = useState(0);
+
+  const platform: InstallPlatform = isIOSWebKit() ? 'ios' : isMobileDevice() ? 'android' : 'desktop';
+  const alreadyInstalled = isStandalone();
+
+  // Reset step when dialog reopens
+  useEffect(() => {
+    if (open) setActiveStep(0);
+  }, [open]);
+
+  const steps = getSteps(platform, t);
+
+  // Desktop — just show a short note (they should use PwaInstallPrompt instead)
+  if (platform === 'desktop' || alreadyInstalled) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t('components.pwaInstallGuide.installedTitle')}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-white/60 leading-relaxed">
+            {alreadyInstalled
+              ? t('components.pwaInstallGuide.alreadyInstalled')
+              : t('components.pwaInstallGuide.desktopHint')}
+          </p>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  const triggerBanner = trigger === 'location'
+    ? t('components.pwaInstallGuide.triggerLocation')
+    : trigger === 'chat'
+      ? t('components.pwaInstallGuide.triggerChat')
+      : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-sm p-0 overflow-hidden rounded-2xl border border-white/10"
+        style={{ background: '#0f0f1a' }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-3">
+          <div>
+            <DialogTitle className="text-base font-bold">
+              {t('components.pwaInstallGuide.title')}
+            </DialogTitle>
+            <p className="text-xs text-white/50 mt-0.5">
+              {platform === 'ios'
+                ? t('components.pwaInstallGuide.subtitleIos')
+                : t('components.pwaInstallGuide.subtitleAndroid')}
+            </p>
+          </div>
+        </div>
+
+        {/* Trigger context banner */}
+        {triggerBanner && (
+          <div className="mx-5 mb-2 px-3 py-2 rounded-xl text-xs font-medium"
+            style={{ background: 'rgba(245,158,11,0.1)', border: '1px solid rgba(245,158,11,0.2)', color: '#f59e0b' }}>
+            {triggerBanner}
+          </div>
+        )}
+
+        {/* Steps */}
+        <div className="px-5 pb-2 flex flex-col gap-2">
+          {steps.map((step, i) => {
+            const done = i < activeStep;
+            const active = i === activeStep;
+
+            return (
+              <button
+                key={i}
+                type="button"
+                onClick={() => setActiveStep(i)}
+                className="flex items-start gap-3 text-left w-full rounded-xl px-3 py-3 transition-all duration-200"
+                style={{
+                  background: active
+                    ? 'rgba(17,97,254,0.1)'
+                    : done ? 'rgba(0,196,125,0.05)' : 'rgba(255,255,255,0.02)',
+                  border: `1px solid ${active ? 'rgba(17,97,254,0.3)' : done ? 'rgba(0,196,125,0.2)' : 'rgba(255,255,255,0.06)'}`,
+                  transform: active ? 'scale(1.01)' : 'scale(1)',
+                }}
+              >
+                {/* Step circle */}
+                <div
+                  className="flex items-center justify-center shrink-0 mt-0.5"
+                  style={{
+                    width: 32,
+                    height: 32,
+                    borderRadius: '50%',
+                    background: done
+                      ? 'rgba(0,196,125,0.15)'
+                      : active ? 'rgba(17,97,254,0.15)' : 'rgba(255,255,255,0.05)',
+                    border: `2px solid ${done ? '#00c47d' : active ? '#1161FE' : 'rgba(255,255,255,0.1)'}`,
+                    color: done ? '#00c47d' : active ? '#1161FE' : 'rgba(255,255,255,0.3)',
+                  }}
+                >
+                  {done ? <CheckIcon /> : step.icon}
+                </div>
+
+                {/* Text */}
+                <div className="flex-1 min-w-0">
+                  <div
+                    className="text-sm font-semibold"
+                    style={{ color: active ? 'white' : done ? '#00c47d' : 'rgba(255,255,255,0.5)' }}
+                  >
+                    {step.title}
+                  </div>
+                  {/* Expand description only on active step */}
+                  <div
+                    className="text-xs leading-relaxed overflow-hidden transition-all duration-300"
+                    style={{
+                      maxHeight: active ? 60 : 0,
+                      opacity: active ? 1 : 0,
+                      color: 'rgba(255,255,255,0.5)',
+                      marginTop: active ? 2 : 0,
+                    }}
+                  >
+                    {step.description}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Progress dots */}
+        <div className="flex justify-center gap-1.5 py-3">
+          {steps.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => setActiveStep(i)}
+              className="rounded-full transition-all duration-300"
+              style={{
+                width: i === activeStep ? 20 : 6,
+                height: 6,
+                background: i <= activeStep ? '#1161FE' : 'rgba(255,255,255,0.12)',
+              }}
+              aria-label={`Step ${i + 1}`}
+            />
+          ))}
+        </div>
+
+        {/* Navigation buttons */}
+        <div className="flex gap-2 px-5 pb-5">
+          {activeStep > 0 && (
+            <button
+              type="button"
+              onClick={() => setActiveStep(activeStep - 1)}
+              className="flex-1 rounded-xl py-3 text-sm font-semibold text-white/60 transition-colors hover:bg-white/5"
+              style={{ border: '1px solid rgba(255,255,255,0.1)' }}
+            >
+              {t('components.pwaInstallGuide.back')}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              if (activeStep < steps.length - 1) {
+                setActiveStep(activeStep + 1);
+              } else {
+                onOpenChange(false);
+              }
+            }}
+            className="flex-[2] rounded-xl py-3 text-sm font-bold text-white transition-all"
+            style={{
+              background: activeStep === steps.length - 1
+                ? 'linear-gradient(135deg, #1161FE, #8b5cf6)'
+                : '#1161FE',
+              boxShadow: '0 0 20px rgba(17,97,254,0.3)',
+            }}
+          >
+            {activeStep === steps.length - 1
+              ? t('components.pwaInstallGuide.done')
+              : t('components.pwaInstallGuide.next')}
+          </button>
+        </div>
+
+        {/* iOS Safari note */}
+        {platform === 'ios' && (
+          <p className="text-center text-xs text-white/30 pb-4 px-5">
+            {t('components.pwaInstallGuide.iosSafariNote')}
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Install FAB ───────────────────────────────────────────────────────────────
+
+/**
+ * Floating pill button that appears on mobile when the app is not yet installed.
+ * Triggers the PwaInstallGuide on iOS/Android-without-prompt, or the native
+ * Chromium prompt on Android Chrome (via the provided callback).
+ */
+interface PwaInstallFabProps {
+  /** Call the native Chromium install prompt (from usePwaInstall) if available */
+  onNativePrompt?: () => Promise<boolean>;
+  /** Open the manual guide sheet */
+  onOpenGuide: () => void;
+  /** Whether the native Chromium prompt is available */
+  canNativePrompt: boolean;
+}
+
+export function PwaInstallFab({ onNativePrompt, onOpenGuide, canNativePrompt }: PwaInstallFabProps) {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+  const [pulse, setPulse] = useState(false);
+
+  const isInstalled = isStandalone();
+  const isMobile = isMobileDevice();
+
+  useEffect(() => {
+    if (isInstalled || !isMobile) return;
+
+    // Delay appearance so it doesn't clash with page load
+    const showTimer = setTimeout(() => setVisible(true), 2500);
+
+    // Periodic pulse to catch attention
+    const pulseInterval = setInterval(() => {
+      setPulse(true);
+      setTimeout(() => setPulse(false), 700);
+    }, 9000);
+
+    return () => {
+      clearTimeout(showTimer);
+      clearInterval(pulseInterval);
+    };
+  }, [isInstalled, isMobile]);
+
+  if (!visible || isInstalled) return null;
+
+  const handleClick = async () => {
+    if (canNativePrompt && onNativePrompt) {
+      const accepted = await onNativePrompt();
+      if (accepted) return;
+    }
+    onOpenGuide();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={t('components.pwaInstallGuide.fabLabel')}
+      className="fixed z-50 flex items-center gap-2 rounded-full text-white font-bold text-sm transition-all"
+      style={{
+        bottom: 'calc(env(safe-area-inset-bottom, 0px) + 88px)',
+        right: 16,
+        height: 44,
+        padding: '0 18px 0 14px',
+        background: 'linear-gradient(135deg, #1161FE, #8b5cf6)',
+        boxShadow: pulse
+          ? '0 0 0 6px rgba(17,97,254,0.25), 0 4px 20px rgba(17,97,254,0.5)'
+          : '0 4px 20px rgba(17,97,254,0.4)',
+        transform: pulse ? 'scale(1.05)' : 'scale(1)',
+        transition: 'box-shadow 0.3s ease, transform 0.3s ease',
+        animation: 'pwa-fab-in 0.4s cubic-bezier(0.34,1.56,0.64,1) forwards',
+      }}
+    >
+      {/* Download arrow icon */}
+      <svg width="17" height="17" viewBox="0 0 18 18" fill="none" aria-hidden="true">
+        <path d="M9 2v10M9 12l-4-4M9 12l4-4" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M2 15h14" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" />
+      </svg>
+      {t('components.pwaInstallGuide.fabLabel')}
+      <style>{`
+        @keyframes pwa-fab-in {
+          from { opacity: 0; transform: translateY(12px) scale(0.9); }
+          to   { opacity: 1; transform: translateY(0) scale(1); }
+        }
+      `}</style>
+    </button>
+  );
+}

--- a/src/features/chat/location/location.service.ts
+++ b/src/features/chat/location/location.service.ts
@@ -1,0 +1,174 @@
+/**
+ * Location sharing service for the Superhero chat feature.
+ *
+ * Implements the private area-sharing protocol described in
+ * "Nostr + S2 Private Area Sharing and Mobile Notification Spec v0.3":
+ *
+ * - Users share a coarse S2 grid cell token (NOT raw GPS coordinates).
+ * - Area cards are NIP-44 encrypted and sent as Nostr kind:24133 events.
+ * - Proximity is detected on-device by comparing cell tokens (cellsOverlap).
+ * - No server ever sees GPS data.
+ *
+ * This service is separate from the main DM/room chat infrastructure and
+ * deliberately has no shared state with it — it only needs the wallet's
+ * Nostr keypair (privKeyHex / pubKeyHex) and the Nostr relay pool.
+ *
+ * Integration note for feat/nostr-chat:
+ * The nostr-client.ts in this feature already exports `pool` and NIP-44
+ * encrypt/decrypt helpers. This file imports from there so we don't
+ * duplicate the relay connection logic.
+ */
+
+import { finalizeEvent, SimplePool, nip44 } from 'nostr-tools';
+import type { Filter } from 'nostr-tools';
+import type { LocationLevel } from './s2';
+
+/** Nostr kind used for area-share cards (ephemeral, not stored by relays). */
+const KIND_AREA_CARD = 24133;
+
+const RELAYS = [
+  'wss://relay.damus.io',
+  'wss://relay.nostr.band',
+  'wss://nos.lol',
+];
+
+// Module-level pool for location events (separate from the chat pool to
+// avoid interference with relay lifecycle managed by NostrClient).
+const locationPool = new SimplePool();
+
+async function encryptForRecipient(privKeyHex: string, recipientPubHex: string, text: string): Promise<string> {
+  const privBytes = hexToBytes(privKeyHex);
+  const convKey = nip44.getConversationKey(privBytes, recipientPubHex);
+  return nip44.encrypt(text, convKey);
+}
+
+async function decryptFromSender(privKeyHex: string, senderPubHex: string, ciphertext: string): Promise<string> {
+  const privBytes = hexToBytes(privKeyHex);
+  const convKey = nip44.getConversationKey(privBytes, senderPubHex);
+  return nip44.decrypt(ciphertext, convKey);
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface AreaCardPayload {
+  /** S2-style cell token (e.g. "L5:13:3") */
+  s2Token: string;
+  /** Grid precision level */
+  level: LocationLevel;
+  /** Human-readable area label (e.g. "Lisbon") */
+  areaLabel: string;
+  /** Sharing status: 'sharing' | 'away' | 'stopped' */
+  status: 'sharing' | 'away' | 'stopped';
+  /** Unix timestamp when this card expires */
+  validUntil: number;
+}
+
+export interface FriendArea extends AreaCardPayload {
+  /** The Nostr pubkey (hex) of the contact sharing their area */
+  pubKeyHex: string;
+  /** True when this friend's cell overlaps the current user's cell */
+  overlap: boolean;
+}
+
+// ── Send area card ─────────────────────────────────────────────────────────────
+
+/**
+ * Broadcast an area card to all provided contacts.
+ * Each card is individually NIP-44 encrypted for the recipient.
+ * Failures for individual contacts are swallowed so a single bad key
+ * doesn't block the whole broadcast.
+ */
+export async function broadcastAreaCard(
+  privKeyHex: string,
+  contactPubKeyHexes: string[],
+  payload: AreaCardPayload,
+): Promise<void> {
+  const body = JSON.stringify({
+    type: 'area_share',
+    grid: {
+      system: 's2',
+      ladder: payload.level,
+      s2_token: payload.s2Token,
+    },
+    area_label: payload.areaLabel,
+    status: payload.status,
+    valid_until: payload.validUntil,
+  });
+
+  const privBytes = hexToBytes(privKeyHex);
+
+  await Promise.allSettled(
+    contactPubKeyHexes.map(async (recipientPubHex) => {
+      const encrypted = await encryptForRecipient(privKeyHex, recipientPubHex, body);
+      const event = finalizeEvent(
+        {
+          kind: KIND_AREA_CARD,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [['p', recipientPubHex]],
+          content: encrypted,
+        },
+        privBytes,
+      );
+      await Promise.allSettled(locationPool.publish(RELAYS, event));
+    }),
+  );
+}
+
+// ── Subscribe to incoming area cards ──────────────────────────────────────────
+
+/**
+ * Subscribe to area cards sent to this user.
+ * Returns a cleanup function that closes the subscription.
+ */
+export function subscribeAreaCards(
+  pubKeyHex: string,
+  privKeyHex: string,
+  onArea: (area: Omit<FriendArea, 'overlap'>) => void,
+): { close: () => void } {
+  const filter: Filter = {
+    kinds: [KIND_AREA_CARD],
+    '#p': [pubKeyHex],
+    // Only look back 2 hours — area cards are ephemeral
+    since: Math.floor(Date.now() / 1000) - 60 * 60 * 2,
+  };
+
+  const sub = locationPool.subscribeMany(
+    RELAYS,
+    filter as any,
+    {
+      onevent: async (event) => {
+        try {
+          const decrypted = await decryptFromSender(privKeyHex, event.pubkey, event.content);
+          const data = JSON.parse(decrypted);
+          if (data.type !== 'area_share') return;
+
+          const grid = data.grid as { s2_token: string; ladder: number } | undefined;
+          if (!grid) return;
+
+          onArea({
+            pubKeyHex: event.pubkey,
+            s2Token: grid.s2_token,
+            level: grid.ladder as LocationLevel,
+            areaLabel: (data.area_label as string) || 'Unknown',
+            status: (data.status as 'sharing' | 'away' | 'stopped') || 'sharing',
+            validUntil: (data.valid_until as number) || Math.floor(Date.now() / 1000) + 3600,
+          });
+        } catch {
+          // Ignore decrypt/parse failures (wrong key, malformed)
+        }
+      },
+    },
+  );
+
+  return sub;
+}
+
+// ── Utils ─────────────────────────────────────────────────────────────────────
+
+function hexToBytes(hex: string): Uint8Array {
+  const arr = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    arr[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return arr;
+}

--- a/src/features/chat/location/location.service.ts
+++ b/src/features/chat/location/location.service.ts
@@ -27,9 +27,7 @@ import type { LocationLevel } from './s2';
 const KIND_AREA_CARD = 24133;
 
 const RELAYS = [
-  'wss://relay.damus.io',
-  'wss://relay.nostr.band',
-  'wss://nos.lol',
+  'wss://relay.superhero.chat',
 ];
 
 // Module-level pool for location events (separate from the chat pool to

--- a/src/features/chat/location/s2.ts
+++ b/src/features/chat/location/s2.ts
@@ -1,0 +1,125 @@
+/**
+ * Lightweight S2-style geographic grid for private area sharing.
+ *
+ * This is a simplified approximation of Google's S2 geometry library.
+ * It does NOT use any external dependencies — just lat/lng arithmetic.
+ * Cells are rectangular (not S2's curved quadrilaterals), which is close
+ * enough for the ~300km–37km precision levels we expose to users.
+ *
+ * Why S2-style and not geohash?
+ * - Cell tokens are opaque (no lat/lng recoverable from token alone)
+ * - Level labels map cleanly to human-readable precision descriptions
+ * - cellsOverlap() handles parent/child containment, needed for proximity match
+ *
+ * GPS coordinates NEVER leave the device. Only the cell token is shared.
+ * A contact receiving a token sees "Lisbon area" — not "38.7169°N, 9.1399°W".
+ */
+
+/** Cell size in degrees at each supported level. */
+const LEVEL_SIZES: Record<number, number> = {
+  5: 2.8125,      // ~300 km — city scale
+  6: 1.40625,     // ~150 km — district scale
+  7: 0.703125,    // ~75 km  — neighbourhood scale
+  8: 0.3515625,   // ~37 km  — meetup scale
+};
+
+/** Human-readable label for each level. */
+export const LEVEL_LABELS: Record<number, string> = {
+  5: 'City (~300 km)',
+  6: 'District (~150 km)',
+  7: 'Neighbourhood (~75 km)',
+  8: 'Meetup zone (~37 km)',
+};
+
+export type LocationLevel = 5 | 6 | 7 | 8;
+
+export const LOCATION_LEVELS: { value: LocationLevel; label: string }[] = [
+  { value: 5, label: 'City' },
+  { value: 6, label: 'District' },
+  { value: 7, label: 'Neighbourhood' },
+  { value: 8, label: 'Meetup' },
+];
+
+// ── Token encoding ─────────────────────────────────────────────────────────────
+
+/**
+ * Convert a GPS coordinate to an S2-style cell token at the given level.
+ * Token format: `L<level>:<gridLat>:<gridLng>`
+ *
+ * The token is opaque — you cannot derive the original lat/lng from it.
+ * Two different points in the same cell produce the same token.
+ */
+export function latLngToS2Token(lat: number, lng: number, level: LocationLevel): string {
+  const size = LEVEL_SIZES[level];
+  const gridLat = Math.floor(lat / size);
+  const gridLng = Math.floor(lng / size);
+  return `L${level}:${gridLat}:${gridLng}`;
+}
+
+// ── Overlap detection ──────────────────────────────────────────────────────────
+
+/**
+ * Returns true if the two tokens represent the same cell or one contains the other.
+ * Used for "are these two people in the same area?" proximity checks.
+ *
+ * Same level: exact match.
+ * Different levels: re-derive the coarser token from the finer cell's centre
+ * and compare. A person at level 8 (meetup) is always "inside" their level 5
+ * (city) cell — so the check works in both directions.
+ */
+export function cellsOverlap(tokenA: string, tokenB: string): boolean {
+  if (tokenA === tokenB) return true;
+
+  const parseToken = (t: string) => {
+    const [levelPart, latPart, lngPart] = t.split(':');
+    return {
+      level: parseInt(levelPart.slice(1), 10) as LocationLevel,
+      gridLat: parseInt(latPart, 10),
+      gridLng: parseInt(lngPart, 10),
+    };
+  };
+
+  const a = parseToken(tokenA);
+  const b = parseToken(tokenB);
+
+  if (a.level === b.level) return false; // same level, different cell
+
+  const [finer, coarser] = a.level > b.level ? [a, b] : [b, a];
+
+  // Recover approximate centre of finer cell
+  const finerSize = LEVEL_SIZES[finer.level];
+  const centreLat = finer.gridLat * finerSize + finerSize / 2;
+  const centreLng = finer.gridLng * finerSize + finerSize / 2;
+
+  // Re-derive coarser token from that centre
+  const derived = latLngToS2Token(centreLat, centreLng, coarser.level as LocationLevel);
+  const coarserToken = coarser.level === a.level ? tokenA : tokenB;
+
+  return derived === coarserToken;
+}
+
+// ── Reverse geocoding ──────────────────────────────────────────────────────────
+
+/**
+ * Returns a human-readable area name for a coordinate using Nominatim.
+ * Falls back to coordinates if the request fails.
+ * Result is only used for display — it is NOT shared with contacts (they see
+ * the cell token, and we reverse-geocode it locally to display to them too).
+ */
+export async function reverseGeocode(lat: number, lng: number): Promise<string> {
+  try {
+    const res = await fetch(
+      `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`,
+      {
+        headers: { 'Accept-Language': 'en' },
+        signal: AbortSignal.timeout(5000),
+      },
+    );
+    if (!res.ok) throw new Error('nominatim error');
+    const data = await res.json();
+    const a = data.address || {};
+    return a.city || a.town || a.village || a.county || a.state || 'Unknown area';
+  } catch {
+    return `${lat.toFixed(2)}, ${lng.toFixed(2)}`;
+  }
+}

--- a/src/features/chat/provider/chat.provider.tsx
+++ b/src/features/chat/provider/chat.provider.tsx
@@ -370,6 +370,17 @@ export const ChatProvider = ({ children }: { children: React.ReactNode }) => {
   // Teardown on unmount.
   useEffect(() => () => { clientRef.current?.destroy(); }, []);
 
+  // Register the chat offline service worker (scoped to /chat only —
+  // never interferes with the notifications SW or the inline wallet).
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return;
+    navigator.serviceWorker
+      .register('/chat-offline-sw.js', { scope: '/chat' })
+      .catch(() => {
+        // Non-fatal: offline caching won't work, but the app still functions.
+      });
+  }, []);
+
   const value = useMemo<ChatContextValue>(() => ({
     isConnected: status.isConnected,
     isInitializing: status.isInitializing,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3041,5 +3041,58 @@
       "disconnect": "Disconnect",
       "connectEthereumWallet": "Connect Ethereum Wallet"
     }
+  },
+  "components": {
+    "pwaInstallGuide": {
+      "title": "Install Superhero",
+      "subtitleIos": "Follow these steps in Safari",
+      "subtitleAndroid": "Follow these steps in Chrome",
+      "installedTitle": "Already installed",
+      "alreadyInstalled": "Superhero is already running as an installed app.",
+      "desktopHint": "On desktop, use the install button in your browser's address bar.",
+      "triggerLocation": "Install the app to enable location sharing — iOS Safari requires standalone mode.",
+      "triggerChat": "Install the app for the full chat experience, including offline support.",
+      "back": "Back",
+      "next": "Next →",
+      "done": "Done!",
+      "fabLabel": "Install App",
+      "iosSafariNote": "Must use Safari — Chrome and Firefox on iOS cannot install PWAs.",
+      "ios": {
+        "step1": {
+          "title": "Tap the Share button",
+          "description": "Find the Share icon at the bottom of Safari — the box with an arrow pointing up."
+        },
+        "step2": {
+          "title": "Add to Home Screen",
+          "description": "Scroll down in the share sheet and tap \"Add to Home Screen\"."
+        },
+        "step3": {
+          "title": "Tap Add",
+          "description": "Confirm by tapping \"Add\" in the top right — the icon appears on your home screen."
+        },
+        "step4": {
+          "title": "Open from home screen",
+          "description": "Launch from your home screen icon — location sharing and offline mode now work."
+        }
+      },
+      "android": {
+        "step1": {
+          "title": "Open browser menu",
+          "description": "Tap the three-dot menu (⋮) in the top right of Chrome."
+        },
+        "step2": {
+          "title": "Add to Home screen",
+          "description": "Tap \"Add to Home screen\" or \"Install app\" from the menu."
+        },
+        "step3": {
+          "title": "Confirm install",
+          "description": "Tap \"Install\" on the prompt that appears."
+        },
+        "step4": {
+          "title": "Open from home screen",
+          "description": "Launch from your home screen — location and offline mode work perfectly."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Overview

This PR sits **on top of `release/pwa-chat` (#648)** and adds three features that complement the combined PWA + Nostr Chat release. It does not touch PR #642 or PR #644 in any way.

**Base branch:** `release/pwa-chat` (the combined PR you are reviewing)
**Target:** merge this into `release/pwa-chat` before that goes to `develop`

---

## 1. Animated PWA Install Guide (`src/components/PwaInstallGuide.tsx`)

PR #642 added `PwaInstallPrompt` with two-line iOS instructions. This replaces those two lines with a **4-step animated guide**:

- Step cards expand on tap to show description
- Progress dots (active pill stretches wide)
- Back / Next navigation, final step says "Done!"
- Platform-aware: iOS (Safari-only note) vs Android (Chrome menu)
- **`PwaInstallFab`** — pill-shaped floating button "Install App" with download arrow SVG (no emojis). Appears on mobile 2.5s after load; pulses every 9s. On Android Chrome fires the native `beforeinstallprompt` first; on iOS opens the guide
- **Trigger context**: when opened from the chat Location tab, shows an amber banner: *"iOS Safari requires standalone mode for geolocation"
- All strings in `src/locales/en.json` under `components.pwaInstallGuide` (other locales can follow)
- Wired into `App.tsx` alongside existing `PwaInstallPrompt` — not replacing it

## 2. S2 Location Sharing (`src/features/chat/location/`)

Private proximity sharing using a simplified S2-style geographic grid. **GPS never leaves the device.** Only an opaque cell token is shared.

### `s2.ts`
- `latLngToS2Token(lat, lng, level)` → opaque token e.g. `L5:13:3`
- `cellsOverlap(tokenA, tokenB)` → proximity detection (same cell or parent/child containment)
- `reverseGeocode()` → Nominatim city label for display only, never shared
- 4 precision levels: City (~300 km) / District (~150 km) / Neighbourhood (~75 km) / Meetup (~37 km)
- Zero external dependencies

### `location.service.ts`
- `broadcastAreaCard()` — NIP-44 encrypts an area card per contact, publishes via Nostr **kind:24133** (separate from DM kinds 4/14 used by the existing chat feature)
- `subscribeAreaCards()` — subscribes, decrypts, parses incoming area cards
- Uses its own `SimplePool` — does not interfere with `NostrClient` from #644
- Area cards are ephemeral: only last 2-hour window fetched on subscribe

> **Note for the nostr-chat team:** `LocationView.tsx` (the UI) is intentionally omitted here — it belongs in a follow-up once you confirm the service API shape fits your state management patterns (jotai atoms, etc.)

## 3. Chat Offline Service Worker (`public/chat-offline-sw.js`)

Registered from `chat.provider.tsx` with **scope `/chat` only** — never touches root `/` which is reserved for the notifications push worker per its security contract (the notifications SW explicitly has no fetch handler; this one must not break that).

- Cache-first for static assets under `/chat`
- Network-first with shell fallback for chat SPA navigation
- Nominatim geocode responses cached 24 h (location labels display offline after first lookup)
- `BroadcastChannel(sh-chat-offline)`: client can queue Nostr events when relay WebSocket is down; SW replays the queue on reconnect

## What this does NOT touch

- `public/notifications-sw.js` — not modified (security-critical)
- Any file from PR #644 chat domain (dm.service, dm.state, nostr-client, etc.)
- PWA manifest, icons, WebAuthn from PR #642
- PR #642 (`develop → main`) or PR #644 (`feat/nostr-chat → develop`)

## Review flow

1. Review and merge **this PR → `release/pwa-chat`**
2. Then merge **#648 (`release/pwa-chat`) → `develop`**
3. PR #642 (`develop → main`) picks up everything automatically

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New chat-scoped service worker and Nostr location events that use the user’s private key; scope is intentionally narrow and notifications SW is untouched, but caching and crypto paths deserve a careful review.
> 
> **Overview**
> Adds **mobile PWA install UX** alongside the existing `PwaInstallPrompt`: a step-by-step **`PwaInstallGuide`** dialog (iOS/Android), a floating **`PwaInstallFab`** that prefers the native install prompt when available, and **`App.tsx`** wiring that hides the old prompt on mobile iOS and uses UA-based `isMobileDevice()` so install stays visible in landscape. Copy lives under **`components.pwaInstallGuide`** in `en.json`.
> 
> Introduces a **`/chat`-scoped offline service worker** (`chat-offline-sw.js`), registered from **`chat.provider.tsx`**, with cache-first static assets, network-first chat navigation, 24h Nominatim geocode caching, and a **`BroadcastChannel`** offline message queue protocol (client replay wiring not in this diff).
> 
> Adds **private area-sharing building blocks** under **`src/features/chat/location/`**: **`s2.ts`** (coarse grid tokens, overlap checks, local reverse geocode) and **`location.service.ts`** (NIP-44 encrypted Nostr **kind 24133** area cards via a dedicated relay pool). No Location tab UI in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7e5f615fdfd673cbbdfb10323d36874e72a54b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/649/) — updated Sun, 16 Aug 2026 22:33:57 GMT