### PR TITLE
test(chat): verify nostr identity for passkey wallets; isolate AE↔Nostr link 500

### DIFF
--- a/src/features/nostr-link/__tests__/link-roundtrip.e2e.test.ts
+++ b/src/features/nostr-link/__tests__/link-roundtrip.e2e.test.ts
@@ -8,6 +8,15 @@
  *
  * It derives a FRESH throwaway seed each run (so nonce/replay never collide),
  * derives the AE account + nostr identity from it, and links them.
+ *
+ * KNOWN BACKEND STATE (2026-08-18, testnet.api.dev.tokensale.org): `claim`
+ * returns 201 and the AE signature verifies locally, but `submit` answers
+ * `500 {"statusCode":500,"message":"Internal server error"}` — for a brand-new
+ * account AND for one funded from the faucet so it exists on chain. The payload
+ * matches what the app sends (same endpoint, `nostr_event` as a JSON string), so
+ * this is a server-side fault, not a client contract mismatch. The failure is
+ * asserted per stage below so a run says WHICH step broke instead of just
+ * "Internal Server Error".
  */
 // @vitest-environment node
 import { describe, expect, it } from 'vitest';
@@ -15,10 +24,12 @@ import { Buffer } from 'buffer';
 import { generateMnemonic, mnemonicToSeedSync } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 
-import { OpenAPI } from '@/api/generated';
+import { OpenAPI, NostrLinkService } from '@/api/generated';
 import { deriveSigner, deriveAccount } from '@/features/wallet/derivation';
 import { deriveKeysFromSeed } from '@/features/chat/nostr/crypto';
 import { createDerivedNostrIdentity } from '@/features/chat/identity/derived-identity';
+import { verifyLinkMessageSignature } from '@/utils/signLinkMessage';
+import { createNostrProofEvent } from '../nostr-proof';
 import { linkNostrIdentity, fetchNostrLink } from '../link-flow';
 
 const TESTNET_API = 'https://testnet.api.dev.tokensale.org';
@@ -49,5 +60,59 @@ describe.skipIf(!process.env.NOSTR_LINK_E2E)('AE↔Nostr link — live testnet r
     const linked = await fetchNostrLink(address);
     // eslint-disable-next-line no-console
     console.log('[e2e] account links.nostr', linked);
+  }, 120_000);
+
+  /**
+   * Stage-by-stage version of the same flow. When the round-trip above fails,
+   * this says whether the client built a bad payload or the server broke: each
+   * step is asserted on its own, and the submit body is printed so it can be
+   * replayed with curl against another environment.
+   */
+  it('isolates which stage fails', async () => {
+    OpenAPI.BASE = (process.env.SUPERHERO_API_URL || TESTNET_API).replace(/\/$/, '');
+
+    const mnemonic = generateMnemonic(wordlist);
+    const { address } = deriveAccount(mnemonic, 0);
+    const account = deriveSigner(mnemonic, 0);
+    const keys = deriveKeysFromSeed(mnemonicToSeedSync(mnemonic), 0);
+    const identity = createDerivedNostrIdentity(keys);
+
+    // 1. claim
+    const claim = (await NostrLinkService.nostrLinkControllerClaim({
+      requestBody: { address, value: keys.npub },
+    })) as { message: string; nonce: number; value: string };
+
+    expect(claim.message).toContain(address);
+    expect(claim.message).toContain(keys.npub);
+
+    // 2. AE signature — must verify locally against the signing account, which is
+    //    the exact digest the contract's verify_user_sig checks.
+    const signature = Buffer.from(await account.signMessage(claim.message)).toString('hex');
+    expect(signature).toMatch(/^[0-9a-f]{128}$/);
+    expect(verifyLinkMessageSignature(address, claim.message, signature)).toBe(true);
+
+    // 3. nostr proof — a kind-22242 event, serialized as a JSON STRING (what the
+    //    backend's DTO expects; an object is rejected with a 400).
+    const nostrEvent = await createNostrProofEvent(identity, claim.message);
+    expect(typeof nostrEvent).toBe('string');
+    const parsed = JSON.parse(nostrEvent);
+    expect(parsed.kind).toBe(22242);
+    expect(parsed.content).toBe(claim.message);
+    expect(parsed.sig).toMatch(/^[0-9a-f]{128}$/);
+
+    // Everything the client controls is now provably well-formed. Print the body
+    // so a failure here is reproducible outside the test.
+    const body = {
+      address, value: keys.npub, nonce: claim.nonce, signature, nostr_event: nostrEvent,
+    };
+    // eslint-disable-next-line no-console
+    console.log('[e2e] submit body', JSON.stringify(body));
+
+    // 4. submit — the stage that is currently 500ing server-side.
+    const submitted = (await NostrLinkService.nostrLinkControllerSubmit({
+      requestBody: body,
+    })) as { txHash?: string };
+
+    expect(submitted?.txHash).toMatch(/^th_/);
   }, 120_000);
 });

--- a/src/features/wallet/__tests__/nostr-key-passkey.test.ts
+++ b/src/features/wallet/__tests__/nostr-key-passkey.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment node
+//
+// WebCrypto (vault seal/unseal, factor KEK, PRF→seed derivation) — exercised in
+// the node environment, which has a complete SubtleCrypto.
+import {
+  describe, expect, it, vi,
+} from 'vitest';
+import { deriveNostrIdentity } from '../nostr-key';
+import { createWalletFromPasskey } from '../wallet-lifecycle';
+import { mnemonicFromPrf } from '../passkey-seed';
+import { deriveAccount } from '../derivation';
+import { kekFromHighEntropy, type HkdfKdf } from '../factors';
+import type { VaultRecord } from '../vault-record';
+import type { UnlockProvider } from '../inline-signer';
+
+/**
+ * A passkey-created wallet must be a FULL wallet — including chat.
+ *
+ * `createWalletFromPasskey` derives the BIP39 seed from the passkey's PRF output
+ * instead of having the user transcribe it (`passkey-seed.ts`). The nostr
+ * identity is derived from that same seed down a second, independent path
+ * (`m/44'/1237'/0'/0/<index>`, secp256k1 — NOT the AE SLIP-0010 path). Nothing
+ * in `nostr-key.ts` knows or cares how the seed got into the vault, and these
+ * tests pin that: chat identity, AE account, and the AE↔Nostr link must all work
+ * for a passkey wallet exactly as for a phrase wallet.
+ *
+ * The regression guarded against is a passkey wallet that can hold funds but
+ * silently cannot enable chat — the seed is there, so any such failure would be
+ * a wiring bug, not a cryptographic limit.
+ */
+
+const PRF = new Uint8Array(32).fill(0x42);
+
+/** An in-memory VaultStore — no IndexedDB in the node environment. */
+const memoryStore = () => {
+  let saved: VaultRecord | null = null;
+  return {
+    load: async () => saved,
+    save: async (r: VaultRecord) => { saved = r; },
+    clear: async () => { saved = null; },
+  };
+};
+
+/**
+ * Stub the WebAuthn ceremony: a real one cannot run headlessly (no
+ * authenticator), so the PRF output is injected. Everything downstream of the
+ * ceremony — HKDF, BIP39, the vault, both derivation paths — is the real code.
+ */
+const stubPasskey = (prfOutput = PRF) => {
+  vi.stubGlobal('navigator', {
+    credentials: {
+      create: async () => ({
+        rawId: new Uint8Array([1, 2, 3, 4]).buffer,
+        getClientExtensionResults: () => ({
+          prf: { enabled: true, results: { first: prfOutput.buffer } },
+        }),
+      }),
+    },
+  });
+};
+
+/**
+ * The unlock the chat entry point would run. A passkey wallet's real unlock is
+ * the WebAuthn PRF ceremony; re-deriving the same KEK from the same PRF output
+ * is exactly what that ceremony yields, without needing an authenticator.
+ */
+const passkeyUnlock = (record: VaultRecord, prfOutput = PRF): UnlockProvider => async () => {
+  const factor = record.factors.find((f) => f.type === 'webauthn-prf');
+  if (!factor) throw new Error('no passkey factor');
+  return { factorId: factor.id, kek: await kekFromHighEntropy(prfOutput, factor.kdf as HkdfKdf) };
+};
+
+describe('nostr identity for a passkey-created wallet', () => {
+  it('derives a nostr identity through the passkey unlock path', async () => {
+    stubPasskey();
+    const store = memoryStore();
+    const created = await createWalletFromPasskey(store, { userName: 'test', now: 0 });
+
+    const keys = await deriveNostrIdentity(created.record, passkeyUnlock(created.record), 0);
+
+    expect(keys.npub).toMatch(/^npub1/);
+    expect(keys.publicKey).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is the identity the passkey’s own seed implies', async () => {
+    // The vault is not an independent source of truth: the same PRF output must
+    // reproduce the same chat identity, which is what makes a passkey wallet
+    // recoverable on a new device.
+    stubPasskey();
+    const store = memoryStore();
+    const created = await createWalletFromPasskey(store, { userName: 'test', now: 0 });
+
+    const viaVault = await deriveNostrIdentity(created.record, passkeyUnlock(created.record), 0);
+
+    // Derive independently, straight from the PRF output, with no vault involved.
+    const { deriveKeysFromSeed } = await import('@/features/chat/nostr/crypto');
+    const { mnemonicToSeedSync } = await import('@scure/bip39');
+    const direct = deriveKeysFromSeed(mnemonicToSeedSync(mnemonicFromPrf(PRF)), 0);
+
+    expect(viaVault.npub).toBe(direct.npub);
+  });
+
+  it('gives different passkeys different chat identities', async () => {
+    const other = new Uint8Array(32).fill(0x99);
+
+    stubPasskey();
+    const a = await createWalletFromPasskey(memoryStore(), { userName: 't', now: 0 });
+    const keysA = await deriveNostrIdentity(a.record, passkeyUnlock(a.record), 0);
+
+    stubPasskey(other);
+    const b = await createWalletFromPasskey(memoryStore(), { userName: 't', now: 0 });
+    const keysB = await deriveNostrIdentity(b.record, passkeyUnlock(b.record, other), 0);
+
+    expect(keysA.npub).not.toBe(keysB.npub);
+  });
+
+  it('returns ONLY nostr key material — the seed does not escape', async () => {
+    stubPasskey();
+    const store = memoryStore();
+    const created = await createWalletFromPasskey(store, { userName: 'test', now: 0 });
+
+    const keys = await deriveNostrIdentity(created.record, passkeyUnlock(created.record), 0);
+
+    expect(Object.keys(keys).sort()).toEqual(['npub', 'nsec', 'privateKey', 'publicKey']);
+    // The derived mnemonic must not be reachable through the returned handle.
+    const words = created.mnemonic.split(' ');
+    expect(JSON.stringify(keys)).not.toContain(words[0]);
+  });
+
+  it('keeps the AE and nostr paths independent', async () => {
+    // Two different curves and derivation paths off one seed. A regression that
+    // routed nostr through AccountMnemonicFactory (or vice versa) would show up
+    // as one of these matching the other.
+    stubPasskey();
+    const store = memoryStore();
+    const created = await createWalletFromPasskey(store, { userName: 'test', now: 0 });
+
+    const keys = await deriveNostrIdentity(created.record, passkeyUnlock(created.record), 0);
+    const { address } = deriveAccount(created.mnemonic, 0);
+
+    expect(address).toMatch(/^ak_/);
+    expect(keys.publicKey).not.toContain(address.slice(3));
+  });
+
+  it('derives per-account-index identities, matching the manifest', async () => {
+    // Chat identity is scoped to the AE account index, so switching account must
+    // switch npub — the account-switch recheck in useNostrLinkCheck depends on it.
+    stubPasskey();
+    const store = memoryStore();
+    const created = await createWalletFromPasskey(store, { userName: 'test', now: 0 });
+
+    const first = await deriveNostrIdentity(created.record, passkeyUnlock(created.record), 0);
+    const second = await deriveNostrIdentity(created.record, passkeyUnlock(created.record), 1);
+
+    expect(first.npub).not.toBe(second.npub);
+  });
+});


### PR DESCRIPTION
Branched off `develop` at 4a8253e8 (after the passkey wallet work in #642).

Answers two questions and adds the tests that were missing. **No production code changes** — this is verification plus one documented finding.

## Is nostr key generation linked to the wallet?

Yes, and it already was. `deriveNostrIdentity` (`features/wallet/nostr-key.ts`) is the single bridge from the encrypted vault to a nostr identity: it runs the same user-verification the signer uses, transiently unseals the mnemonic, and derives the nostr key at `m/44'/1237'/0'/0/<index>` — a second, independent path from the AE `m/44'/457'/…` one. It returns nostr key material only.

So one seed backs both identities, and the nostr identity is scoped per AE account index.

**What was untested:** whether this works for a **passkey-created** wallet, where the seed is derived from the passkey's PRF output rather than transcribed by the user. It does — `nostr-key-passkey.test.ts` now pins it:

- identity derives through the passkey unlock path
- it matches what the PRF output implies on its own (no vault involved) — this is the recoverability guarantee that lets a passkey wallet restore chat on a new device
- different passkeys → different identities; different account indices → different identities
- returns nostr-only material; the derived mnemonic does not escape
- the AE and nostr paths stay independent

The regression guarded against: a passkey wallet that holds funds but silently can't enable chat.

## "Enable chat" popup + SuperheroID link

Already implemented and mirrors `superhero-app`: `features/nostr-link/` has `EnableChatDialog` (the web port of the app's `EnableChatSheet`), `NostrLinkGate` (mounted in `RoomView`), `useNostrLinkCheck`, per-account dismissal cooldown, and `link-flow.ts` doing claim → AE-sign → kind-22242 proof → submit. Same endpoints and same payload shape as the app. 19 unit tests already cover it.

## Finding: testnet `submit` returns 500

The gated live round-trip fails, so I added a stage-by-stage variant that says *where*. Against `testnet.api.dev.tokensale.org`:

| stage | result |
|---|---|
| `claim` | **201** — message + nonce correct |
| AE signature | **verifies locally** against the signing account (the digest `verify_user_sig` checks) |
| kind-22242 proof | **correctly signed JSON string** (an object gets a 400 — the DTO wants a string) |
| `submit` | **500** `{"statusCode":500,"message":"Internal server error"}` |

Also 500s for a faucet-funded account that exists on chain, so it is not "unknown account". The payload matches what the app sends. **Conclusion: the client flow is correct; the testnet submit endpoint is faulting server-side.**

Relevant: the app defaults to mainnet (`api.superhero.com`) while web's testnet config points at `testnet.api.dev.tokensale.org` — which is why the flow works in the app and not here. Mainnet `claim` also returns 201; I did **not** run mainnet `submit`, since that is a real on-chain write.

Reproduce:

```bash
NOSTR_LINK_E2E=1 VITE_NETWORK=ae_uat \
  npx vitest run src/features/nostr-link/__tests__/link-roundtrip.e2e.test.ts -t "isolates"
```

It prints the exact submit body for curl replay against another environment.

## Verification

187 tests pass across wallet + nostr-link (26 files, 1 gated e2e skipped), lint clean on touched files, typecheck clean.

## Needs a decision

The end-to-end "enable chat" flow **cannot be green until the testnet 500 is fixed** — that's a backend issue outside this repo. Options: point the testnet config at a working backend, get the endpoint fixed, or verify against mainnet with a funded account (real on-chain write, so I did not do that unilaterally).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds and extends tests and e2e documentation; no runtime wallet, auth, or API client behavior changes.
> 
> **Overview**
> **Test-only PR** — no production code changes. It adds coverage for passkey wallets’ chat identity and makes the gated live Nostr link flow easier to debug when testnet fails.
> 
> A new **`nostr-key-passkey.test.ts`** suite exercises `deriveNostrIdentity` end-to-end for wallets created via `createWalletFromPasskey` (stubbed WebAuthn PRF, in-memory vault). It pins that passkey unlock yields valid npub material, matches direct PRF→seed derivation (recoverability), varies by passkey and account index, returns only nostr keys without leaking the mnemonic, and keeps AE vs nostr derivation paths separate.
> 
> The gated **`link-roundtrip.e2e.test.ts`** file documents that testnet **`submit`** currently returns **500** while **`claim`**, local AE signature verification, and kind-22242 proof formatting are correct. A second test **`isolates which stage fails`** walks claim → sign → proof → submit with per-step assertions and logs the submit body for curl replay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86c2d3eaa41f614d3c520d10db5619062493736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/654/) — updated Tue, 18 Aug 2026 19:50:52 GMT