### PR TITLE
Feat/token tag envelope reader

### DIFF
--- a/netlify/edge-functions/seo.ts
+++ b/netlify/edge-functions/seo.ts
@@ -17,6 +17,14 @@ function truncate(s: string, n: number): string {
   return `${str.slice(0, Math.max(0, n - 1))}…`;
 }
 
+// Strip a token-tag display envelope (`#SYMBOL{mode=advanced}` -> `#SYMBOL`) so it never
+// lands in a meta description, snippet, or link preview. Kept in sync with the client
+// grammar in src/utils/tokenTagEnvelope.ts (this edge runtime is a standalone copy — same
+// reason truncate/absolutize are duplicated here rather than imported).
+function stripTokenTagEnvelopes(s: string): string {
+  return (s || '').replace(/(#[\p{L}\p{N}-]{1,50})\{[^{}\r\n]{0,64}\}/gu, '$1');
+}
+
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"]/g, (c) => ({
     '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;',
@@ -183,7 +191,7 @@ async function buildMeta(pathname: string, fullUrl: URL): Promise<Meta> {
         }
       }
       if (data) {
-        const raw: string = (data?.content || '').toString();
+        const raw: string = stripTokenTagEnvelopes((data?.content || '').toString());
         const content: string = raw.replace(/\s+/g, ' ').trim();
         const media: string[] = Array.isArray(data?.media) ? data.media : [];
         return {

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -42,6 +42,12 @@ function envInject(html) {
 
 function truncate(s, n){ const t=(s||'').trim(); return t.length<=n?t:t.slice(0,Math.max(0,n-1))+'…'; }
 
+// Strip a token-tag display envelope (`#SYMBOL{mode=advanced}` -> `#SYMBOL`) so it never
+// lands in a meta description or link preview. Kept in sync with the client grammar in
+// src/utils/tokenTagEnvelope.ts (this file is a standalone CommonJS SSR copy — same reason
+// truncate/absolutize are duplicated here rather than imported).
+function stripTokenTagEnvelopes(s){ return String(s||'').replace(/(#[\p{L}\p{N}-]{1,50})\{[^{}\r\n]{0,64}\}/gu, '$1'); }
+
 function absolutize(url, origin){ if(!url) return undefined; if(/^https?:\/\//i.test(url)) return url; if(url.startsWith('//')) return `https:${url}`; if(url.startsWith('/')) return `${origin}${url}`; return `${origin}/${url}`; }
 
 async function buildMeta(pathname, origin){
@@ -89,7 +95,7 @@ async function buildMeta(pathname, origin){
         }
       }
       if (data) {
-        const raw = String(data?.content || '');
+        const raw = stripTokenTagEnvelopes(String(data?.content || ''));
         const content = raw.replace(/\s+/g,' ').trim();
         const media = Array.isArray(data?.media) ? data.media : [];
         return {

--- a/src/components/social/PostHashtagLink.tsx
+++ b/src/components/social/PostHashtagLink.tsx
@@ -34,6 +34,9 @@ interface PostHashtagLinkProps {
   label: string;
   trendMentions?: TrendMention[];
   variant?: 'pill' | 'inline';
+  // Whether to show the 24h change badge. Defaults to true so every existing call site — and
+  // a bare `#SYMBOL` — renders exactly as today; a token tag written `{change=0}` passes false.
+  showChange?: boolean;
 }
 
 function normalizeTag(tag: string) {
@@ -61,6 +64,7 @@ const PostHashtagLink = ({
   label,
   trendMentions,
   variant = 'pill',
+  showChange = true,
 }: PostHashtagLinkProps) => {
   const normalized = normalizeTag(tag);
   const target = `/trends/tokens/${encodeURIComponent(normalized.toUpperCase())}?showTrade=0`;
@@ -89,7 +93,7 @@ const PostHashtagLink = ({
     queryKey: ['post-hashtag-performance', tokenAddress],
     queryFn: () => SuperheroApi.getTokenPerformance(String(tokenAddress)),
     staleTime: 60 * 1000,
-    enabled: Boolean(tokenAddress) && !matchedMention?.performance,
+    enabled: showChange && Boolean(tokenAddress) && !matchedMention?.performance,
   });
 
   const performanceData = matchedMention?.performance || (performance as any);
@@ -111,7 +115,7 @@ const PostHashtagLink = ({
       onClick={(e) => e.stopPropagation()}
     >
       <span className="leading-none">{label}</span>
-      {changeText && (
+      {showChange && changeText && (
         <span
           className={cn(
             'inline-flex items-center gap-0.5 text-[11px] font-semibold tabular-nums leading-none',

--- a/src/components/social/PostTokenTag.tsx
+++ b/src/components/social/PostTokenTag.tsx
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import { TokensService } from '@/api/generated';
+import type { TokenDto } from '@/api/generated/models/TokenDto';
+import { toTokenLookupParam } from '@/utils/address';
+import { cn } from '@/lib/utils';
+import PriceDataFormatter from '@/features/shared/components/PriceDataFormatter';
+import TokenChange from '@/components/Trendminer/TokenChange';
+import { TokenLineChart } from '@/features/trending/components/TokenLineChart';
+import type { TokenTagDisplayOptions } from '@/utils/tokenTagEnvelope';
+
+interface PostTokenTagProps {
+  symbol: string;
+  options: TokenTagDisplayOptions;
+  variant?: 'pill' | 'inline';
+}
+
+/**
+ * Renders a `#SYMBOL{...}` token tag with the display options its envelope resolved to.
+ * The symbol link always renders; price, 24h change and chart are added only when asked
+ * for and only once the token resolves, so an unknown or still-loading token degrades to
+ * the plain tag — the envelope itself is never shown as text.
+ */
+const PostTokenTag = ({ symbol, options, variant = 'inline' }: PostTokenTagProps) => {
+  const normalized = symbol.replace(/^#/, '');
+  const target = `/trends/tokens/${encodeURIComponent(normalized.toUpperCase())}?showTrade=0`;
+
+  const { data: token } = useQuery<TokenDto | null>({
+    queryKey: ['post-token-tag', normalized.toUpperCase()],
+    queryFn: () => TokensService.findByAddress({ address: toTokenLookupParam(normalized) }),
+    staleTime: 60 * 1000,
+    enabled: Boolean(normalized),
+    retry: false,
+  });
+
+  const showChart = options.chart && Boolean(token?.sale_address);
+  const showPrice = options.price && Boolean(token?.price_data);
+  const showChange = options.change && Boolean(token?.performance);
+
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1.5 align-baseline">
+      <Link
+        to={target}
+        className={cn(
+          variant === 'pill'
+            ? 'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-white/10 border border-white/15 text-[var(--neon-blue)] text-[12px] font-semibold hover:bg-white/15 hover:border-white/25'
+            : 'inline-flex items-baseline gap-1 text-[var(--neon-blue)] underline-offset-2 hover:underline text-[13px] font-medium',
+          'no-underline outline-none focus:outline-none break-words',
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <span className="leading-none">{`#${normalized}`}</span>
+      </Link>
+      {showPrice && token && (
+        <span className="text-[12px] font-semibold tabular-nums leading-none">
+          <PriceDataFormatter priceData={token.price_data} watchPrice hideFiatPrice />
+        </span>
+      )}
+      {showChange && token && <TokenChange token={token} hideNewBadge />}
+      {showChart && token && (
+        <TokenLineChart saleAddress={token.sale_address} height={28} width={96} interval="all-time" />
+      )}
+    </span>
+  );
+};
+
+export default PostTokenTag;

--- a/src/components/social/__tests__/PostHashtagLink.test.tsx
+++ b/src/components/social/__tests__/PostHashtagLink.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect } from 'vitest';
+import PostHashtagLink, { type TrendMention } from '../PostHashtagLink';
+
+// A mention carrying its own performance so no network call is needed: PostHashtagLink reads
+// the 24h change straight off it. DEFAULT_PAST_TIMEFRAME is past_30d.
+const MENTION: TrendMention = {
+  name: 'SUPERHERO',
+  symbol: 'SUPERHERO',
+  address: 'ct_super',
+  sale_address: 'ct_super',
+  performance: { past_30d: { current_change_percent: 12.5 } },
+};
+
+function renderTag(showChange?: boolean) {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <PostHashtagLink
+          tag="SUPERHERO"
+          label="#SUPERHERO"
+          variant="inline"
+          trendMentions={[MENTION]}
+          showChange={showChange}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('PostHashtagLink — showChange', () => {
+  it('shows the 24h change badge by default (today\'s rendering, unchanged)', () => {
+    renderTag(undefined);
+    expect(screen.getByRole('link', { name: /#SUPERHERO/ })).toBeInTheDocument();
+    expect(screen.getByText('12.50%')).toBeInTheDocument();
+  });
+
+  it('hides the change badge when showChange is false ({change=0} → only the tag)', () => {
+    renderTag(false);
+    expect(screen.getByRole('link', { name: /#SUPERHERO/ })).toBeInTheDocument();
+    expect(screen.queryByText('12.50%')).not.toBeInTheDocument();
+  });
+});

--- a/src/utils/__tests__/linkify.test.tsx
+++ b/src/utils/__tests__/linkify.test.tsx
@@ -14,6 +14,23 @@ vi.mock('@/hooks/useChainName', () => ({
   useChainName: () => ({ chainName: null }),
 }));
 
+// The enhanced widget fetches token data and pulls in currency/i18n providers; the reader's
+// job here is to consume the envelope and choose the right node, so the widget is stubbed to
+// a marker that echoes the symbol and the resolved options.
+vi.mock('@/components/social/PostTokenTag', () => ({
+  default: ({ symbol, options }: { symbol: string; options: Record<string, boolean> }) => (
+    <span
+      data-testid="post-token-tag"
+      data-symbol={symbol}
+      data-chart={String(options.chart)}
+      data-price={String(options.price)}
+      data-change={String(options.change)}
+    >
+      {`#${symbol}`}
+    </span>
+  ),
+}));
+
 function renderLinkify(text: string, options?: Parameters<typeof linkify>[1]) {
   return render(
     <MemoryRouter>
@@ -294,5 +311,105 @@ describe('linkify hashtag parsing — non-Latin BCL collections', () => {
     renderLinkify('gm #こんにちは gm', { hashtagAllowedChars });
 
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});
+
+describe('linkify token-tag envelope reader', () => {
+  it('renders a bare #SYMBOL exactly as before (no envelope)', () => {
+    renderLinkify('gm #SUPERHERO fam');
+
+    expect(screen.getByRole('link', { name: '#SUPERHERO' }))
+      .toHaveAttribute('href', '/trends/tokens/SUPERHERO');
+    expect(screen.queryByTestId('post-token-tag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('gm #SUPERHERO fam');
+  });
+
+  it('consumes an empty envelope and renders the plain tag', () => {
+    renderLinkify('gm #SUPERHERO{} fam');
+
+    expect(screen.getByRole('link', { name: '#SUPERHERO' })).toBeInTheDocument();
+    expect(screen.queryByTestId('post-token-tag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('gm #SUPERHERO fam');
+  });
+
+  it('treats mode=tag as the plain tag', () => {
+    renderLinkify('#SUPERHERO{mode=tag}');
+
+    expect(screen.getByRole('link', { name: '#SUPERHERO' })).toBeInTheDocument();
+    expect(screen.queryByTestId('post-token-tag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('#SUPERHERO');
+  });
+
+  it('renders a widget for mode=compact (price + change, no chart)', () => {
+    renderLinkify('#SUPERHERO{mode=compact}');
+
+    const widget = screen.getByTestId('post-token-tag');
+    expect(widget).toHaveAttribute('data-symbol', 'SUPERHERO');
+    expect(widget).toHaveAttribute('data-price', 'true');
+    expect(widget).toHaveAttribute('data-change', 'true');
+    expect(widget).toHaveAttribute('data-chart', 'false');
+    expect(screen.getByTestId('content').textContent).toBe('#SUPERHERO');
+  });
+
+  it('renders a widget for mode=advanced (chart + price + change)', () => {
+    renderLinkify('#SUPERHERO{mode=advanced}');
+
+    const widget = screen.getByTestId('post-token-tag');
+    expect(widget).toHaveAttribute('data-chart', 'true');
+    expect(widget).toHaveAttribute('data-price', 'true');
+    expect(widget).toHaveAttribute('data-change', 'true');
+    expect(screen.getByTestId('content').textContent).toBe('#SUPERHERO');
+  });
+
+  it('honours an explicit override — advanced minus the chart', () => {
+    renderLinkify('#SUPERHERO{mode=advanced;chart=0}');
+
+    const widget = screen.getByTestId('post-token-tag');
+    expect(widget).toHaveAttribute('data-chart', 'false');
+    expect(widget).toHaveAttribute('data-price', 'true');
+    expect(widget).toHaveAttribute('data-change', 'true');
+  });
+
+  // The forward-compatibility proof: an envelope written by a future client renders as a
+  // clean plain tag in today's client, never as broken text.
+  it('renders an unknown future envelope as a clean plain tag', () => {
+    renderLinkify('#SUPERHERO{mode=hologram;fps=60}');
+
+    expect(screen.getByRole('link', { name: '#SUPERHERO' })).toBeInTheDocument();
+    expect(screen.queryByTestId('post-token-tag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('#SUPERHERO');
+    expect(screen.getByTestId('content').textContent).not.toContain('{');
+  });
+
+  it('consumes an unparseable envelope and renders the plain tag', () => {
+    renderLinkify('#SUPERHERO{!!garbage!!}');
+
+    expect(screen.getByRole('link', { name: '#SUPERHERO' })).toBeInTheDocument();
+    expect(screen.queryByTestId('post-token-tag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('#SUPERHERO');
+  });
+
+  it('never prints the braces and preserves the surrounding text', () => {
+    renderLinkify('gm #SUPERHERO{mode=advanced} to the moon');
+
+    expect(screen.getByTestId('post-token-tag')).toHaveAttribute('data-symbol', 'SUPERHERO');
+    const { textContent } = screen.getByTestId('content');
+    expect(textContent).toBe('gm #SUPERHERO to the moon');
+    expect(textContent).not.toContain('{');
+    expect(textContent).not.toContain('}');
+  });
+
+  it('reads an envelope on a hyphenated symbol', () => {
+    renderLinkify('#EMOTER-AI{mode=advanced}');
+
+    expect(screen.getByTestId('post-token-tag')).toHaveAttribute('data-symbol', 'EMOTER-AI');
+    expect(screen.getByTestId('content').textContent).toBe('#EMOTER-AI');
+  });
+
+  it('an unterminated brace is not an envelope and the tag still links', () => {
+    renderLinkify('#SUPERHERO{mode=advanced fam');
+
+    expect(screen.getByRole('link', { name: '#SUPERHERO' })).toBeInTheDocument();
+    expect(screen.queryByTestId('post-token-tag')).not.toBeInTheDocument();
   });
 });

--- a/src/utils/__tests__/linkify.test.tsx
+++ b/src/utils/__tests__/linkify.test.tsx
@@ -340,6 +340,22 @@ describe('linkify token-tag envelope reader', () => {
     expect(screen.getByTestId('content').textContent).toBe('#SUPERHERO');
   });
 
+  it('treats {change=0} as a plain tag, not a widget (badge gating tested in PostHashtagLink)', () => {
+    renderLinkify('#SUPERHERO{change=0}');
+
+    expect(screen.getByRole('link', { name: '#SUPERHERO' })).toBeInTheDocument();
+    expect(screen.queryByTestId('post-token-tag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('#SUPERHERO');
+  });
+
+  it('treats the fully-explicit all-off form as a plain tag', () => {
+    renderLinkify('#SUPERHERO{chart=0;price=0;change=0}');
+
+    expect(screen.getByRole('link', { name: '#SUPERHERO' })).toBeInTheDocument();
+    expect(screen.queryByTestId('post-token-tag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('#SUPERHERO');
+  });
+
   it('renders a widget for mode=compact (price + change, no chart)', () => {
     renderLinkify('#SUPERHERO{mode=compact}');
 

--- a/src/utils/__tests__/tokenTagEnvelope.test.ts
+++ b/src/utils/__tests__/tokenTagEnvelope.test.ts
@@ -6,14 +6,17 @@ import {
 } from '../tokenTagEnvelope';
 
 describe('parseTokenTagEnvelope — presets', () => {
-  it('empty payload resolves to the tag preset (nothing enhanced)', () => {
+  // `tag` carries change:true — it is today's rendering, badge included. See MODE_PRESETS.
+  it('empty payload resolves to the tag preset (change on, no widget)', () => {
     const options = parseTokenTagEnvelope('');
-    expect(options).toEqual({ chart: false, price: false, change: false });
+    expect(options).toEqual({ chart: false, price: false, change: true });
     expect(isTokenTagEnhanced(options)).toBe(false);
   });
 
-  it('mode=tag is all off', () => {
-    expect(parseTokenTagEnvelope('mode=tag')).toEqual({ chart: false, price: false, change: false });
+  it('mode=tag is the tag preset — change badge on, no widget', () => {
+    const options = parseTokenTagEnvelope('mode=tag');
+    expect(options).toEqual({ chart: false, price: false, change: true });
+    expect(isTokenTagEnhanced(options)).toBe(false);
   });
 
   it('mode=compact is price + change, no chart', () => {
@@ -23,6 +26,33 @@ describe('parseTokenTagEnvelope — presets', () => {
   it('mode=advanced is chart + price + change', () => {
     const options = parseTokenTagEnvelope('mode=advanced');
     expect(options).toEqual({ chart: true, price: true, change: true });
+    expect(isTokenTagEnhanced(options)).toBe(true);
+  });
+});
+
+describe('parseTokenTagEnvelope — the {change=0} "only the tag" form', () => {
+  // Badi's "or only the tag" is the symbol with the badge explicitly off — not mode=tag.
+  it('change=0 turns the badge off and stays a plain tag (not a widget)', () => {
+    const options = parseTokenTagEnvelope('change=0');
+    expect(options).toEqual({ chart: false, price: false, change: false });
+    expect(isTokenTagEnhanced(options)).toBe(false);
+  });
+
+  it('the fully-explicit all-off form is a plain tag with no badge', () => {
+    const options = parseTokenTagEnvelope('chart=0;price=0;change=0');
+    expect(options).toEqual({ chart: false, price: false, change: false });
+    expect(isTokenTagEnhanced(options)).toBe(false);
+  });
+
+  it('change alone never triggers the widget; only chart/price do', () => {
+    expect(isTokenTagEnhanced({ chart: false, price: false, change: true })).toBe(false);
+    expect(isTokenTagEnhanced({ chart: false, price: true, change: false })).toBe(true);
+    expect(isTokenTagEnhanced({ chart: true, price: false, change: false })).toBe(true);
+  });
+
+  it('compact minus the change keeps the widget (price survives)', () => {
+    const options = parseTokenTagEnvelope('mode=compact;change=0');
+    expect(options).toEqual({ chart: false, price: true, change: false });
     expect(isTokenTagEnhanced(options)).toBe(true);
   });
 });
@@ -42,19 +72,19 @@ describe('parseTokenTagEnvelope — overrides and degradation', () => {
   });
 
   it('an unknown mode value falls back to tag, and known keys still apply', () => {
-    expect(parseTokenTagEnvelope('mode=hologram;fps=60')).toEqual({ chart: false, price: false, change: false });
-    expect(parseTokenTagEnvelope('mode=hologram;chart=1')).toEqual({ chart: true, price: false, change: false });
+    expect(parseTokenTagEnvelope('mode=hologram;fps=60')).toEqual({ chart: false, price: false, change: true });
+    expect(parseTokenTagEnvelope('mode=hologram;chart=1')).toEqual({ chart: true, price: false, change: true });
   });
 
   it('a known key with an unrecognised value drops that pair only', () => {
     expect(parseTokenTagEnvelope('mode=compact;price=maybe')).toEqual({ chart: false, price: true, change: true });
-    expect(parseTokenTagEnvelope('chart=yes;price=1')).toEqual({ chart: false, price: true, change: false });
+    expect(parseTokenTagEnvelope('chart=yes;price=1')).toEqual({ chart: false, price: true, change: true });
   });
 
   it('unknown keys and bare flags are dropped, resolving to tag', () => {
-    expect(parseTokenTagEnvelope('advanced')).toEqual({ chart: false, price: false, change: false });
-    expect(parseTokenTagEnvelope('!!garbage!!')).toEqual({ chart: false, price: false, change: false });
-    expect(parseTokenTagEnvelope('fps=60;quality=high')).toEqual({ chart: false, price: false, change: false });
+    expect(parseTokenTagEnvelope('advanced')).toEqual({ chart: false, price: false, change: true });
+    expect(parseTokenTagEnvelope('!!garbage!!')).toEqual({ chart: false, price: false, change: true });
+    expect(parseTokenTagEnvelope('fps=60;quality=high')).toEqual({ chart: false, price: false, change: true });
   });
 });
 

--- a/src/utils/__tests__/tokenTagEnvelope.test.ts
+++ b/src/utils/__tests__/tokenTagEnvelope.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTokenTagEnvelope,
+  isTokenTagEnhanced,
+  stripTokenTagEnvelopes,
+} from '../tokenTagEnvelope';
+
+describe('parseTokenTagEnvelope — presets', () => {
+  it('empty payload resolves to the tag preset (nothing enhanced)', () => {
+    const options = parseTokenTagEnvelope('');
+    expect(options).toEqual({ chart: false, price: false, change: false });
+    expect(isTokenTagEnhanced(options)).toBe(false);
+  });
+
+  it('mode=tag is all off', () => {
+    expect(parseTokenTagEnvelope('mode=tag')).toEqual({ chart: false, price: false, change: false });
+  });
+
+  it('mode=compact is price + change, no chart', () => {
+    expect(parseTokenTagEnvelope('mode=compact')).toEqual({ chart: false, price: true, change: true });
+  });
+
+  it('mode=advanced is chart + price + change', () => {
+    const options = parseTokenTagEnvelope('mode=advanced');
+    expect(options).toEqual({ chart: true, price: true, change: true });
+    expect(isTokenTagEnhanced(options)).toBe(true);
+  });
+});
+
+describe('parseTokenTagEnvelope — overrides and degradation', () => {
+  it('an explicit key overrides its preset regardless of order', () => {
+    expect(parseTokenTagEnvelope('mode=advanced;chart=0')).toEqual({ chart: false, price: true, change: true });
+    expect(parseTokenTagEnvelope('chart=0;mode=advanced')).toEqual({ chart: false, price: true, change: true });
+  });
+
+  it('keys with no mode start from the tag preset', () => {
+    expect(parseTokenTagEnvelope('price=1;change=1')).toEqual({ chart: false, price: true, change: true });
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseTokenTagEnvelope('MODE=Advanced')).toEqual({ chart: true, price: true, change: true });
+  });
+
+  it('an unknown mode value falls back to tag, and known keys still apply', () => {
+    expect(parseTokenTagEnvelope('mode=hologram;fps=60')).toEqual({ chart: false, price: false, change: false });
+    expect(parseTokenTagEnvelope('mode=hologram;chart=1')).toEqual({ chart: true, price: false, change: false });
+  });
+
+  it('a known key with an unrecognised value drops that pair only', () => {
+    expect(parseTokenTagEnvelope('mode=compact;price=maybe')).toEqual({ chart: false, price: true, change: true });
+    expect(parseTokenTagEnvelope('chart=yes;price=1')).toEqual({ chart: false, price: true, change: false });
+  });
+
+  it('unknown keys and bare flags are dropped, resolving to tag', () => {
+    expect(parseTokenTagEnvelope('advanced')).toEqual({ chart: false, price: false, change: false });
+    expect(parseTokenTagEnvelope('!!garbage!!')).toEqual({ chart: false, price: false, change: false });
+    expect(parseTokenTagEnvelope('fps=60;quality=high')).toEqual({ chart: false, price: false, change: false });
+  });
+});
+
+describe('stripTokenTagEnvelopes', () => {
+  it('drops the envelope and keeps the symbol', () => {
+    expect(stripTokenTagEnvelopes('gm #SUPERHERO{mode=advanced} to the moon'))
+      .toBe('gm #SUPERHERO to the moon');
+  });
+
+  it('strips an unknown/forward-compat envelope too', () => {
+    expect(stripTokenTagEnvelopes('#SUPERHERO{mode=hologram;fps=60}')).toBe('#SUPERHERO');
+    expect(stripTokenTagEnvelopes('#SUPERHERO{!!garbage!!}')).toBe('#SUPERHERO');
+  });
+
+  it('handles hyphenated and non-Latin symbols', () => {
+    expect(stripTokenTagEnvelopes('#EMOTER-AI{chart=1}')).toBe('#EMOTER-AI');
+    expect(stripTokenTagEnvelopes('#你好{mode=compact}')).toBe('#你好');
+  });
+
+  it('leaves bare symbols and non-envelope content untouched', () => {
+    expect(stripTokenTagEnvelopes('gm #SUPERHERO to the moon')).toBe('gm #SUPERHERO to the moon');
+    expect(stripTokenTagEnvelopes('an object literal { a: 1 } stays')).toBe('an object literal { a: 1 } stays');
+    expect(stripTokenTagEnvelopes('#SUPERHERO')).toBe('#SUPERHERO');
+  });
+
+  it('strips multiple envelopes in one string', () => {
+    expect(stripTokenTagEnvelopes('#A{mode=tag} and #B{mode=advanced}')).toBe('#A and #B');
+  });
+});

--- a/src/utils/linkify.tsx
+++ b/src/utils/linkify.tsx
@@ -11,8 +11,19 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PostHashtagLink, { type TrendMention } from '@/components/social/PostHashtagLink';
 import { InlineAccountMention } from '@/components/social/InlineAccountMention';
+import PostTokenTag from '@/components/social/PostTokenTag';
+import {
+  parseTokenTagEnvelope,
+  isTokenTagEnhanced,
+  TOKEN_TAG_ENVELOPE_PAYLOAD,
+} from '@/utils/tokenTagEnvelope';
 import { trustedHtml } from '@/utils/trustedTypes';
 import { formatAddress } from './address';
+
+// The `{payload}` display envelope immediately following a token symbol. Anchored so it
+// only matches directly after the symbol; the symbol itself is matched by the existing
+// hashtag classes above. A present-but-invalid envelope is still consumed (never printed).
+const TOKEN_TAG_ENVELOPE_REGEX = new RegExp(`^\\{(${TOKEN_TAG_ENVELOPE_PAYLOAD})\\}`);
 
 // URL matcher (external links)
 const URL_REGEX = /((https?:\/\/)?[\w.-]+\.[a-z]{2,}(\/[\w\-._~:\/?#[\]@!$&'()*+,;=%]*)?)/gi;
@@ -154,8 +165,33 @@ export function linkify(
         ? fullRun.slice(i + 1).match(hashtagTokenRegex)
         : null;
       if (tokenMatch) {
-        nodes.push(renderHashtagNode(tokenMatch[0], hashStart + i));
-        i += 1 + tokenMatch[0].length;
+        const symbol = tokenMatch[0];
+        const symEnd = i + 1 + symbol.length;
+        // A `{payload}` directly after the symbol is a display envelope. It is always
+        // consumed so its text never renders; an enhanced option set becomes a widget,
+        // and an absent/empty/unrecognised envelope falls back to the plain tag.
+        const envMatch = fullRun[symEnd] === '{'
+          ? fullRun.slice(symEnd).match(TOKEN_TAG_ENVELOPE_REGEX)
+          : null;
+        if (envMatch) {
+          const tagOptions = parseTokenTagEnvelope(envMatch[1]);
+          nodes.push(
+            isTokenTagEnhanced(tagOptions) ? (
+              <PostTokenTag
+                symbol={symbol}
+                options={tagOptions}
+                variant={options?.hashtagVariant === 'post-inline' ? 'inline' : 'pill'}
+                key={`token-tag-${symbol}-${hashStart + i}`}
+              />
+            ) : (
+              renderHashtagNode(symbol, hashStart + i)
+            ),
+          );
+          i = symEnd + envMatch[0].length;
+        } else {
+          nodes.push(renderHashtagNode(symbol, hashStart + i));
+          i = symEnd;
+        }
         matchedAny = true;
       } else {
         // Inert stretch: not a valid token start. Consume up to (not including) the next '#'

--- a/src/utils/linkify.tsx
+++ b/src/utils/linkify.tsx
@@ -120,13 +120,20 @@ export function linkify(
 
   // Renders a single '#token' as a link, per the `hashtagVariant` option. `keyPos` is the
   // absolute offset of the '#' in `raw`, used to keep React keys unique across the whole text.
-  const renderHashtagNode = (tokenName: string, keyPos: number): React.ReactNode => (
+  // `showChange` gates the inline change badge — true for a bare tag (today's rendering) and
+  // for the `tag` preset, false for an explicit `{change=0}`.
+  const renderHashtagNode = (
+    tokenName: string,
+    keyPos: number,
+    showChange = true,
+  ): React.ReactNode => (
     options?.hashtagVariant === 'post-inline' ? (
       <PostHashtagLink
         tag={tokenName}
         label={`#${tokenName}`}
         trendMentions={options?.trendMentions}
         variant="inline"
+        showChange={showChange}
         key={`hashtag-${tokenName}-${keyPos}`}
       />
     ) : (
@@ -184,7 +191,9 @@ export function linkify(
                 key={`token-tag-${symbol}-${hashStart + i}`}
               />
             ) : (
-              renderHashtagNode(symbol, hashStart + i)
+              // Not a widget: render today's tag, but honour an explicit `{change=0}` by
+              // gating the badge on the resolved `change` option (default `tag` keeps it on).
+              renderHashtagNode(symbol, hashStart + i, tagOptions.change)
             ),
           );
           i = symEnd + envMatch[0].length;

--- a/src/utils/tokenTagEnvelope.ts
+++ b/src/utils/tokenTagEnvelope.ts
@@ -1,0 +1,78 @@
+// Token-tag display envelope. A token stays `#SYMBOL`; an optional `{...}` suffix carries
+// how the composer wants it displayed — `#SYMBOL{mode=advanced}`. The symbol is never
+// touched, so nothing already on chain renders differently and the on-chain indexing
+// contract is untouched. The envelope is permissive; the interpreter here is strict: a
+// payload we do not understand resolves to the plain tag rather than rendering as text.
+
+export interface TokenTagDisplayOptions {
+  chart: boolean;
+  price: boolean;
+  change: boolean;
+}
+
+// Named presets are pure sugar over the three toggles, so there is one model, not two.
+const MODE_PRESETS: Record<string, TokenTagDisplayOptions> = {
+  tag: { chart: false, price: false, change: false },
+  compact: { chart: false, price: true, change: true },
+  advanced: { chart: true, price: true, change: true },
+};
+
+const TAG_PRESET = MODE_PRESETS.tag;
+const BOOLEAN_KEYS = ['chart', 'price', 'change'] as const;
+
+// The envelope payload following a token symbol: at most 64 chars, no braces or newlines.
+// Kept here so the reader and the SEO strippers share one grammar.
+export const TOKEN_TAG_ENVELOPE_PAYLOAD = '[^{}\\r\\n]{0,64}';
+
+/**
+ * Resolve a raw envelope payload into display options. Degradation is total and in this
+ * order: an empty, unparseable, or entirely-unknown payload resolves to the `tag` preset;
+ * an unknown `mode` value falls back to `tag` while known keys still apply; an unknown key
+ * or an unrecognised value drops that pair only. The caller always renders the symbol.
+ */
+export function parseTokenTagEnvelope(payload: string): TokenTagDisplayOptions {
+  const resolved: TokenTagDisplayOptions = { ...TAG_PRESET };
+  const pairs = String(payload ?? '')
+    .toLowerCase()
+    .split(';')
+    .map((pair) => pair.trim())
+    .filter(Boolean);
+
+  // `mode` first, so explicit toggles override its preset regardless of their order.
+  const modePair = pairs.find((pair) => pair.startsWith('mode='));
+  if (modePair) {
+    const mode = modePair.slice('mode='.length);
+    Object.assign(resolved, MODE_PRESETS[mode] ?? TAG_PRESET);
+  }
+
+  pairs.forEach((pair) => {
+    const eq = pair.indexOf('=');
+    if (eq < 0) return; // bare flag / garbage: no `key=value`, drop it
+    const key = pair.slice(0, eq);
+    const value = pair.slice(eq + 1);
+    if (key === 'mode') return; // handled above
+    if ((BOOLEAN_KEYS as readonly string[]).includes(key)) {
+      if (value === '1') resolved[key as (typeof BOOLEAN_KEYS)[number]] = true;
+      else if (value === '0') resolved[key as (typeof BOOLEAN_KEYS)[number]] = false;
+      // any other value: drop this pair only
+    }
+    // unknown key: drop
+  });
+
+  return resolved;
+}
+
+/** Whether the resolved options ask for anything beyond the plain tag. */
+export function isTokenTagEnhanced(options: TokenTagDisplayOptions): boolean {
+  return options.chart || options.price || options.change;
+}
+
+// Strip token-tag envelopes from raw content, leaving the bare `#symbol`, so an envelope
+// never reaches a meta description, a search snippet, or a link preview. The symbol class
+// is deliberately broad (any Unicode letter/number/dash) to cover every collection
+// alphabet; only the trailing `{...}` is removed, never the symbol itself.
+const STRIP_REGEX_SOURCE = `(#[\\p{L}\\p{N}-]{1,50})\\{${TOKEN_TAG_ENVELOPE_PAYLOAD}\\}`;
+
+export function stripTokenTagEnvelopes(content: string): string {
+  return String(content ?? '').replace(new RegExp(STRIP_REGEX_SOURCE, 'gu'), '$1');
+}

--- a/src/utils/tokenTagEnvelope.ts
+++ b/src/utils/tokenTagEnvelope.ts
@@ -11,8 +11,11 @@ export interface TokenTagDisplayOptions {
 }
 
 // Named presets are pure sugar over the three toggles, so there is one model, not two.
+// `tag` carries `change: true` because `tag` means *today's rendering*, which already shows
+// the change badge — dropping it would retroactively change every post on chain. The ladder
+// is strictly monotonic: tag ⊂ compact ⊂ advanced. Turning the badge off is `{change=0}`.
 const MODE_PRESETS: Record<string, TokenTagDisplayOptions> = {
-  tag: { chart: false, price: false, change: false },
+  tag: { chart: false, price: false, change: true },
   compact: { chart: false, price: true, change: true },
   advanced: { chart: true, price: true, change: true },
 };
@@ -62,9 +65,14 @@ export function parseTokenTagEnvelope(payload: string): TokenTagDisplayOptions {
   return resolved;
 }
 
-/** Whether the resolved options ask for anything beyond the plain tag. */
+/**
+ * Whether the resolved options need the richer widget. Only `chart`/`price` do — `change`
+ * is the tag's own badge, rendered on the plain node and gated separately, so it must NOT be
+ * part of this switch. Were it included, all-false `{change=0}` would be indistinguishable
+ * from the default and the badge could never be turned off.
+ */
 export function isTokenTagEnhanced(options: TokenTagDisplayOptions): boolean {
-  return options.chart || options.price || options.change;
+  return options.chart || options.price;
 }
 
 // Strip token-tag envelopes from raw content, leaving the bare `#symbol`, so an envelope


### PR DESCRIPTION


<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/660/) — updated Tue, 25 Aug 2026 05:37:20 GMT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-layer and SEO text normalization only; bare `#SYMBOL` behavior is preserved by design, with broad test coverage for parsing, degradation, and badge gating.
> 
> **Overview**
> Adds support for optional **`#SYMBOL{...}` display envelopes** on token hashtags: the symbol stays on-chain as-is, while a trailing `{mode=compact|advanced}` (or explicit `chart`/`price`/`change` toggles) controls how the tag renders in the feed.
> 
> **`linkify`** now consumes any `{...}` immediately after a valid token name so braces never appear as plain text. Unknown or invalid payloads degrade to today’s plain linked tag (with the change badge unless `{change=0}`). **`mode=compact`** / **`mode=advanced`** (and overrides like `chart=0`) route to a new **`PostTokenTag`** widget that can show price, 24h change, and a mini chart once the token resolves; otherwise it falls back to a link only. **`PostHashtagLink`** gains **`showChange`** so envelope-driven “tag only” can hide the badge without pulling in the widget.
> 
> **SEO / link previews:** duplicated **`stripTokenTagEnvelopes`** in the Netlify edge SEO injector and **`server/index.cjs`** post meta builder so titles/descriptions use `#SYMBOL` only. Shared parsing/strip grammar lives in **`src/utils/tokenTagEnvelope.ts`**, with unit and linkify integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a80cd643b8c681b544d18db3a6c4391f2131733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->