### PR TITLE
feat(social): unify post author header, timestamps and skeleton

### DIFF
--- a/src/features/social/components/PostSkeleton.tsx
+++ b/src/features/social/components/PostSkeleton.tsx
@@ -2,59 +2,53 @@ import { memo } from 'react';
 
 const PostSkeleton = memo(() => (
   <>
-    <article className="relative w-[100dvw] ml-[calc(50%-50dvw)] mr-[calc(50%-50dvw)] px-2 pt-4 pb-5 md:w-full md:mx-0 md:p-5 bg-transparent md:bg-white/[0.02] md:border md:border-white/10 md:rounded-2xl md:backdrop-blur-xl">
+    {/* Mirrors ReplyToFeedItem: a borderless border-b row with the same paddings,
+        avatar sizes and action layout, so the loading state resembles the card it becomes. */}
+    <article className="relative w-full px-3 md:px-4 py-4 md:py-5 border-b border-white/10 bg-transparent">
       {/* Top-right on-chain badge skeleton */}
       <div className="absolute top-4 right-2 md:top-5 md:right-5 z-10">
         <div className="px-2 py-1 md:py-0 md:h-7 bg-white/[0.08] rounded-lg skeleton-shimmer flex items-center">
           <div className="h-3 w-16" />
         </div>
       </div>
+      {/* Bottom-right share skeleton */}
+      <div className="absolute bottom-4 right-2 md:bottom-5 md:right-5 z-10">
+        <div className="h-[28px] w-8 skeleton-shimmer rounded-lg" />
+      </div>
 
-      <div className="flex gap-2 md:gap-3 items-start">
+      <div className="flex gap-3 items-start">
         {/* Avatar skeleton - circular */}
         <div className="flex-shrink-0 pt-0.5">
           <div className="md:hidden">
-            <div className="w-[34px] h-[34px] rounded-full skeleton-shimmer" />
+            <div className="w-[36px] h-[36px] rounded-full skeleton-shimmer" />
           </div>
           <div className="hidden md:block">
             <div className="w-[40px] h-[40px] rounded-full skeleton-shimmer" />
           </div>
         </div>
 
-        <div className="flex-1 min-w-0">
-          {/* Text content with padding for on-chain badge */}
-          <div className="pr-8 md:pr-12">
-            {/* Header skeleton: name · time */}
-            <div className="flex items-center justify-between gap-2.5">
-              <div className="flex items-baseline gap-2.5 min-w-0">
-                <div className="h-[15px] w-24 mt-1 mb-1.5 skeleton-shimmer rounded" />
-              </div>
-            </div>
-            {/* Address skeleton - mono font style, smaller */}
-            <div className="mt-1 h-[10px] w-80 skeleton-shimmer rounded font-mono" />
+        <div className="flex-1 min-w-0 pr-9 md:pr-24">
+          {/* Header skeleton: name · time */}
+          <div className="flex items-center gap-2 min-w-0">
+            <div className="h-[15px] w-28 skeleton-shimmer rounded" />
+            <div className="h-[12px] w-8 skeleton-shimmer rounded" />
+          </div>
+          {/* Address skeleton - mono font style, smaller */}
+          <div className="mt-1 h-[10px] w-56 skeleton-shimmer rounded font-mono" />
 
-            {/* Content skeleton - text lines */}
-            <div className="mt-3 space-y-2">
-              <div className="h-4 w-full skeleton-shimmer rounded" />
-              <div className="h-4 w-5/6 skeleton-shimmer rounded" />
-            </div>
+          {/* Content skeleton - text lines */}
+          <div className="mt-3 space-y-2">
+            <div className="h-4 w-full skeleton-shimmer rounded" />
+            <div className="h-4 w-5/6 skeleton-shimmer rounded" />
           </div>
 
-          {/* Actions skeleton - Tip button, Comment button, Share button */}
-          <div className="mt-4 flex items-center justify-between w-full">
-            <div className="inline-flex items-center gap-4 md:gap-2">
-              {/* Tip button skeleton */}
-              <div className="h-[28px] w-12 md:w-14 skeleton-shimmer rounded-lg" />
-              {/* Comment button skeleton */}
-              <div className="h-[28px] w-16 md:w-20 skeleton-shimmer rounded-lg" />
-            </div>
-            {/* Share button skeleton - 34px width on md+, aligned right */}
-            <div className="h-[28px] w-12 md:w-[34px] skeleton-shimmer rounded-lg shrink-0" />
+          {/* Actions skeleton - Comment + Tip buttons (Share is bottom-right, above) */}
+          <div className="mt-3 flex items-center gap-5">
+            <div className="h-5 w-10 skeleton-shimmer rounded-lg" />
+            <div className="h-5 w-12 skeleton-shimmer rounded-lg" />
           </div>
         </div>
       </div>
-      {/* Full-bleed divider on mobile */}
-      <div className="md:hidden pointer-events-none absolute bottom-0 left-[calc(50%-50dvw)] w-[100dvw] h-px bg-white/10" />
     </article>
     <style>
       {`

--- a/src/features/social/components/ReplyToFeedItem.tsx
+++ b/src/features/social/components/ReplyToFeedItem.tsx
@@ -95,6 +95,9 @@ const ReplyToFeedItem = memo(({
   const displayName = (profileDisplayNames?.[authorAddress] ?? chainNames?.[authorAddress] ?? '').trim();
   const hasDisplayName = Boolean(displayName);
   const { containerRef, isCompact } = useCompactFeedItemLayout(item.tx_hash ? 700 : 620);
+  // Full ak_ address on wide cards; ak_ + first 6 + … + last 6 once the card is
+  // compact. Driven by the card's own width breakpoint, never the user agent.
+  const headerAddress = isCompact ? formatAddress(authorAddress, 6, true) : authorAddress;
 
   // Token collections (WORDS/Chinese/Arabic/Russian/...) drive which characters a hashtag's
   // token name may contain. New collections the backend adds are picked up automatically.
@@ -273,16 +276,16 @@ const ReplyToFeedItem = memo(({
 
         <div className={cn('flex-1 min-w-0', item.tx_hash && (isCompact ? 'pr-9' : 'pr-24'))}>
           {/* Header: one shape for named and unnamed. Primary line is the resolved
-              name, else a shortened address — never the full ak_ string as a title.
-              The mono address line is dropped for unnamed accounts, where it would
-              only repeat the address already shown above. */}
+              name, else the address — full on wide cards, middle-truncated on
+              compact ones. The mono address line is dropped for unnamed accounts,
+              where it would only repeat the address already shown above. */}
           <div className="min-w-0">
             <div className={cn('flex items-center min-w-0', isCompact ? 'gap-1.5' : 'gap-2')}>
               <div
                 className={cn('font-semibold text-white truncate min-w-0', isCompact ? 'text-[14px]' : 'text-[15px]')}
                 title={authorAddress}
               >
-                {hasDisplayName ? displayName : formatAddress(authorAddress, 6, true)}
+                {hasDisplayName ? displayName : headerAddress}
               </div>
               {!hasDisplayName && (
                 <InlineCopyButton value={authorAddress} className="shrink-0" />
@@ -292,7 +295,7 @@ const ReplyToFeedItem = memo(({
             </div>
             {hasDisplayName && (
               <div className="flex items-center gap-1 text-[10px] text-white/60 font-mono min-w-0">
-                <span className="truncate">{formatAddress(authorAddress, 10, false)}</span>
+                <span className="truncate">{headerAddress}</span>
                 <InlineCopyButton value={authorAddress} className="shrink-0" />
               </div>
             )}

--- a/src/features/social/components/ReplyToFeedItem.tsx
+++ b/src/features/social/components/ReplyToFeedItem.tsx
@@ -275,10 +275,12 @@ const ReplyToFeedItem = memo(({
         </div>
 
         <div className={cn('flex-1 min-w-0', item.tx_hash && (isCompact ? 'pr-9' : 'pr-24'))}>
-          {/* Header: one shape for named and unnamed. Primary line is the resolved
-              name, else the address — full on wide cards, middle-truncated on
-              compact ones. The mono address line is dropped for unnamed accounts,
-              where it would only repeat the address already shown above. */}
+          {/* Header: avatar + two lines for every card. Primary line is the
+              resolved name (else the address — full on wide cards,
+              middle-truncated on compact ones). Second line carries the mono
+              address for named accounts, or the timestamp for unnamed ones —
+              where the timestamp on the top line would leave a single line and
+              the mono address would only repeat what is already shown above. */}
           <div className="min-w-0">
             <div className={cn('flex items-center min-w-0', isCompact ? 'gap-1.5' : 'gap-2')}>
               <div
@@ -290,14 +292,20 @@ const ReplyToFeedItem = memo(({
               {!hasDisplayName && (
                 <InlineCopyButton value={authorAddress} className="shrink-0" />
               )}
-              <span className="text-white/50 shrink-0">·</span>
-              {timestampNode}
+              {hasDisplayName && (
+                <>
+                  <span className="text-white/50 shrink-0">·</span>
+                  {timestampNode}
+                </>
+              )}
             </div>
-            {hasDisplayName && (
+            {hasDisplayName ? (
               <div className="flex items-center gap-1 text-[10px] text-white/60 font-mono min-w-0">
                 <span className="truncate">{headerAddress}</span>
                 <InlineCopyButton value={authorAddress} className="shrink-0" />
               </div>
+            ) : (
+              <div className="min-w-0">{timestampNode}</div>
             )}
           </div>
 

--- a/src/features/social/components/ReplyToFeedItem.tsx
+++ b/src/features/social/components/ReplyToFeedItem.tsx
@@ -153,65 +153,27 @@ const ReplyToFeedItem = memo(({
   const media = Array.isArray(item.media)
     ? item.media.filter((m) => (typeof m === 'string' ? !m.startsWith('comment:') : true))
     : [];
-  const unnamedHeader = isCompact ? (
-    <>
-      <div className="flex items-center gap-2 min-w-0">
-        <div className="text-[15px] font-semibold text-white truncate" title={authorAddress}>
-          {formatAddress(authorAddress, 6, true)}
-        </div>
-        <span className="text-white/50 shrink-0">·</span>
-        {item.tx_hash ? (
-          <BlockchainInfoPopover
-            txHash={(item as any).tx_hash}
-            createdAt={item.created_at as unknown as string}
-            sender={(item as any).sender_address}
-            contract={(item as any).contract_address}
-            postId={String(item.id)}
-            triggerContent={(
-              <span className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={fullTimestamp(item.created_at as unknown as string)}>
-                {compactTime(item.created_at as unknown as string)}
-              </span>
-            )}
-          />
-        ) : (
-          <div className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={fullTimestamp(item.created_at as unknown as string)}>{compactTime(item.created_at as unknown as string)}</div>
-        )}
-      </div>
-      <div className="flex items-center gap-1 text-[10px] text-white/60 font-mono min-w-0">
-        <span className="truncate">{formatAddress(authorAddress, 10, false)}</span>
-        <InlineCopyButton value={authorAddress} className="shrink-0" />
-      </div>
-    </>
+  // One canonical timestamp: relative label, exact time on hover, on-chain popover
+  // when the post has a tx. Shared by every header layout so no branch drifts.
+  const timeLabel = compactTime(item.created_at as unknown as string);
+  const timeTitle = fullTimestamp(item.created_at as unknown as string);
+  const timestampNode = item.tx_hash ? (
+    <BlockchainInfoPopover
+      txHash={(item as any).tx_hash}
+      createdAt={item.created_at as unknown as string}
+      sender={(item as any).sender_address}
+      contract={(item as any).contract_address}
+      postId={String(item.id)}
+      triggerContent={(
+        <span className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={timeTitle}>
+          {timeLabel}
+        </span>
+      )}
+    />
   ) : (
-    <>
-      <div className="text-[15px] font-semibold text-white truncate" title={authorAddress}>
-        {authorAddress}
-      </div>
-      <div>
-        {item.tx_hash ? (
-          <BlockchainInfoPopover
-            txHash={(item as any).tx_hash}
-            createdAt={item.created_at as unknown as string}
-            sender={(item as any).sender_address}
-            contract={(item as any).contract_address}
-            postId={String(item.id)}
-            triggerContent={(
-              <span className="text-[10px] text-white/60 truncate" title={fullTimestamp(item.created_at as unknown as string)}>
-                {compactTime(item.created_at as unknown as string)}
-                {' '}
-                ago
-              </span>
-            )}
-          />
-        ) : (
-          <div className="text-[10px] text-white/60 truncate" title={fullTimestamp(item.created_at as unknown as string)}>
-            {compactTime(item.created_at as unknown as string)}
-            {' '}
-            ago
-          </div>
-        )}
-      </div>
-    </>
+    <span className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={timeTitle}>
+      {timeLabel}
+    </span>
   );
 
   // Compute total descendant comments (all levels) for this item
@@ -310,39 +272,29 @@ const ReplyToFeedItem = memo(({
         </div>
 
         <div className={cn('flex-1 min-w-0', item.tx_hash && (isCompact ? 'pr-9' : 'pr-24'))}>
-          {/* Header: keep named-user layout; show address-first layout for unnamed users */}
+          {/* Header: one shape for named and unnamed. Primary line is the resolved
+              name, else a shortened address — never the full ak_ string as a title.
+              The mono address line is dropped for unnamed accounts, where it would
+              only repeat the address already shown above. */}
           <div className="min-w-0">
-            {hasDisplayName ? (
-              <>
-                <div className={cn('flex items-center min-w-0', isCompact ? 'gap-1.5' : 'gap-2')}>
-                  <div className={cn('font-semibold text-white truncate min-w-0', isCompact ? 'text-[14px]' : 'text-[15px]')}>
-                    {displayName}
-                  </div>
-                  <span className="text-white/50 shrink-0">·</span>
-                  {item.tx_hash ? (
-                    <BlockchainInfoPopover
-                      txHash={(item as any).tx_hash}
-                      createdAt={item.created_at as unknown as string}
-                      sender={(item as any).sender_address}
-                      contract={(item as any).contract_address}
-                      postId={String(item.id)}
-                      triggerContent={(
-                        <span className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={fullTimestamp(item.created_at as unknown as string)}>
-                          {compactTime(item.created_at as unknown as string)}
-                        </span>
-                      )}
-                    />
-                  ) : (
-                    <div className="text-[12px] text-white/70 whitespace-nowrap shrink-0" title={fullTimestamp(item.created_at as unknown as string)}>{compactTime(item.created_at as unknown as string)}</div>
-                  )}
-                </div>
-                <div className="flex items-center gap-1 text-[10px] text-white/60 font-mono min-w-0">
-                  <span className="truncate">{formatAddress(authorAddress, 10, false)}</span>
-                  <InlineCopyButton value={authorAddress} className="shrink-0" />
-                </div>
-              </>
-            ) : (
-              unnamedHeader
+            <div className={cn('flex items-center min-w-0', isCompact ? 'gap-1.5' : 'gap-2')}>
+              <div
+                className={cn('font-semibold text-white truncate min-w-0', isCompact ? 'text-[14px]' : 'text-[15px]')}
+                title={authorAddress}
+              >
+                {hasDisplayName ? displayName : formatAddress(authorAddress, 6, true)}
+              </div>
+              {!hasDisplayName && (
+                <InlineCopyButton value={authorAddress} className="shrink-0" />
+              )}
+              <span className="text-white/50 shrink-0">·</span>
+              {timestampNode}
+            </div>
+            {hasDisplayName && (
+              <div className="flex items-center gap-1 text-[10px] text-white/60 font-mono min-w-0">
+                <span className="truncate">{formatAddress(authorAddress, 10, false)}</span>
+                <InlineCopyButton value={authorAddress} className="shrink-0" />
+              </div>
             )}
           </div>
 

--- a/src/utils/__tests__/time.test.ts
+++ b/src/utils/__tests__/time.test.ts
@@ -1,0 +1,61 @@
+import {
+  afterEach, beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import { compactTime, fullTimestamp } from '@/utils/time';
+
+const NOW = new Date('2026-08-20T12:00:00Z').getTime();
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe('compactTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns an empty string for falsy input', () => {
+    expect(compactTime(undefined)).toBe('');
+    expect(compactTime('')).toBe('');
+  });
+
+  it('uses relative units under a week', () => {
+    expect(compactTime(NOW - 5 * SECOND)).toBe('5s');
+    expect(compactTime(NOW - 3 * MINUTE)).toBe('3m');
+    expect(compactTime(NOW - 5 * HOUR)).toBe('5h');
+    expect(compactTime(NOW - 4 * DAY)).toBe('4d');
+  });
+
+  it('clamps sub-second and future timestamps to at least 1s', () => {
+    expect(compactTime(NOW)).toBe('1s');
+    expect(compactTime(NOW + 5 * MINUTE)).toBe('1s');
+  });
+
+  it('rolls over to a short absolute date past a week instead of "52w"', () => {
+    const label = compactTime(NOW - 10 * DAY);
+    // "Mon D" — no relative "w"/"d" unit, no stray "ago", and this year needs no year suffix.
+    expect(label).toMatch(/^[A-Z][a-z]{2} \d{1,2}$/);
+    expect(label).not.toMatch(/w|ago/);
+  });
+
+  it('includes the year for a date in another year', () => {
+    const label = compactTime(new Date('2025-08-04T12:00:00Z'));
+    expect(label).toMatch(/^[A-Z][a-z]{2} \d{1,2}, \d{4}$/);
+    expect(label).toContain('2025');
+  });
+});
+
+describe('fullTimestamp', () => {
+  it('renders an exact DD/MM/YYYY, HH:MM:SS label for the hover title', () => {
+    const label = fullTimestamp(new Date('2026-08-20T09:07:05'));
+    expect(label).toBe('20/08/2026, 09:07:05');
+  });
+
+  it('returns an empty string for falsy input', () => {
+    expect(fullTimestamp(undefined)).toBe('');
+  });
+});

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,8 +1,16 @@
-// Mobile-friendly compact time like 2m, 2h, 1d, 4d, 1w
+const SHORT_MONTHS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+// Mobile-friendly compact time like 2m, 2h, 1d, 4d — then a short absolute
+// date ("Aug 4", or "Aug 4, 2025" for another year) once it is over a week old,
+// which reads better than "52w".
 export function compactTime(input: string | number | Date | undefined): string {
   if (!input) return '';
   const now = Date.now();
-  const ts = new Date(input).getTime();
+  const d = new Date(input);
+  const ts = d.getTime();
   const seconds = Math.max(0, Math.floor((now - ts) / 1000));
   if (seconds < 60) return `${Math.max(1, seconds)}s`;
   const minutes = Math.floor(seconds / 60);
@@ -11,8 +19,11 @@ export function compactTime(input: string | number | Date | undefined): string {
   if (hours < 24) return `${hours}h`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d`;
-  const weeks = Math.floor(days / 7);
-  return `${weeks}w`;
+  const month = SHORT_MONTHS[d.getMonth()];
+  const label = `${month} ${d.getDate()}`;
+  return d.getFullYear() === new Date(now).getFullYear()
+    ? label
+    : `${label}, ${d.getFullYear()}`;
 }
 
 export function fullTimestamp(input: string | number | Date | undefined): string {


### PR DESCRIPTION
Unify the ReplyToFeedItem author/identity header into one shape for named and unnamed accounts: the primary line is the resolved name, else a shortened address, never the full ak_ string as the card title. Drop the duplicated address line for unnamed accounts, keeping an inline copy affordance so the full address stays reachable.

Make compactTime canonical: one relative format that rolls over to a short absolute date ("Aug 4", or "Aug 4, 2025" for another year) past a week instead of "52w". The stray " ago" on one header branch is gone with the header unification; the exact-time hover title is unchanged.

Align PostSkeleton with the real card: a borderless border-b row with the same paddings, avatar sizes and action layout, so the loading state resembles what it becomes.

<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/658/) — updated Thu, 27 Aug 2026 07:48:46 GMT