### PR TITLE
Feat/social inline mentions

### DIFF
--- a/src/components/social/InlineAccountMention.tsx
+++ b/src/components/social/InlineAccountMention.tsx
@@ -1,0 +1,34 @@
+import { Link } from 'react-router-dom';
+import AddressAvatar from '@/components/AddressAvatar';
+import { useChainName } from '@/hooks/useChainName';
+import { formatAddress } from '@/utils/address';
+
+interface InlineAccountMentionProps {
+  /** The tagged account address (`ak_...`). */
+  address: string;
+}
+
+/**
+ * Inline rendering of an `@ak_...` account mention inside post content: a small
+ * avatar chip that resolves to the account's `.chain` name when known and falls
+ * back to the shortened address otherwise (so a mention of an account with no
+ * chain name still renders with its identicon).
+ */
+export const InlineAccountMention = ({ address }: InlineAccountMentionProps) => {
+  const { chainName } = useChainName(address);
+  const label = chainName ? `@${chainName}` : `@${formatAddress(address, 3, true)}`;
+
+  return (
+    <Link
+      to={`/users/${address}`}
+      onClick={(e) => e.stopPropagation()}
+      className="inline-flex items-center gap-1 align-middle px-1.5 py-0.5 -my-0.5 rounded-full bg-white/10 border border-white/15 text-[var(--neon-teal)] text-[13px] font-medium no-underline hover:bg-white/15 hover:border-white/25 break-words"
+      title={address}
+    >
+      <AddressAvatar address={address} size={16} />
+      <span className="leading-none">{label}</span>
+    </Link>
+  );
+};
+
+export default InlineAccountMention;

--- a/src/components/social/InlineAccountMention.tsx
+++ b/src/components/social/InlineAccountMention.tsx
@@ -4,16 +4,11 @@ import { useChainName } from '@/hooks/useChainName';
 import { formatAddress } from '@/utils/address';
 
 interface InlineAccountMentionProps {
-  /** The tagged account address (`ak_...`). */
   address: string;
 }
 
-/**
- * Inline rendering of an `@ak_...` account mention inside post content: a small
- * avatar chip that resolves to the account's `.chain` name when known and falls
- * back to the shortened address otherwise (so a mention of an account with no
- * chain name still renders with its identicon).
- */
+// Avatar chip for an `@ak_...` mention: shows the account's `.chain` name when
+// known, else the shortened address (identicon renders either way).
 export const InlineAccountMention = ({ address }: InlineAccountMentionProps) => {
   const { chainName } = useChainName(address);
   const label = chainName ? `@${chainName}` : `@${formatAddress(address, 3, true)}`;

--- a/src/features/social/components/MentionSuggestionList.tsx
+++ b/src/features/social/components/MentionSuggestionList.tsx
@@ -10,10 +10,8 @@ interface MentionSuggestionListProps {
   onSelect: (item: MentionItem) => void;
 }
 
-/**
- * The compose-side dropdown of account/token suggestions. Rows use `onMouseDown`
- * (not click) so selecting does not blur the textarea before the handler runs.
- */
+// Rows use `onMouseDown` (not click) so selecting does not blur the textarea
+// before the handler runs.
 export const MentionSuggestionList = ({
   items,
   activeIndex,

--- a/src/features/social/components/MentionSuggestionList.tsx
+++ b/src/features/social/components/MentionSuggestionList.tsx
@@ -1,0 +1,80 @@
+import AddressAvatar from '@/components/AddressAvatar';
+import { cn } from '@/lib/utils';
+import { formatAddress } from '@/utils/address';
+import type { MentionItem } from '../hooks/useMentionSearch';
+
+interface MentionSuggestionListProps {
+  items: MentionItem[];
+  activeIndex: number;
+  onHover: (index: number) => void;
+  onSelect: (item: MentionItem) => void;
+}
+
+/**
+ * The compose-side dropdown of account/token suggestions. Rows use `onMouseDown`
+ * (not click) so selecting does not blur the textarea before the handler runs.
+ */
+export const MentionSuggestionList = ({
+  items,
+  activeIndex,
+  onHover,
+  onSelect,
+}: MentionSuggestionListProps) => (
+  <div
+    role="listbox"
+    aria-label="Mention suggestions"
+    className="absolute left-0 right-0 top-full mt-1 z-30 max-h-64 overflow-y-auto rounded-xl border border-white/15 bg-gray-900/95 backdrop-blur-xl shadow-[0_16px_30px_rgba(0,0,0,0.4)] py-1"
+  >
+    {items.map((item, index) => {
+      const isActive = index === activeIndex;
+      const key = item.type === 'account' ? `a-${item.address}` : `t-${item.name}`;
+      return (
+        <button
+          type="button"
+          key={key}
+          role="option"
+          aria-selected={isActive}
+          className={cn(
+            'w-full flex items-center gap-2 px-3 py-2 text-left transition-colors',
+            isActive ? 'bg-white/10' : 'hover:bg-white/5',
+          )}
+          onMouseEnter={() => onHover(index)}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSelect(item);
+          }}
+        >
+          {item.type === 'account' ? (
+            <>
+              <AddressAvatar address={item.address} size={24} />
+              <div className="min-w-0">
+                <div className="text-sm text-white truncate">
+                  {item.chainName ? `@${item.chainName}` : formatAddress(item.address, 6, true)}
+                </div>
+                {item.chainName && (
+                  <div className="text-[11px] text-white/50 truncate font-mono">
+                    {formatAddress(item.address, 4, true)}
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="w-6 h-6 rounded-full bg-white/10 border border-white/15 flex items-center justify-center text-[11px] font-bold text-[var(--neon-blue)] flex-shrink-0">
+                #
+              </div>
+              <div className="min-w-0">
+                <div className="text-sm text-white truncate">{`#${item.name}`}</div>
+                {item.symbol && item.symbol.toLowerCase() !== item.name.toLowerCase() && (
+                  <div className="text-[11px] text-white/50 truncate">{item.symbol}</div>
+                )}
+              </div>
+            </>
+          )}
+        </button>
+      );
+    })}
+  </div>
+);
+
+export default MentionSuggestionList;

--- a/src/features/social/components/MentionSuggestionList.tsx
+++ b/src/features/social/components/MentionSuggestionList.tsx
@@ -1,3 +1,7 @@
+import {
+  useCallback, useEffect, useLayoutEffect, useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 import AddressAvatar from '@/components/AddressAvatar';
 import { cn } from '@/lib/utils';
 import { formatAddress } from '@/utils/address';
@@ -8,6 +12,10 @@ interface MentionSuggestionListProps {
   activeIndex: number;
   onHover: (index: number) => void;
   onSelect: (item: MentionItem) => void;
+  // Element the list anchors under. The list is portalled to <body> so it escapes
+  // the composer card's `backdrop-blur` stacking context; a raised z-index inside
+  // that context cannot beat the feed painted after it.
+  anchorEl: HTMLElement | null;
 }
 
 // Rows use `onMouseDown` (not click) so selecting does not blur the textarea
@@ -17,62 +25,93 @@ export const MentionSuggestionList = ({
   activeIndex,
   onHover,
   onSelect,
-}: MentionSuggestionListProps) => (
-  <div
-    role="listbox"
-    aria-label="Mention suggestions"
-    className="absolute left-0 right-0 top-full mt-1 z-30 max-h-64 overflow-y-auto rounded-xl border border-white/15 bg-gray-900/95 backdrop-blur-xl shadow-[0_16px_30px_rgba(0,0,0,0.4)] py-1"
-  >
-    {items.map((item, index) => {
-      const isActive = index === activeIndex;
-      const key = item.type === 'account' ? `a-${item.address}` : `t-${item.name}`;
-      return (
-        <button
-          type="button"
-          key={key}
-          role="option"
-          aria-selected={isActive}
-          className={cn(
-            'w-full flex items-center gap-2 px-3 py-2 text-left transition-colors',
-            isActive ? 'bg-white/10' : 'hover:bg-white/5',
-          )}
-          onMouseEnter={() => onHover(index)}
-          onMouseDown={(e) => {
-            e.preventDefault();
-            onSelect(item);
-          }}
-        >
-          {item.type === 'account' ? (
-            <>
-              <AddressAvatar address={item.address} size={24} />
-              <div className="min-w-0">
-                <div className="text-sm text-white truncate">
-                  {item.chainName ? `@${item.chainName}` : formatAddress(item.address, 6, true)}
-                </div>
-                {item.chainName && (
+  anchorEl,
+}: MentionSuggestionListProps) => {
+  const [pos, setPos] = useState<{ top: number; left: number; width: number } | null>(null);
+
+  const place = useCallback(() => {
+    if (!anchorEl) return;
+    const r = anchorEl.getBoundingClientRect();
+    setPos({ top: r.bottom + 4, left: r.left, width: r.width });
+  }, [anchorEl]);
+
+  useLayoutEffect(place, [place, items.length]);
+
+  useEffect(() => {
+    place();
+    // `true` (capture) so a scroll in any ancestor, not just window, repositions.
+    window.addEventListener('scroll', place, true);
+    window.addEventListener('resize', place);
+    return () => {
+      window.removeEventListener('scroll', place, true);
+      window.removeEventListener('resize', place);
+    };
+  }, [place]);
+
+  if (!pos) return null;
+
+  const list = (
+    <div
+      role="listbox"
+      aria-label="Mention suggestions"
+      style={{
+        position: 'fixed', top: pos.top, left: pos.left, width: pos.width, zIndex: 2000,
+      }}
+      className="max-h-64 overflow-y-auto rounded-xl border border-white/15 bg-gray-900/95 backdrop-blur-xl shadow-[0_16px_30px_rgba(0,0,0,0.4)] py-1"
+    >
+      {items.map((item, index) => {
+        const isActive = index === activeIndex;
+        const key = item.type === 'account' ? `a-${item.address}` : `t-${item.name}`;
+        return (
+          <button
+            type="button"
+            key={key}
+            role="option"
+            aria-selected={isActive}
+            className={cn(
+              'w-full flex items-center gap-2 px-3 py-2 text-left transition-colors',
+              isActive ? 'bg-white/10' : 'hover:bg-white/5',
+            )}
+            onMouseEnter={() => onHover(index)}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onSelect(item);
+            }}
+          >
+            {item.type === 'account' ? (
+              <>
+                <AddressAvatar address={item.address} size={24} />
+                <div className="min-w-0">
+                  <div className="text-sm text-white truncate">
+                    {item.chainName ? `@${item.chainName}` : formatAddress(item.address, 6, true)}
+                  </div>
+                  {item.chainName && (
                   <div className="text-[11px] text-white/50 truncate font-mono">
                     {formatAddress(item.address, 4, true)}
                   </div>
-                )}
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="w-6 h-6 rounded-full bg-white/10 border border-white/15 flex items-center justify-center text-[11px] font-bold text-[var(--neon-blue)] flex-shrink-0">
-                #
-              </div>
-              <div className="min-w-0">
-                <div className="text-sm text-white truncate">{`#${item.name}`}</div>
-                {item.symbol && item.symbol.toLowerCase() !== item.name.toLowerCase() && (
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="w-6 h-6 rounded-full bg-white/10 border border-white/15 flex items-center justify-center text-[11px] font-bold text-[var(--neon-blue)] flex-shrink-0">
+                  #
+                </div>
+                <div className="min-w-0">
+                  <div className="text-sm text-white truncate">{`#${item.name}`}</div>
+                  {item.symbol && item.symbol.toLowerCase() !== item.name.toLowerCase() && (
                   <div className="text-[11px] text-white/50 truncate">{item.symbol}</div>
-                )}
-              </div>
-            </>
-          )}
-        </button>
-      );
-    })}
-  </div>
-);
+                  )}
+                </div>
+              </>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  return createPortal(list, document.body);
+};
 
 export default MentionSuggestionList;

--- a/src/features/social/components/PostForm.tsx
+++ b/src/features/social/components/PostForm.tsx
@@ -34,6 +34,7 @@ import {
   applyMention,
   serializeMentions,
   segmentMentions,
+  clampMentionInput,
   type AppliedMention,
 } from '../utils/mentions';
 
@@ -379,7 +380,11 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
   const serializedText = useMemo(() => serializeMentions(text, mentions), [text, mentions]);
   // Segments for the overlay mirror: identical glyph runs, mention runs flagged for pills.
   const mentionSegments = useMemo(() => segmentMentions(text, mentions), [text, mentions]);
-  const showMirror = Boolean(overlayComputed) && text.length > 0;
+  // Only mirror when there is a pill to draw. With no tagged run the mirror is a
+  // pixel-for-pixel no-op, so keeping the textarea's own text avoids taking on any
+  // metric-fidelity (or stale-padding-on-resize) risk for the common untagged post.
+  const hasPilledMention = mentionSegments.some((seg) => seg.mention !== null);
+  const showMirror = Boolean(overlayComputed) && hasPilledMention;
 
   const handleSelectMention = (item: MentionItem) => {
     if (!activeMention) return;
@@ -1095,15 +1100,13 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
                   onChange={(e) => {
                     const next = e.target.value;
                     // The 280 cap counts serialised length (the macro, not the chip), so
-                    // it moves off `maxLength` into here; deletions are always allowed.
-                    if (
+                    // it moves off `maxLength` into here. Clamp an over-cap insert to the
+                    // room left — like `maxLength` did — rather than dropping a whole paste.
+                    setText(
                       characterLimit
-                      && next.length > text.length
-                      && serializeMentions(next, mentions).length > characterLimit
-                    ) {
-                      return;
-                    }
-                    setText(next);
+                        ? clampMentionInput(text, next, mentions, characterLimit)
+                        : next,
+                    );
                   }}
                   onFocus={() => {
                     if (requiredHashtag && !text) {

--- a/src/features/social/components/PostForm.tsx
+++ b/src/features/social/components/PostForm.tsx
@@ -22,7 +22,15 @@ import { initializeContractTyped } from '../../../libs/initializeContractTyped';
 import { GifSelectorDialog } from './GifSelectorDialog';
 import { ImageSelectorDialog } from './ImageSelectorDialog';
 import { DetectedLinkPreview } from './DetectedLinkPreview';
+import { MentionSuggestionList } from './MentionSuggestionList';
 import { useLinkDetection } from '../hooks/useLinkDetection';
+import { useMentionSearch, type MentionItem } from '../hooks/useMentionSearch';
+import {
+  detectActiveMention,
+  buildAccountMentionToken,
+  buildTokenMentionToken,
+  applyMention,
+} from '../utils/mentions';
 
 type TippingV3ContractApi = ContractMethodsBase & {
   post_without_tip: (
@@ -164,6 +172,8 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
   const [showImage, setShowImage] = useState(false);
   const [promptIndex, setPromptIndex] = useState(0);
   const [dismissedLinkUrl, setDismissedLinkUrl] = useState<string | null>(null);
+  const [mentionIndex, setMentionIndex] = useState(0);
+  const [mentionDismissed, setMentionDismissed] = useState(false);
 
   const detectedLink = useLinkDetection(text);
   const linkPreviewDismissedForCurrent = Boolean(
@@ -329,6 +339,44 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
     && matchesRequiredPrefix
     && remainingSuggestion.length > 0,
   );
+
+  // Inline mentions: detect an in-progress `@account` / `#token` at the caret,
+  // fetch suggestions, and let the user pick one to insert into the content.
+  const activeMention = useMemo(
+    () => detectActiveMention(text, caretPosition),
+    [text, caretPosition],
+  );
+  const mentionKey = activeMention ? `${activeMention.trigger}:${activeMention.start}` : null;
+  // Reset dismissal + highlight whenever the caret moves to a different mention token.
+  useEffect(() => {
+    setMentionDismissed(false);
+    setMentionIndex(0);
+  }, [mentionKey]);
+
+  const { items: mentionItems } = useMentionSearch(mentionDismissed ? null : activeMention);
+  // Defer to the required-hashtag ghost text when it is active to avoid two overlays.
+  const showMentionMenu = Boolean(activeMention)
+    && !mentionDismissed
+    && !showAutoComplete
+    && mentionItems.length > 0;
+  const boundedMentionIndex = Math.min(mentionIndex, Math.max(mentionItems.length - 1, 0));
+
+  const handleSelectMention = (item: MentionItem) => {
+    if (!activeMention) return;
+    const token = item.type === 'account'
+      ? buildAccountMentionToken({ address: item.address })
+      : buildTokenMentionToken({ name: item.name, symbol: item.symbol });
+    const { text: nextText, caret } = applyMention(text, activeMention, token);
+    setText(nextText);
+    setMentionDismissed(true);
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (el) {
+        el.focus();
+        el.setSelectionRange(caret, caret);
+      }
+    });
+  };
 
   // Measure the pixel width of the prefix using canvas to fine-tune horizontal placement
   const measuredLeft = useMemo(() => {
@@ -985,6 +1033,29 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
                     }
                   }}
                   onKeyDown={(e) => {
+                    // Mention picker navigation takes priority while it is open.
+                    if (showMentionMenu) {
+                      if (e.key === 'ArrowDown') {
+                        e.preventDefault();
+                        setMentionIndex((i) => (i + 1) % mentionItems.length);
+                        return;
+                      }
+                      if (e.key === 'ArrowUp') {
+                        e.preventDefault();
+                        setMentionIndex((i) => (i - 1 + mentionItems.length) % mentionItems.length);
+                        return;
+                      }
+                      if (e.key === 'Enter' || e.key === 'Tab') {
+                        e.preventDefault();
+                        handleSelectMention(mentionItems[boundedMentionIndex]);
+                        return;
+                      }
+                      if (e.key === 'Escape') {
+                        e.preventDefault();
+                        setMentionDismissed(true);
+                        return;
+                      }
+                    }
                     if (!requiredHashtag || !showAutoComplete) return;
                     if (e.key === 'Tab' || e.key === 'Enter') {
                       e.preventDefault();
@@ -1027,6 +1098,15 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
                   >
                     <span style={{ color: 'rgba(255,255,255,0.5)' }}>{remainingSuggestion}</span>
                   </div>
+                )}
+
+                {showMentionMenu && (
+                  <MentionSuggestionList
+                    items={mentionItems}
+                    activeIndex={boundedMentionIndex}
+                    onHover={setMentionIndex}
+                    onSelect={handleSelectMention}
+                  />
                 )}
 
                 <div className="md:hidden absolute bottom-5 left-2 flex items-center gap-1.5">

--- a/src/features/social/components/PostForm.tsx
+++ b/src/features/social/components/PostForm.tsx
@@ -18,6 +18,7 @@ import { PostsService } from '../../../api/generated';
 import { CONFIG } from '../../../config';
 import { useAccount } from '../../../hooks/useAccount';
 import { useAeSdk } from '../../../hooks/useAeSdk';
+import { useHashtagAllowedChars } from '../../../hooks/useCommunityFactory';
 import { initializeContractTyped } from '../../../libs/initializeContractTyped';
 import { GifSelectorDialog } from './GifSelectorDialog';
 import { ImageSelectorDialog } from './ImageSelectorDialog';
@@ -353,7 +354,11 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
     setMentionIndex(0);
   }, [mentionKey]);
 
-  const { items: mentionItems } = useMentionSearch(mentionDismissed ? null : activeMention);
+  const hashtagAllowedChars = useHashtagAllowedChars();
+  const { items: mentionItems } = useMentionSearch(
+    mentionDismissed ? null : activeMention,
+    hashtagAllowedChars,
+  );
   // Defer to the required-hashtag ghost text when it is active to avoid two overlays.
   const showMentionMenu = Boolean(activeMention)
     && !mentionDismissed

--- a/src/features/social/components/PostForm.tsx
+++ b/src/features/social/components/PostForm.tsx
@@ -29,8 +29,12 @@ import { useMentionSearch, type MentionItem } from '../hooks/useMentionSearch';
 import {
   detectActiveMention,
   buildAccountMentionToken,
+  buildAccountMentionDisplay,
   buildTokenMentionToken,
   applyMention,
+  serializeMentions,
+  segmentMentions,
+  type AppliedMention,
 } from '../utils/mentions';
 
 type TippingV3ContractApi = ContractMethodsBase & {
@@ -175,6 +179,10 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
   const [dismissedLinkUrl, setDismissedLinkUrl] = useState<string | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
   const [mentionDismissed, setMentionDismissed] = useState(false);
+  // Display→storage split for tagged mentions: the textarea holds the short display
+  // run, and these carry the `[account:{address}]` form each serialises to on submit.
+  const [mentions, setMentions] = useState<AppliedMention[]>([]);
+  const inputWrapRef = useRef<HTMLDivElement>(null);
 
   const detectedLink = useLinkDetection(text);
   const linkPreviewDismissedForCurrent = Boolean(
@@ -366,13 +374,33 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
     && mentionItems.length > 0;
   const boundedMentionIndex = Math.min(mentionIndex, Math.max(mentionItems.length - 1, 0));
 
+  // What actually goes on the wire — display runs expanded to their `[account:…]` form.
+  // Drives both the submit content and the character counter (the macro is what counts).
+  const serializedText = useMemo(() => serializeMentions(text, mentions), [text, mentions]);
+  // Segments for the overlay mirror: identical glyph runs, mention runs flagged for pills.
+  const mentionSegments = useMemo(() => segmentMentions(text, mentions), [text, mentions]);
+  const showMirror = Boolean(overlayComputed) && text.length > 0;
+
   const handleSelectMention = (item: MentionItem) => {
     if (!activeMention) return;
-    const token = item.type === 'account'
-      ? buildAccountMentionToken({ address: item.address })
-      : buildTokenMentionToken({ name: item.name, symbol: item.symbol });
-    const { text: nextText, caret } = applyMention(text, activeMention, token);
+    // The textarea gets the short display run; the map remembers what it serialises to.
+    const applied: AppliedMention = item.type === 'account'
+      ? {
+        trigger: 'account',
+        display: buildAccountMentionDisplay({ address: item.address, chainName: item.chainName }),
+        serialized: buildAccountMentionToken({ address: item.address }),
+      }
+      : (() => {
+        const token = buildTokenMentionToken({ name: item.name, symbol: item.symbol });
+        return { trigger: 'token' as const, display: token, serialized: token };
+      })();
+    const { text: nextText, caret } = applyMention(text, activeMention, applied.display);
     setText(nextText);
+    setMentions((prev) => {
+      const dup = prev.some((m) => m.display === applied.display
+        && m.serialized === applied.serialized);
+      return dup ? prev : [...prev, applied];
+    });
     setMentionDismissed(true);
     requestAnimationFrame(() => {
       const el = textareaRef.current;
@@ -425,11 +453,13 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
     const trimmed = text.trim();
     if (!trimmed) return;
     if (!activeAccount) return;
+    // Expand display runs to their `[account:{address}]` storage form for the wire.
+    const serialized = serializeMentions(text, mentions).trim();
 
     setIsSubmitting(true);
 
     const txPayload = isPost
-      ? { type: TxPayloadType.CreatePost, content: trimmed } as const
+      ? { type: TxPayloadType.CreatePost, content: serialized } as const
       : { type: TxPayloadType.CreateComment, postId: postId! } as const;
 
     notifySubmitted(txPayload);
@@ -450,7 +480,7 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
       }
 
       const { decodedResult } = await contract.post_without_tip(
-        trimmed,
+        serialized,
         postMedia,
       );
 
@@ -464,7 +494,7 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
         // This ensures the post appears instantly even if backend isn't ready yet
         const optimisticPost: any = {
           id: newPostId,
-          content: trimmed,
+          content: serialized,
           sender_address: activeAccount,
           media: mediaUrls,
           total_comments: 0,
@@ -655,7 +685,7 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
         // This ensures the reply appears instantly even if backend isn't ready yet
         const optimisticReply: any = {
           id: newReplyId,
-          content: trimmed,
+          content: serialized,
           sender_address: activeAccount,
           media: mediaUrls,
           total_comments: 0,
@@ -941,6 +971,7 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
 
       // Reset after success
       setText(initialText || '');
+      setMentions([]);
       setMediaUrls([]);
       setDismissedLinkUrl(null);
       setShowImage(false);
@@ -1021,12 +1052,59 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
               </div>
             )}
             <div className={activeAccount ? 'md:col-start-2' : 'md:col-span-2'}>
-              <div className="relative bg-white/7 border border-white/14 rounded-xl md:rounded-2xl transition-all duration-200 focus-within:border-[#1161FE] focus-within:bg-white/10 focus-within:shadow-[0_0_0_2px_rgba(17,97,254,0.5),0_8px_24px_rgba(0,0,0,0.25)]">
+              <div ref={inputWrapRef} className="relative bg-white/7 border border-white/14 rounded-xl md:rounded-2xl transition-all duration-200 focus-within:border-[#1161FE] focus-within:bg-white/10 focus-within:shadow-[0_0_0_2px_rgba(17,97,254,0.5),0_8px_24px_rgba(0,0,0,0.25)]">
+                {/* Overlay mirror: same glyph runs as the textarea, mention runs pilled.
+                    Sits behind the transparent-text textarea so caret/selection stay on top;
+                    no horizontal padding on pills, so widths — and the caret — stay exact. */}
+                {showMirror && overlayComputed && (
+                  <div
+                    aria-hidden
+                    className="absolute inset-0 overflow-hidden pointer-events-none select-none text-white whitespace-pre-wrap break-words box-border"
+                    style={{
+                      zIndex: 0,
+                      paddingTop: overlayComputed.paddingTop,
+                      paddingRight: overlayComputed.paddingRight,
+                      paddingBottom: overlayComputed.paddingBottom,
+                      paddingLeft: overlayComputed.paddingLeft,
+                      fontFamily: overlayComputed.fontFamily,
+                      fontSize: overlayComputed.fontSize,
+                      fontWeight: overlayComputed.fontWeight,
+                      lineHeight: overlayComputed.lineHeight,
+                      letterSpacing: overlayComputed.letterSpacing,
+                    }}
+                  >
+                    {mentionSegments.map((seg, i) => (seg.mention ? (
+                      <span
+                        // eslint-disable-next-line react/no-array-index-key
+                        key={`m-${i}`}
+                        className={`rounded bg-white/10 ${seg.mention.trigger === 'account' ? 'text-[var(--neon-teal)]' : 'text-[var(--neon-blue)]'}`}
+                        style={{ boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.15)' }}
+                      >
+                        {seg.text}
+                      </span>
+                    ) : (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <span key={`t-${i}`}>{seg.text}</span>
+                    )))}
+                  </div>
+                )}
                 <textarea
                   ref={textareaRef}
                   placeholder={currentPlaceholder}
                   value={text}
-                  onChange={(e) => setText(e.target.value)}
+                  onChange={(e) => {
+                    const next = e.target.value;
+                    // The 280 cap counts serialised length (the macro, not the chip), so
+                    // it moves off `maxLength` into here; deletions are always allowed.
+                    if (
+                      characterLimit
+                      && next.length > text.length
+                      && serializeMentions(next, mentions).length > characterLimit
+                    ) {
+                      return;
+                    }
+                    setText(next);
+                  }}
                   onFocus={() => {
                     if (requiredHashtag && !text) {
                       const tag = `${requiredHashtag.toUpperCase()} `;
@@ -1083,9 +1161,13 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
                     }
                   }}
                   className="bg-transparent border-none outline-none pt-1.5 pr-2.5 pl-2.5 pb-9 text-white text-base resize-none leading-snug md:leading-relaxed w-full box-border placeholder-white/60 font-medium md:p-4 md:pr-14 md:pb-8 md:text-base focus:!shadow-none focus:!translate-y-0 focus:!bg-transparent caret-[#1161FE]"
-                  style={{ minHeight: computedMinHeight }}
+                  style={{
+                    minHeight: computedMinHeight,
+                    // Text goes transparent so the mirror below shows the pills; caret
+                    // (caret-color) and selection stay painted by the textarea on top.
+                    ...(showMirror ? { color: 'transparent', position: 'relative', zIndex: 1 } : null),
+                  }}
                   rows={1}
-                  maxLength={characterLimit}
                 />
 
                 {showAutoComplete && overlayComputed && (
@@ -1111,6 +1193,7 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
                     activeIndex={boundedMentionIndex}
                     onHover={setMentionIndex}
                     onSelect={handleSelectMention}
+                    anchorEl={inputWrapRef.current}
                   />
                 )}
 
@@ -1207,8 +1290,8 @@ const PostForm = forwardRef<{ focus:(opts?: { immediate?: boolean; preventScroll
                   )}
                 </div>
                 {characterLimit && (
-                  <div className="absolute bottom-4 right-2 md:bottom-4 md:right-4 text-white/60 text-sm font-semibold pointer-events-none select-none">
-                    {text.length}
+                  <div className="absolute bottom-4 right-2 md:bottom-4 md:right-4 text-white/60 text-sm font-semibold pointer-events-none select-none z-10">
+                    {serializedText.length}
                     /
                     {characterLimit}
                   </div>

--- a/src/features/social/components/__tests__/PostForm.test.tsx
+++ b/src/features/social/components/__tests__/PostForm.test.tsx
@@ -59,6 +59,12 @@ vi.mock('../../../../hooks/useAccount', () => ({
   }),
 }));
 
+// The composer reads the collection charset for the mention picker; isolate the
+// unit test from the factory-schema loader (it fetches via AppService).
+vi.mock('../../../../hooks/useCommunityFactory', () => ({
+  useHashtagAllowedChars: () => '',
+}));
+
 vi.mock('../../../../libs/initializeContractTyped', () => ({
   initializeContractTyped: (...args: any[]) => mockInitializeContractTyped(...args),
 }));

--- a/src/features/social/hooks/useMentionSearch.ts
+++ b/src/features/social/hooks/useMentionSearch.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { AccountsService } from '@/api/generated';
 import { SuperheroApi } from '@/api/backend';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
-import type { ActiveMention } from '../utils/mentions';
+import { type ActiveMention, isRenderableTokenName } from '../utils/mentions';
 
 export interface AccountMentionItem {
   type: 'account';
@@ -23,13 +23,8 @@ export type MentionItem = AccountMentionItem | TokenMentionItem;
 
 const MAX_RESULTS = 6;
 
-/**
- * Typeahead results for the compose-side mention picker. Accounts come from the
- * backend's account typeahead (`/api/accounts/search`); tokens from the token
- * list search. The query is debounced; when no mention is active both queries
- * are disabled so nothing is fetched.
- */
-export function useMentionSearch(active: ActiveMention | null): {
+/** Typeahead results (accounts + tokens) for the compose-side mention picker. */
+export function useMentionSearch(active: ActiveMention | null, tokenAllowedChars = ''): {
   items: MentionItem[];
   isLoading: boolean;
 } {
@@ -58,10 +53,12 @@ export function useMentionSearch(active: ActiveMention | null): {
   const tokens = useQuery({
     queryKey: ['mention-tokens', tokenQuery],
     queryFn: async (): Promise<TokenMentionItem[]> => {
+      // `order_by=trending_score` applies the trending ELIGIBILITY gate, not just a
+      // sort — it silently drops most matches. Rank by trending only for the empty
+      // cold-start query; a named search must reach every matching token.
       const res: any = await SuperheroApi.listTokens({
         search: tokenQuery || undefined,
-        orderBy: 'trending_score',
-        orderDirection: 'DESC',
+        ...(tokenQuery ? {} : { orderBy: 'trending_score' as const, orderDirection: 'DESC' as const }),
         limit: MAX_RESULTS,
       });
       const list = Array.isArray(res?.items) ? res.items : [];
@@ -82,7 +79,10 @@ export function useMentionSearch(active: ActiveMention | null): {
     return { items: accounts.data ?? [], isLoading: accounts.isFetching };
   }
   if (trigger === 'token') {
-    return { items: tokens.data ?? [], isLoading: tokens.isFetching };
+    // Drop tokens whose name would truncate on render (e.g. contains '.' or '_').
+    const items = (tokens.data ?? [])
+      .filter((tk) => isRenderableTokenName(tk.name, tokenAllowedChars));
+    return { items, isLoading: tokens.isFetching };
   }
   return { items: [], isLoading: false };
 }

--- a/src/features/social/hooks/useMentionSearch.ts
+++ b/src/features/social/hooks/useMentionSearch.ts
@@ -1,0 +1,88 @@
+import { useQuery } from '@tanstack/react-query';
+// @ts-ignore - generated client has no type re-export barrel
+import { AccountsService } from '@/api/generated';
+import { SuperheroApi } from '@/api/backend';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import type { ActiveMention } from '../utils/mentions';
+
+export interface AccountMentionItem {
+  type: 'account';
+  address: string;
+  chainName: string | null;
+}
+
+export interface TokenMentionItem {
+  type: 'token';
+  name: string;
+  symbol: string;
+  address?: string;
+  saleAddress?: string;
+}
+
+export type MentionItem = AccountMentionItem | TokenMentionItem;
+
+const MAX_RESULTS = 6;
+
+/**
+ * Typeahead results for the compose-side mention picker. Accounts come from the
+ * backend's account typeahead (`/api/accounts/search`); tokens from the token
+ * list search. The query is debounced; when no mention is active both queries
+ * are disabled so nothing is fetched.
+ */
+export function useMentionSearch(active: ActiveMention | null): {
+  items: MentionItem[];
+  isLoading: boolean;
+} {
+  const trigger = active?.trigger ?? null;
+  const debouncedQuery = useDebouncedValue(active?.query ?? '', 200);
+
+  const accountQuery = trigger === 'account' ? debouncedQuery : '';
+  const tokenQuery = trigger === 'token' ? debouncedQuery : '';
+
+  const accounts = useQuery({
+    queryKey: ['mention-accounts', accountQuery],
+    queryFn: async (): Promise<AccountMentionItem[]> => {
+      const res = await AccountsService.searchAccounts({ q: accountQuery, limit: MAX_RESULTS });
+      const rows = Array.isArray(res) ? res : [];
+      return rows.map((r: { address: string; chain_name: string | null }) => ({
+        type: 'account' as const,
+        address: r.address,
+        chainName: r.chain_name,
+      }));
+    },
+    // The backend returns [] for a blank query, so only search once a char is typed.
+    enabled: trigger === 'account' && accountQuery.length >= 1,
+    staleTime: 60_000,
+  });
+
+  const tokens = useQuery({
+    queryKey: ['mention-tokens', tokenQuery],
+    queryFn: async (): Promise<TokenMentionItem[]> => {
+      const res: any = await SuperheroApi.listTokens({
+        search: tokenQuery || undefined,
+        orderBy: 'trending_score',
+        orderDirection: 'DESC',
+        limit: MAX_RESULTS,
+      });
+      const list = Array.isArray(res?.items) ? res.items : [];
+      return list.map((tk: any) => ({
+        type: 'token' as const,
+        name: String(tk?.name ?? tk?.symbol ?? ''),
+        symbol: String(tk?.symbol ?? ''),
+        address: tk?.address,
+        saleAddress: tk?.sale_address,
+      })).filter((tk: TokenMentionItem) => tk.name);
+    },
+    // An empty token query surfaces the trending tokens as a starting point.
+    enabled: trigger === 'token',
+    staleTime: 60_000,
+  });
+
+  if (trigger === 'account') {
+    return { items: accounts.data ?? [], isLoading: accounts.isFetching };
+  }
+  if (trigger === 'token') {
+    return { items: tokens.data ?? [], isLoading: tokens.isFetching };
+  }
+  return { items: [], isLoading: false };
+}

--- a/src/features/social/utils/__tests__/mentions.test.ts
+++ b/src/features/social/utils/__tests__/mentions.test.ts
@@ -4,6 +4,7 @@ import {
   buildAccountMentionToken,
   buildTokenMentionToken,
   applyMention,
+  isRenderableTokenName,
 } from '../mentions';
 
 describe('detectActiveMention', () => {
@@ -92,6 +93,32 @@ describe('buildTokenMentionToken', () => {
   });
   it('falls back to the symbol when there is no name', () => {
     expect(buildTokenMentionToken({ name: '', symbol: 'EMO' })).toBe('#EMO');
+  });
+});
+
+describe('isRenderableTokenName', () => {
+  it('accepts plain Latin names with digits and dashes', () => {
+    expect(isRenderableTokenName('EMOTER')).toBe(true);
+    expect(isRenderableTokenName('ROCK-N-ROLL')).toBe(true);
+    expect(isRenderableTokenName('AE2')).toBe(true);
+  });
+
+  it('rejects names with a dot or underscore (they truncate on render)', () => {
+    expect(isRenderableTokenName('EMOTER.AI')).toBe(false);
+    expect(isRenderableTokenName('FOO_BAR')).toBe(false);
+  });
+
+  it('rejects empty, whitespace, and over-length names', () => {
+    expect(isRenderableTokenName('')).toBe(false);
+    expect(isRenderableTokenName('has space')).toBe(false);
+    expect(isRenderableTokenName('A'.repeat(51))).toBe(false);
+  });
+
+  it('accepts non-Latin names only when the collection charset is provided', () => {
+    // Chinese range as linkify would receive it from mergedCollectionNameCharsPattern.
+    const chinese = '\\u4e00-\\u9fff';
+    expect(isRenderableTokenName('你好')).toBe(false);
+    expect(isRenderableTokenName('你好', chinese)).toBe(true);
   });
 });
 

--- a/src/features/social/utils/__tests__/mentions.test.ts
+++ b/src/features/social/utils/__tests__/mentions.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectActiveMention,
+  buildAccountMentionToken,
+  buildTokenMentionToken,
+  applyMention,
+} from '../mentions';
+
+describe('detectActiveMention', () => {
+  it('detects an account mention being typed at the caret', () => {
+    const text = 'hey @mar';
+    expect(detectActiveMention(text, text.length)).toEqual({
+      trigger: 'account', query: 'mar', start: 4, end: 8,
+    });
+  });
+
+  it('detects a token mention being typed at the caret', () => {
+    const text = 'buying #emo';
+    expect(detectActiveMention(text, text.length)).toEqual({
+      trigger: 'token', query: 'emo', start: 7, end: 11,
+    });
+  });
+
+  it('detects a bare trigger with an empty query', () => {
+    expect(detectActiveMention('gm @', 4)).toEqual({
+      trigger: 'account', query: '', start: 3, end: 4,
+    });
+    expect(detectActiveMention('gm #', 4)).toEqual({
+      trigger: 'token', query: '', start: 3, end: 4,
+    });
+  });
+
+  it('detects a trigger at the very start of the text', () => {
+    expect(detectActiveMention('@bob', 4)).toEqual({
+      trigger: 'account', query: 'bob', start: 0, end: 4,
+    });
+  });
+
+  it('detects an in-progress ak_ address mention', () => {
+    const text = 'wen @ak_123ABC';
+    expect(detectActiveMention(text, text.length)).toEqual({
+      trigger: 'account', query: 'ak_123ABC', start: 4, end: 14,
+    });
+  });
+
+  it('does not trigger on an email-style "@" (preceded by a word char)', () => {
+    const text = 'mail me at bob@gmail';
+    expect(detectActiveMention(text, text.length)).toBeNull();
+  });
+
+  it('does not trigger on a URL fragment "#" (preceded by a non-space char)', () => {
+    const text = 'see example.com/page#top';
+    expect(detectActiveMention(text, text.length)).toBeNull();
+  });
+
+  it('is inactive once the token is closed by a space', () => {
+    const text = 'hey @marek ';
+    expect(detectActiveMention(text, text.length)).toBeNull();
+  });
+
+  it('only considers the token immediately before the caret, not later text', () => {
+    const text = 'hey @marek gm';
+    // caret at end sits inside "gm", which is not a mention
+    expect(detectActiveMention(text, text.length)).toBeNull();
+  });
+
+  it('detects the token the caret sits inside, ignoring text after it', () => {
+    const text = 'hey @mar and #tok';
+    // caret placed right after "@mar"
+    expect(detectActiveMention(text, 8)).toEqual({
+      trigger: 'account', query: 'mar', start: 4, end: 8,
+    });
+  });
+
+  it('accepts non-Latin token names', () => {
+    const text = '支持 #你好';
+    expect(detectActiveMention(text, text.length)).toEqual({
+      trigger: 'token', query: '你好', start: 3, end: 6,
+    });
+  });
+});
+
+describe('buildAccountMentionToken', () => {
+  it('stores the raw account address', () => {
+    expect(buildAccountMentionToken({ address: 'ak_123' })).toBe('@ak_123');
+  });
+});
+
+describe('buildTokenMentionToken', () => {
+  it('uses the token name', () => {
+    expect(buildTokenMentionToken({ name: 'EMOTER', symbol: 'EMO' })).toBe('#EMOTER');
+  });
+  it('falls back to the symbol when there is no name', () => {
+    expect(buildTokenMentionToken({ name: '', symbol: 'EMO' })).toBe('#EMO');
+  });
+});
+
+describe('applyMention', () => {
+  it('replaces the in-progress token and appends a trailing space', () => {
+    const text = 'hey @mar';
+    const active = detectActiveMention(text, text.length)!;
+    expect(applyMention(text, active, '@ak_123')).toEqual({
+      text: 'hey @ak_123 ',
+      caret: 'hey @ak_123 '.length,
+    });
+  });
+
+  it('does not add a second space when one already follows', () => {
+    const text = 'hey @mar there';
+    const active = detectActiveMention(text, 8)!; // caret after "@mar"
+    expect(applyMention(text, active, '@ak_123')).toEqual({
+      text: 'hey @ak_123 there',
+      caret: 'hey @ak_123'.length,
+    });
+  });
+
+  it('inserts a token mention with a trailing space', () => {
+    const text = 'buying #emo';
+    const active = detectActiveMention(text, text.length)!;
+    expect(applyMention(text, active, '#EMOTER')).toEqual({
+      text: 'buying #EMOTER ',
+      caret: 'buying #EMOTER '.length,
+    });
+  });
+});

--- a/src/features/social/utils/__tests__/mentions.test.ts
+++ b/src/features/social/utils/__tests__/mentions.test.ts
@@ -82,8 +82,8 @@ describe('detectActiveMention', () => {
 });
 
 describe('buildAccountMentionToken', () => {
-  it('stores the raw account address', () => {
-    expect(buildAccountMentionToken({ address: 'ak_123' })).toBe('@ak_123');
+  it('stores the address as an [account:…] macro', () => {
+    expect(buildAccountMentionToken({ address: 'ak_123' })).toBe('[account:ak_123]');
   });
 });
 
@@ -126,18 +126,18 @@ describe('applyMention', () => {
   it('replaces the in-progress token and appends a trailing space', () => {
     const text = 'hey @mar';
     const active = detectActiveMention(text, text.length)!;
-    expect(applyMention(text, active, '@ak_123')).toEqual({
-      text: 'hey @ak_123 ',
-      caret: 'hey @ak_123 '.length,
+    expect(applyMention(text, active, '[account:ak_123]')).toEqual({
+      text: 'hey [account:ak_123] ',
+      caret: 'hey [account:ak_123] '.length,
     });
   });
 
   it('does not add a second space when one already follows', () => {
     const text = 'hey @mar there';
     const active = detectActiveMention(text, 8)!; // caret after "@mar"
-    expect(applyMention(text, active, '@ak_123')).toEqual({
-      text: 'hey @ak_123 there',
-      caret: 'hey @ak_123'.length,
+    expect(applyMention(text, active, '[account:ak_123]')).toEqual({
+      text: 'hey [account:ak_123] there',
+      caret: 'hey [account:ak_123]'.length,
     });
   });
 

--- a/src/features/social/utils/__tests__/mentions.test.ts
+++ b/src/features/social/utils/__tests__/mentions.test.ts
@@ -8,6 +8,7 @@ import {
   isRenderableTokenName,
   serializeMentions,
   segmentMentions,
+  clampMentionInput,
   type AppliedMention,
 } from '../mentions';
 
@@ -228,5 +229,34 @@ describe('segmentMentions', () => {
       { text: ' and ', mention: null },
       { text: '#EMOTER', mention: emoter },
     ]);
+  });
+});
+
+describe('clampMentionInput', () => {
+  it('leaves an in-budget change untouched', () => {
+    expect(clampMentionInput('a', 'ab', [], 280)).toBe('ab');
+  });
+
+  it('truncates an over-cap paste to the remaining room, not dropping it whole', () => {
+    expect(clampMentionInput('', 'x'.repeat(300), [], 280)).toBe('x'.repeat(280));
+  });
+
+  it('inserts only what fits when pasting into a partially-full composer', () => {
+    expect(clampMentionInput('ab', 'abXYZ', [], 4)).toBe('abXY');
+  });
+
+  it('rejects a mid-string keystroke when the cap is already reached', () => {
+    const full = 'a'.repeat(280);
+    const typed = `${'a'.repeat(5)}x${'a'.repeat(275)}`; // 281 chars, an 'x' inserted at index 5
+    expect(clampMentionInput(full, typed, [], 280)).toBe(full);
+  });
+
+  it('counts the serialised macro against the cap when clamping', () => {
+    // display run is 13 chars incl. trailing space; serialised is "[account:ak_marek] " (19).
+    const prev = '@marek.chain ';
+    // Appending "xxx" after the intact run -> serialised 22 > 20, clamp to the room left.
+    const clamped = clampMentionInput(prev, '@marek.chain xxx', [marek], 20);
+    expect(serializeMentions(clamped, [marek]).length).toBeLessThanOrEqual(20);
+    expect(clamped).toBe('@marek.chain x');
   });
 });

--- a/src/features/social/utils/__tests__/mentions.test.ts
+++ b/src/features/social/utils/__tests__/mentions.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect } from 'vitest';
 import {
   detectActiveMention,
   buildAccountMentionToken,
+  buildAccountMentionDisplay,
   buildTokenMentionToken,
   applyMention,
   isRenderableTokenName,
+  serializeMentions,
+  segmentMentions,
+  type AppliedMention,
 } from '../mentions';
 
 describe('detectActiveMention', () => {
@@ -148,5 +152,81 @@ describe('applyMention', () => {
       text: 'buying #EMOTER ',
       caret: 'buying #EMOTER '.length,
     });
+  });
+});
+
+describe('buildAccountMentionDisplay', () => {
+  it('uses the chain name when present', () => {
+    expect(buildAccountMentionDisplay({ address: 'ak_123', chainName: 'marek.chain' }))
+      .toBe('@marek.chain');
+  });
+
+  it('falls back to a short address when there is no chain name', () => {
+    // ak_123 is not a valid/long hash, so formatAddress returns it as-is.
+    expect(buildAccountMentionDisplay({ address: 'ak_123' })).toBe('@ak_123');
+  });
+});
+
+const marek: AppliedMention = {
+  trigger: 'account', display: '@marek.chain', serialized: '[account:ak_marek]',
+};
+const emoter: AppliedMention = { trigger: 'token', display: '#EMOTER', serialized: '#EMOTER' };
+
+describe('serializeMentions', () => {
+  it('expands an intact account display run to its macro (display → wire)', () => {
+    expect(serializeMentions('gm @marek.chain', [marek])).toBe('gm [account:ak_marek]');
+  });
+
+  it('leaves token mentions unchanged on the wire', () => {
+    expect(serializeMentions('buying #EMOTER now', [emoter])).toBe('buying #EMOTER now');
+  });
+
+  it('expands two adjacent mentions separated by a single space', () => {
+    expect(serializeMentions('@marek.chain #EMOTER', [marek, emoter]))
+      .toBe('[account:ak_marek] #EMOTER');
+  });
+
+  it('drops the tag once the user edits the run (degrades to plain text)', () => {
+    expect(serializeMentions('gm @marek.chainX', [marek])).toBe('gm @marek.chainX');
+  });
+
+  it('does not expand a run embedded inside a larger word', () => {
+    expect(serializeMentions('x@marek.chain', [marek])).toBe('x@marek.chain');
+  });
+
+  it('round-trips a picked account from insertion to the wire', () => {
+    const typed = 'gm @mar';
+    const active = detectActiveMention(typed, typed.length)!;
+    const display = buildAccountMentionDisplay({ address: 'ak_marek', chainName: 'marek.chain' });
+    const { text: composed } = applyMention(typed, active, display);
+    expect(composed).toBe('gm @marek.chain ');
+    const mention: AppliedMention = {
+      trigger: 'account', display, serialized: buildAccountMentionToken({ address: 'ak_marek' }),
+    };
+    expect(serializeMentions(composed, [mention]).trim()).toBe('gm [account:ak_marek]');
+  });
+});
+
+describe('segmentMentions', () => {
+  it('flags the mention run and leaves the surrounding text plain', () => {
+    expect(segmentMentions('gm @marek.chain !', [marek])).toEqual([
+      { text: 'gm ', mention: null },
+      { text: '@marek.chain', mention: marek },
+      { text: ' !', mention: null },
+    ]);
+  });
+
+  it('returns one plain segment when the edited run no longer matches', () => {
+    expect(segmentMentions('gm @marek.chainX', [marek])).toEqual([
+      { text: 'gm @marek.chainX', mention: null },
+    ]);
+  });
+
+  it('segments two mentions in one line', () => {
+    expect(segmentMentions('@marek.chain and #EMOTER', [marek, emoter])).toEqual([
+      { text: '@marek.chain', mention: marek },
+      { text: ' and ', mention: null },
+      { text: '#EMOTER', mention: emoter },
+    ]);
   });
 });

--- a/src/features/social/utils/mentions.ts
+++ b/src/features/social/utils/mentions.ts
@@ -127,6 +127,51 @@ export function serializeMentions(text: string, mentions: AppliedMention[]): str
   );
 }
 
+/**
+ * Accept an input change while keeping the serialised length within `limit`, the way
+ * the old `maxLength` did: an over-cap insert is truncated at the caret to the room
+ * left — a 300-char paste keeps what fits rather than being dropped whole — and a
+ * single keystroke with no room is rejected. The inserted region is isolated by the
+ * common prefix/suffix of `prev` and `next`, then binary-searched for the longest
+ * prefix that still fits, counting the serialised macro rather than the display run.
+ */
+export function clampMentionInput(
+  prev: string,
+  next: string,
+  mentions: AppliedMention[],
+  limit: number,
+): string {
+  if (serializeMentions(next, mentions).length <= limit) return next;
+
+  let start = 0;
+  const minLen = Math.min(prev.length, next.length);
+  while (start < minLen && prev[start] === next[start]) start += 1;
+  let endPrev = prev.length;
+  let endNext = next.length;
+  while (endPrev > start && endNext > start && prev[endPrev - 1] === next[endNext - 1]) {
+    endPrev -= 1;
+    endNext -= 1;
+  }
+
+  const before = next.slice(0, start);
+  const after = next.slice(endNext);
+  const inserted = next.slice(start, endNext);
+
+  let lo = 0;
+  let hi = inserted.length;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    const candidate = `${before}${inserted.slice(0, mid)}${after}`;
+    if (serializeMentions(candidate, mentions).length <= limit) lo = mid;
+    else hi = mid - 1;
+  }
+
+  const clamped = `${before}${inserted.slice(0, lo)}${after}`;
+  // before+after drops the replaced span from an in-limit prev, so lo=0 always fits;
+  // the guard keeps prev only in the degenerate case that assumption ever fails.
+  return serializeMentions(clamped, mentions).length <= limit ? clamped : prev;
+}
+
 export interface MentionSegment {
   text: string;
   mention: AppliedMention | null;

--- a/src/features/social/utils/mentions.ts
+++ b/src/features/social/utils/mentions.ts
@@ -38,9 +38,14 @@ export function detectActiveMention(text: string, caret: number): ActiveMention 
   };
 }
 
-/** Token stored for a tagged account: the raw address. */
+/**
+ * Token stored for a tagged account: an explicit `[account:{address}]` macro. The
+ * `]` terminator bounds the token by format (not by charset), the macro cannot be
+ * produced by accident, and it is a pure client contract — `superhero-api` does
+ * not index `ak_` mentions. Raw `ak_` addresses in content stay plain links.
+ */
 export function buildAccountMentionToken(account: { address: string }): string {
-  return `@${account.address}`;
+  return `[account:${account.address}]`;
 }
 
 /** Token stored for a tagged token: `#name` (falls back to symbol). */

--- a/src/features/social/utils/mentions.ts
+++ b/src/features/social/utils/mentions.ts
@@ -1,6 +1,8 @@
 // Inline @account / #token mentions live inside on-chain post content, using the
 // tokens `utils/linkify` already parses — no API or contract change.
 
+import { formatAddress } from '@/utils/address';
+
 export type MentionTrigger = 'account' | 'token';
 
 export interface ActiveMention {
@@ -78,4 +80,86 @@ export function applyMention(
     text: `${head}${inserted}${tail}`,
     caret: head.length + inserted.length,
   };
+}
+
+/**
+ * A mention the user picked from the composer picker. `display` is the short run
+ * shown in the textarea (`@marek.chain`); `serialized` is what it becomes on the
+ * wire (`[account:{address}]` for accounts, `#name` for tokens — identical there).
+ * The composer keeps display and storage split so the mirror overlay can pill the
+ * run without the 57-char macro leaking into the input.
+ */
+export interface AppliedMention {
+  trigger: MentionTrigger;
+  display: string;
+  serialized: string;
+}
+
+/** Short in-textarea display run for a tagged account — `@name`, or `@ak_…` short address. */
+export function buildAccountMentionDisplay(
+  account: { address: string; chainName?: string | null },
+): string {
+  const name = account.chainName?.trim();
+  return name ? `@${name}` : `@${formatAddress(account.address, 6, true)}`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// A mention run is bounded the same way `detectActiveMention` bounds it: it starts
+// the text or follows whitespace, and ends at whitespace or end of text. Editing the
+// run so it no longer matches these bounds is the correct way to drop the tag.
+function mentionRunRegex(display: string): RegExp {
+  return new RegExp(`(^|\\s)(${escapeRegExp(display)})(?=\\s|$)`, 'g');
+}
+
+/**
+ * Convert every intact display run to its on-the-wire form. A run the user has since
+ * edited no longer matches its `display` and is left as the plain text it now is.
+ */
+export function serializeMentions(text: string, mentions: AppliedMention[]): string {
+  return mentions.reduce(
+    (out, m) => (m.display === m.serialized // token mentions are already 1:1
+      ? out
+      : out.replace(mentionRunRegex(m.display), (_full, lead) => `${lead}${m.serialized}`)),
+    text,
+  );
+}
+
+export interface MentionSegment {
+  text: string;
+  mention: AppliedMention | null;
+}
+
+/**
+ * Split `text` into ordered segments, tagging each intact mention run with its
+ * `AppliedMention` so the overlay mirror can pill it. Plain runs carry `mention: null`.
+ * Widths are untouched — the segment text is the exact run the textarea holds.
+ */
+export function segmentMentions(text: string, mentions: AppliedMention[]): MentionSegment[] {
+  if (!text) return [];
+  const hits: Array<{ start: number; end: number; mention: AppliedMention }> = [];
+  mentions.forEach((m) => {
+    if (!m.display) return;
+    const re = mentionRunRegex(m.display);
+    let match: RegExpExecArray | null = re.exec(text);
+    while (match !== null) {
+      const start = match.index + match[1].length;
+      hits.push({ start, end: start + m.display.length, mention: m });
+      match = re.exec(text);
+    }
+  });
+  hits.sort((a, b) => a.start - b.start);
+
+  const segments: MentionSegment[] = [];
+  let cursor = 0;
+  hits.forEach((hit) => {
+    if (hit.start < cursor) return; // overlapping run already covered
+    if (hit.start > cursor) segments.push({ text: text.slice(cursor, hit.start), mention: null });
+    segments.push({ text: text.slice(hit.start, hit.end), mention: hit.mention });
+    cursor = hit.end;
+  });
+  if (cursor < text.length) segments.push({ text: text.slice(cursor), mention: null });
+  return segments;
 }

--- a/src/features/social/utils/mentions.ts
+++ b/src/features/social/utils/mentions.ts
@@ -1,0 +1,90 @@
+// Inline mentions for post/comment content.
+//
+// A mention is stored INSIDE the on-chain post `content` string using the same
+// tokens the render pipeline (`utils/linkify`) already understands, so no API or
+// contract change is needed and existing posts stay backwards compatible:
+//   - an account  -> `@ak_...`  (the account address; renders as an avatar chip)
+//   - a token     -> `#name`    (the token name; renders as a price chip)
+// The compose-side picker below only decides which token to insert; the render
+// side is unchanged in shape.
+
+export type MentionTrigger = 'account' | 'token';
+
+export interface ActiveMention {
+  trigger: MentionTrigger;
+  /** The text typed after the trigger char, without the `@`/`#`. */
+  query: string;
+  /** Index of the trigger char (`@`/`#`) in the source text. */
+  start: number;
+  /** Caret index — exclusive end of the in-progress token. */
+  end: number;
+}
+
+// Characters allowed in the live token while typing. Account tokens accept the
+// address/chain-name set; token tokens accept the (possibly non-Latin) name set.
+const ACCOUNT_QUERY_RE = /^[A-Za-z0-9_.-]*$/;
+const TOKEN_QUERY_RE = /^[\p{L}\p{N}_-]*$/u;
+
+// A trigger is only a mention when it starts the text or follows whitespace —
+// this keeps `a@b.com` (emails) and `example.com/page#x` (URL fragments) inert,
+// mirroring how `utils/linkify` protects the same shapes at render time.
+const TRIGGER_RE = /(^|\s)([@#])(\S*)$/u;
+
+/**
+ * Detect an in-progress `@account` / `#token` mention immediately before the caret.
+ * Returns `null` when the caret is not inside a mention token.
+ */
+export function detectActiveMention(text: string, caret: number): ActiveMention | null {
+  if (typeof text !== 'string' || caret < 0 || caret > text.length) return null;
+  const before = text.slice(0, caret);
+  const match = before.match(TRIGGER_RE);
+  if (!match) return null;
+
+  const trigger = match[2];
+  const run = match[3];
+  const start = caret - run.length - 1; // index of the trigger char
+
+  if (trigger === '@') {
+    if (!ACCOUNT_QUERY_RE.test(run)) return null;
+    return {
+      trigger: 'account', query: run, start, end: caret,
+    };
+  }
+  if (!TOKEN_QUERY_RE.test(run)) return null;
+  return {
+    trigger: 'token', query: run, start, end: caret,
+  };
+}
+
+/** The token stored in post content for a tagged account: the raw address. */
+export function buildAccountMentionToken(account: { address: string }): string {
+  return `@${account.address}`;
+}
+
+/** The token stored in post content for a tagged token: `#name` (falls back to symbol). */
+export function buildTokenMentionToken(
+  token: { name?: string | null; symbol?: string | null },
+): string {
+  const tag = String(token.name || token.symbol || '').trim();
+  return `#${tag}`;
+}
+
+/**
+ * Replace the in-progress mention token with the chosen `token`, followed by a
+ * single space (unless one already follows). Returns the new text and the caret
+ * position to place after the inserted token.
+ */
+export function applyMention(
+  text: string,
+  active: ActiveMention,
+  token: string,
+): { text: string; caret: number } {
+  const head = text.slice(0, active.start);
+  const tail = text.slice(active.end);
+  const needsSpace = tail.length === 0 || !/^\s/.test(tail);
+  const inserted = needsSpace ? `${token} ` : token;
+  return {
+    text: `${head}${inserted}${tail}`,
+    caret: head.length + inserted.length,
+  };
+}

--- a/src/features/social/utils/mentions.ts
+++ b/src/features/social/utils/mentions.ts
@@ -1,39 +1,21 @@
-// Inline mentions for post/comment content.
-//
-// A mention is stored INSIDE the on-chain post `content` string using the same
-// tokens the render pipeline (`utils/linkify`) already understands, so no API or
-// contract change is needed and existing posts stay backwards compatible:
-//   - an account  -> `@ak_...`  (the account address; renders as an avatar chip)
-//   - a token     -> `#name`    (the token name; renders as a price chip)
-// The compose-side picker below only decides which token to insert; the render
-// side is unchanged in shape.
+// Inline @account / #token mentions live inside on-chain post content, using the
+// tokens `utils/linkify` already parses — no API or contract change.
 
 export type MentionTrigger = 'account' | 'token';
 
 export interface ActiveMention {
   trigger: MentionTrigger;
-  /** The text typed after the trigger char, without the `@`/`#`. */
   query: string;
-  /** Index of the trigger char (`@`/`#`) in the source text. */
   start: number;
-  /** Caret index — exclusive end of the in-progress token. */
   end: number;
 }
 
-// Characters allowed in the live token while typing. Account tokens accept the
-// address/chain-name set; token tokens accept the (possibly non-Latin) name set.
 const ACCOUNT_QUERY_RE = /^[A-Za-z0-9_.-]*$/;
 const TOKEN_QUERY_RE = /^[\p{L}\p{N}_-]*$/u;
-
-// A trigger is only a mention when it starts the text or follows whitespace —
-// this keeps `a@b.com` (emails) and `example.com/page#x` (URL fragments) inert,
-// mirroring how `utils/linkify` protects the same shapes at render time.
+// A trigger must start the text or follow whitespace, so `a@b.com` and URL `#frags` stay inert.
 const TRIGGER_RE = /(^|\s)([@#])(\S*)$/u;
 
-/**
- * Detect an in-progress `@account` / `#token` mention immediately before the caret.
- * Returns `null` when the caret is not inside a mention token.
- */
+/** Detect an in-progress `@account` / `#token` at the caret, or null. */
 export function detectActiveMention(text: string, caret: number): ActiveMention | null {
   if (typeof text !== 'string' || caret < 0 || caret > text.length) return null;
   const before = text.slice(0, caret);
@@ -42,7 +24,7 @@ export function detectActiveMention(text: string, caret: number): ActiveMention 
 
   const trigger = match[2];
   const run = match[3];
-  const start = caret - run.length - 1; // index of the trigger char
+  const start = caret - run.length - 1;
 
   if (trigger === '@') {
     if (!ACCOUNT_QUERY_RE.test(run)) return null;
@@ -56,12 +38,12 @@ export function detectActiveMention(text: string, caret: number): ActiveMention 
   };
 }
 
-/** The token stored in post content for a tagged account: the raw address. */
+/** Token stored for a tagged account: the raw address. */
 export function buildAccountMentionToken(account: { address: string }): string {
   return `@${account.address}`;
 }
 
-/** The token stored in post content for a tagged token: `#name` (falls back to symbol). */
+/** Token stored for a tagged token: `#name` (falls back to symbol). */
 export function buildTokenMentionToken(
   token: { name?: string | null; symbol?: string | null },
 ): string {
@@ -69,11 +51,15 @@ export function buildTokenMentionToken(
   return `#${tag}`;
 }
 
-/**
- * Replace the in-progress mention token with the chosen `token`, followed by a
- * single space (unless one already follows). Returns the new text and the caret
- * position to place after the inserted token.
- */
+// A name only round-trips if every char is one `linkify` renders inside a `#tag`
+// (letters/digits/dash + the loaded collections' chars, capped at 50); names with
+// '.' or '_' truncate on render, so such tokens are dropped from the picker.
+export function isRenderableTokenName(name: string, allowedCharsPattern = ''): boolean {
+  if (!name) return false;
+  return new RegExp(`^[A-Za-z0-9\\-${allowedCharsPattern}]{1,50}$`, 'u').test(name);
+}
+
+/** Replace the in-progress token with `token` + a trailing space (unless one follows). */
 export function applyMention(
   text: string,
   active: ActiveMention,

--- a/src/utils/__tests__/linkify.test.tsx
+++ b/src/utils/__tests__/linkify.test.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, it, expect } from 'vitest';
+import {
+  describe, it, expect, vi,
+} from 'vitest';
 import { linkify } from '../linkify';
 import { mergedCollectionNameCharsPattern } from '../collectionNameChars';
 import type { ICollectionData } from '../types';
+
+// The account-mention chip resolves a chain name via a batched network hook; pin it
+// so these render tests stay deterministic and offline.
+vi.mock('@/hooks/useChainName', () => ({
+  useChainName: () => ({ chainName: null }),
+}));
 
 function renderLinkify(text: string, options?: Parameters<typeof linkify>[1]) {
   return render(
@@ -115,6 +123,27 @@ describe('linkify hashtag parsing', () => {
 
     const link = screen.getByRole('link', { name: /ak_123abc456/i });
     expect(link).toHaveAttribute('href', '/users/ak_123abc456');
+  });
+
+  const MACRO_ADDR = 'ak_2mMPQ2E9zN8Dd6Fm8jrThQvcYQ7cwR3hh6iC5xGZ2gZ4tHacBdEf';
+
+  it('renders an [account:ak_...] macro as an inline account chip', () => {
+    renderLinkify(`gm [account:${MACRO_ADDR}] there`);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/users/${MACRO_ADDR}`);
+    // The macro delimiters are consumed, and the chip label is '@'-prefixed.
+    expect(screen.getByTestId('content').textContent).not.toContain('[account:');
+    expect(link.textContent).toMatch(/^@ak_/);
+  });
+
+  it('leaves a bare ak_ address as a plain link, not a macro chip', () => {
+    renderLinkify(`plain ${MACRO_ADDR} address`);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/users/${MACRO_ADDR}`);
+    // No '@' prefix: this is the plain-link path, not the chip.
+    expect(link.textContent).not.toContain('@');
   });
 
   it('treats a lone "#" with no following token characters as plain text', () => {

--- a/src/utils/linkify.tsx
+++ b/src/utils/linkify.tsx
@@ -20,6 +20,9 @@ const URL_REGEX = /((https?:\/\/)?[\w.-]+\.[a-z]{2,}(\/[\w\-._~:\/?#[\]@!$&'()*+
 const AENS_TAG_REGEX = /@?[a-z0-9-]+\.chain\b/gi;
 // Optional '@' followed by an account address starting with ak_
 const ACCOUNT_TAG_REGEX = /@?(ak_[A-Za-z0-9]+)/gi;
+// Explicit deliberate account mention: `[account:ak_...]`. The `]` terminator bounds
+// the token; base58 is case-sensitive (no `i` flag); the macro cannot occur by accident.
+const ACCOUNT_MACRO_REGEX = /\[account:(ak_[1-9A-HJ-NP-Za-km-z]{48,56})\]/g;
 // A hashtag "word": '#' at the start of the text, or anywhere NOT immediately preceded by a
 // domain/path-forming character (word char, '.', or '/'), followed by the full run of
 // non-whitespace characters. The exclusion specifically protects URL fragments like
@@ -180,9 +183,31 @@ export function linkify(
   });
   if (hLast < raw.length) hashtagLinked.push(raw.slice(hLast));
 
+  // Pass 0.5: Explicit `[account:ak_...]` macros → inline account chip. Runs before the
+  // AENS/account/URL passes so the address inside the macro is not re-processed, and is the
+  // only account form that renders a chip; raw `ak_` addresses stay plain links (Pass 2a).
+  const macroLinked: React.ReactNode[] = [];
+  hashtagLinked.forEach((node, nodeIdx) => {
+    if (typeof node !== 'string') {
+      macroLinked.push(node);
+      return;
+    }
+    const segment = node as string;
+    let last = 0;
+    segment.replace(ACCOUNT_MACRO_REGEX, (m: string, addr: string, offset: number) => {
+      if (offset > last) macroLinked.push(segment.slice(last, offset));
+      macroLinked.push(
+        <InlineAccountMention address={addr} key={`acc-macro-${addr}-${nodeIdx}-${offset}`} />,
+      );
+      last = offset + m.length;
+      return m;
+    });
+    if (last < segment.length) macroLinked.push(segment.slice(last));
+  });
+
   // Pass 1: Identify AENS mentions and turn them into profile links
   const aensLinked: React.ReactNode[] = [];
-  hashtagLinked.forEach((node, nodeIdx) => {
+  macroLinked.forEach((node, nodeIdx) => {
     if (typeof node !== 'string') {
       aensLinked.push(node);
       return;
@@ -226,24 +251,19 @@ export function linkify(
     segment.replace(ACCOUNT_TAG_REGEX, (m: string, addr: string, off: number) => {
       if (off > segLast) accountLinked.push(segment.slice(segLast, off));
       const address = addr; // captured address without leading '@'
-      if (m.startsWith('@')) {
-        // An explicit '@ak_...' is an intentional account mention — render it as
-        // an inline avatar chip that resolves the account's chain name.
-        accountLinked.push(
-          <InlineAccountMention address={address} key={`acc-${address}-${idx}-${off}`} />,
-        );
-      } else {
-        // A bare address (no '@') stays a plain profile link.
-        accountLinked.push(
-          <a
-            href={`/users/${address}`}
-            key={`acc-${address}-${idx}-${off}`}
-            className="text-[var(--neon-teal)] underline-offset-2 hover:underline break-words"
-          >
-            {formatAddress(address)}
-          </a>,
-        );
-      }
+      // A raw address (with or without '@') is a plain profile link — a deliberate
+      // mention is the `[account:...]` macro handled in Pass 0.5, not a bare address.
+      const displayCore = formatAddress(address);
+      const display = m.startsWith('@') ? `@${displayCore}` : displayCore;
+      accountLinked.push(
+        <a
+          href={`/users/${address}`}
+          key={`acc-${address}-${idx}-${off}`}
+          className="text-[var(--neon-teal)] underline-offset-2 hover:underline break-words"
+        >
+          {display}
+        </a>,
+      );
       segLast = off + m.length;
       return m;
     });

--- a/src/utils/linkify.tsx
+++ b/src/utils/linkify.tsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PostHashtagLink, { type TrendMention } from '@/components/social/PostHashtagLink';
+import { InlineAccountMention } from '@/components/social/InlineAccountMention';
 import { trustedHtml } from '@/utils/trustedTypes';
 import { formatAddress } from './address';
 
@@ -225,17 +226,24 @@ export function linkify(
     segment.replace(ACCOUNT_TAG_REGEX, (m: string, addr: string, off: number) => {
       if (off > segLast) accountLinked.push(segment.slice(segLast, off));
       const address = addr; // captured address without leading '@'
-      const displayCore = formatAddress(address);
-      const display = m.startsWith('@') ? `@${displayCore}` : displayCore;
-      accountLinked.push(
-        <a
-          href={`/users/${address}`}
-          key={`acc-${address}-${idx}-${off}`}
-          className="text-[var(--neon-teal)] underline-offset-2 hover:underline break-words"
-        >
-          {display}
-        </a>,
-      );
+      if (m.startsWith('@')) {
+        // An explicit '@ak_...' is an intentional account mention — render it as
+        // an inline avatar chip that resolves the account's chain name.
+        accountLinked.push(
+          <InlineAccountMention address={address} key={`acc-${address}-${idx}-${off}`} />,
+        );
+      } else {
+        // A bare address (no '@') stays a plain profile link.
+        accountLinked.push(
+          <a
+            href={`/users/${address}`}
+            key={`acc-${address}-${idx}-${off}`}
+            className="text-[var(--neon-teal)] underline-offset-2 hover:underline break-words"
+          >
+            {formatAddress(address)}
+          </a>,
+        );
+      }
       segLast = off + m.length;
       return m;
     });


### PR DESCRIPTION


<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/657/) — updated Fri, 21 Aug 2026 07:35:16 GMT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain post/comment payload format for tagged accounts (`[account:…]` macros) and adds non-trivial composer UX (overlay, serialization, API typeahead); contract/API surface is unchanged but stored content semantics differ from raw `@` text.
> 
> **Overview**
> Adds **inline mention authoring** in the post/reply composer: typing `@` or `#` opens a typeahead (accounts via `AccountsService`, tokens via `SuperheroApi`) with keyboard/mouse selection, while deferring to the existing required-hashtag ghost when both would show.
> 
> Picked **accounts** show a short label in the textarea (`@chain.name` or shortened `ak_…`) but **submit and count characters** against the on-wire `[account:{address}]` macro; **tokens** insert `#name` as today. A mirror overlay pills intact mention runs without breaking caret alignment; input is clamped to the limit using serialized length instead of `maxLength`.
> 
> **Feed rendering** gains a `linkify` pass that turns `[account:ak_…]` into an `InlineAccountMention` chip (avatar + `@` label); bare `ak_` addresses remain plain profile links. Unit tests cover mention utilities and macro linkify behavior; `PostForm` tests mock `useHashtagAllowedChars`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 149fa6cc3f953cc7144f946de333cf65a0deb5b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->