### PR TITLE
Feat/account mention pill avatar

### DIFF
--- a/src/components/social/AccountMentionPill.tsx
+++ b/src/components/social/AccountMentionPill.tsx
@@ -1,22 +1,56 @@
+import { useMemo } from 'react';
+import * as jdenticon from 'jdenticon';
+import { JDENTICON_CONFIG } from '@/components/AddressAvatar';
 import { useChainName } from '@/hooks/useChainName';
 import { formatAddress } from '@/utils/address';
+import { trustedHtml } from '@/utils/trustedTypes';
 import { MentionPill } from './PostMentionTag';
 
 interface AccountMentionPillProps {
   address: string;
 }
 
-// A deliberate `[account:ak_…]` mention, rendered through the one shared mention pill: the
-// account's `.chain` name when known, else the shortened address. No leading mark — the '@'
-// sigil carries it, matching the token pill and the mobile client.
+// A deliberate `[account:ak_…]` mention, rendered through the one shared mention pill and
+// carrying the account's identity the way the header user-search row does: the identicon,
+// the `.chain` name when known, and the muted address beside it. With no name it falls back
+// to the identicon plus the shortened address — unchanged from before, no trailing duplicate.
 export const AccountMentionPill = ({ address }: AccountMentionPillProps) => {
   const { chainName } = useChainName(address);
-  const label = chainName ?? formatAddress(address, 3, true);
+  const name = chainName?.trim();
+  const shortAddress = formatAddress(address, 4, true);
+
+  // The identicon IS the account's visual identity (not a monogram), so it stays. It is sized
+  // in em by `.sh-pill__avatar`; a viewBox'd jdenticon SVG scales to fill that box.
+  const avatar = useMemo(() => {
+    const svg = trustedHtml(jdenticon.toSvg(address, 100, JDENTICON_CONFIG));
+    return (
+      <span
+        className="sh-pill__avatar"
+        aria-hidden="true"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+    );
+  }, [address]);
+
+  // Name resolved → `@name` with the address trailing, muted and aria-hidden. No name → the
+  // shortened address is the label itself, so there is no trailing part to duplicate it.
+  const label = name ?? formatAddress(address, 3, true);
+  const trailing = name
+    ? <span className="sh-pill__addr" aria-hidden="true">{shortAddress}</span>
+    : undefined;
+  const ariaLabel = name
+    ? `${name}, ${shortAddress}, mention — link`
+    : `${label}, mention — link`;
+
   return (
     <MentionPill
       name={address}
       label={label}
       href={`/users/${address}`}
+      leading={avatar}
+      trailing={trailing}
+      ariaLabel={ariaLabel}
     />
   );
 };

--- a/src/components/social/EntityPill.tsx
+++ b/src/components/social/EntityPill.tsx
@@ -7,6 +7,10 @@ export interface EntityPillProps {
   ariaLabel: string;
   sigil: string; // '#' token, '@' mention
   label: string; // symbol/handle without sigil, pre-truncated
+  // Optional leading node — only an account mention passes it (its identicon). Token pills
+  // pass nothing, so the monogram removal stands: this is not the old `mark`, it is the
+  // account's visual identity, sized in em so it seats inside the line box.
+  leading?: React.ReactNode;
   trailing?: React.ReactNode; // price / change / chart, each already aria-hidden
   rich?: boolean; // has price/chart → eligible for block promotion on a narrow column
   to?: string; // token → in-app router link
@@ -17,12 +21,13 @@ export interface EntityPillProps {
 }
 
 // The shared inline pill for a token tag and a mention: one link, one hit target, one spoken
-// label, height on the line box, never split across a wrap. No leading mark — the '#' / '@'
-// sigil carries the token-vs-mention distinction, matching the mobile client.
+// label, height on the line box, never split across a wrap. The '#' / '@' sigil carries the
+// token-vs-mention distinction; only an account mention adds a leading identicon.
 const EntityPill = ({
   ariaLabel,
   sigil,
   label,
+  leading,
   trailing,
   rich = false,
   to,
@@ -38,6 +43,7 @@ const EntityPill = ({
 
   const inner = (
     <>
+      {leading}
       <span className="sh-pill__symbol" aria-hidden="true">
         {`${sigil}${label}`}
       </span>

--- a/src/components/social/PostMentionTag.tsx
+++ b/src/components/social/PostMentionTag.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import EntityPill from './EntityPill';
 
 export interface MentionPillProps {
@@ -5,25 +6,31 @@ export interface MentionPillProps {
   href: string; // profile target, matching today's mention links (/users/...)
   label?: string; // display text when it differs from name (e.g. a formatted ak_ address)
   unresolvable?: boolean; // → plain text, no pill, no link, same as an unknown token
+  // Only a deliberate `[account:…]` mention passes these: its identicon and the muted
+  // trailing address. A bare handle/AENS mention passes neither and stays text-only.
+  leading?: React.ReactNode;
+  trailing?: React.ReactNode;
+  ariaLabel?: string; // override the default spoken label (account folds in the address)
 }
 
-// A mention rendered as the same pill a token uses, distinguished only by the '@' sigil; an
-// unresolvable handle degrades to plain text. No leading mark — the mark was the only thing the
-// former `loading` state shimmered, and the handle text is known synchronously, so both the mark
-// and the loading skeleton are gone with it.
+// A mention rendered as the same pill a token uses, distinguished by the '@' sigil; an
+// unresolvable handle degrades to plain text. Only an account mention carries a leading
+// identicon and a trailing address — a bare handle is the handle text alone.
 export const MentionPill = ({
-  name, href, label, unresolvable = false,
+  name, href, label, unresolvable = false, leading, trailing, ariaLabel,
 }: MentionPillProps) => {
   const display = label ?? name;
   if (unresolvable) {
-    return <EntityPill plain sigil="@" label={display} ariaLabel={`${display} — unresolved mention`} />;
+    return <EntityPill plain sigil="@" label={display} ariaLabel={ariaLabel ?? `${display} — unresolved mention`} />;
   }
   return (
     <EntityPill
       sigil="@"
       label={display}
       href={href}
-      ariaLabel={`${display}, mention — link`}
+      leading={leading}
+      trailing={trailing}
+      ariaLabel={ariaLabel ?? `${display}, mention — link`}
     />
   );
 };

--- a/src/components/social/__tests__/AccountMentionPill.test.tsx
+++ b/src/components/social/__tests__/AccountMentionPill.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  describe, it, expect, vi, beforeEach,
+} from 'vitest';
+import { AccountMentionPill } from '../AccountMentionPill';
+
+// The pill resolves the chain name via a batched network hook; pin it per test so these
+// render assertions stay deterministic and offline.
+const mockUseChainName = vi.fn();
+vi.mock('@/hooks/useChainName', () => ({
+  useChainName: (address: string) => mockUseChainName(address),
+}));
+
+const ADDR = 'ak_2mMPQ2E9zN8Dd6Fm8jrThQvcYQ7cwR3hh6iC5xGZ2gZ4tHacBdEf';
+
+function renderPill() {
+  return render(
+    <MemoryRouter>
+      <AccountMentionPill address={ADDR} />
+    </MemoryRouter>,
+  );
+}
+
+describe('AccountMentionPill', () => {
+  beforeEach(() => {
+    mockUseChainName.mockReset();
+  });
+
+  it('resolved name → identicon, @name, and the muted address beside it', () => {
+    mockUseChainName.mockReturnValue({ chainName: 'superhero.chain' });
+    const { container } = renderPill();
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/users/${ADDR}`);
+    expect(container.querySelector('.sh-pill__avatar')).toBeInTheDocument();
+    expect(container.querySelector('.sh-pill__symbol')).toHaveTextContent('@superhero.chain');
+    // Address is present as a distinct trailing part, not folded into the handle text.
+    expect(container.querySelector('.sh-pill__addr')?.textContent).toMatch(/^ak_/);
+    // One spoken label folds in the address; the visible parts are aria-hidden.
+    expect(link.getAttribute('aria-label')).toContain('superhero.chain');
+    expect(link.getAttribute('aria-label')).toContain('mention');
+  });
+
+  it('no name → identicon + shortened address as the label, no duplicate trailing', () => {
+    mockUseChainName.mockReturnValue({ chainName: null });
+    const { container } = renderPill();
+
+    const link = screen.getByRole('link');
+    expect(container.querySelector('.sh-pill__avatar')).toBeInTheDocument();
+    expect(link.textContent).toMatch(/^@ak_/);
+    expect(container.querySelector('.sh-pill__addr')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/wallet/__tests__/passkey-recovery.test.ts
+++ b/src/features/wallet/__tests__/passkey-recovery.test.ts
@@ -20,8 +20,8 @@ const authenticator = vi.hoisted(() => ({
 }));
 
 vi.mock('../webauthn', async () => {
-  const { hmac } = await import('@noble/hashes/hmac');
-  const { sha256 } = await import('@noble/hashes/sha2');
+  const { hmac } = await import('@noble/hashes/hmac.js');
+  const { sha256 } = await import('@noble/hashes/sha2.js');
   const prf = (id: string, salt: Uint8Array) => (
     hmac(sha256, authenticator.credentials.get(id)!, salt)
   );

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -758,6 +758,29 @@ textarea:disabled {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Leading identicon — account mention only. The account's visual identity, not a monogram, so
+   it survives the monogram removal. Sized in em against the pill's own line box (1.1 line-height)
+   so it seats inside the line without re-raising pill height, and scales with Dynamic Type. The
+   viewBox'd jdenticon SVG fills the em box. */
+.sh-pill__avatar {
+  flex: 0 0 auto;
+  width: 1.1em;
+  height: 1.1em;
+  border-radius: 50%;
+  overflow: hidden;
+  display: inline-flex;
+  line-height: 0;
+}
+.sh-pill__avatar svg { width: 100%; height: 100%; display: block; }
+
+/* Muted address trailing an account mention's chain name. aria-hidden — the name and address
+   are spoken once in the pill's single aria-label, never as a second string. */
+.sh-pill__addr {
+  color: var(--light-font-color);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
 .sh-pill__price {
   color: var(--standard-font-color);
   font-variant-numeric: tabular-nums;

--- a/src/utils/__tests__/linkify.test.tsx
+++ b/src/utils/__tests__/linkify.test.tsx
@@ -144,14 +144,18 @@ describe('linkify hashtag parsing', () => {
 
   const MACRO_ADDR = 'ak_2mMPQ2E9zN8Dd6Fm8jrThQvcYQ7cwR3hh6iC5xGZ2gZ4tHacBdEf';
 
-  it('renders an [account:ak_...] macro as an inline account chip', () => {
-    renderLinkify(`gm [account:${MACRO_ADDR}] there`);
+  it('renders an [account:ak_...] macro as an inline account chip with its identicon', () => {
+    const { container } = renderLinkify(`gm [account:${MACRO_ADDR}] there`);
 
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', `/users/${MACRO_ADDR}`);
     // The macro delimiters are consumed, and the chip label is '@'-prefixed.
     expect(screen.getByTestId('content').textContent).not.toContain('[account:');
     expect(link.textContent).toMatch(/^@ak_/);
+    // The account badge carries the identicon; with no chain name (mocked null) there is no
+    // separate trailing address — the shortened address is the label itself, not duplicated.
+    expect(container.querySelector('.sh-pill__avatar')).toBeInTheDocument();
+    expect(container.querySelector('.sh-pill__addr')).not.toBeInTheDocument();
   });
 
   it('leaves a bare ak_ address as a plain link, not a macro chip', () => {
@@ -171,6 +175,9 @@ describe('linkify hashtag parsing', () => {
     // Account macro (Pass 0.5), AENS name (Pass 1) and raw address (Pass 2a) each render as the
     // shared EntityPill — no bespoke second treatment beside it.
     expect(container.querySelectorAll('.sh-pill')).toHaveLength(3);
+    // Only the deliberate `[account:…]` badge carries an identicon; the bare AENS name and the
+    // raw address stay text-only pills.
+    expect(container.querySelectorAll('.sh-pill__avatar')).toHaveLength(1);
   });
 
   it('treats a lone "#" with no following token characters as plain text', () => {


### PR DESCRIPTION


<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/665/) — updated Wed, 26 Aug 2026 07:36:37 GMT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and accessibility tweaks to social mention rendering with trustedTypes-wrapped jdenticon SVG; no auth, wallet, or data-path changes beyond a test import fix.
> 
> **Overview**
> **Account `[account:ak_…]` mention pills** now match header user-search identity: a **leading jdenticon**, `@chain.name` when resolved, and a **muted trailing shortened address** when a name exists. With no chain name, the pill still shows the identicon plus `@shortAddress` only—no duplicate trailing address.
> 
> The shared **`EntityPill` / `MentionPill`** stack gains optional **`leading`**, **`trailing`**, and **`ariaLabel`** so only deliberate account macros pass the avatar and address; bare AENS and raw `ak_` mentions stay text-only pills.
> 
> **Styles** add `.sh-pill__avatar` (em-sized circular identicon) and `.sh-pill__addr` (muted tabular address). **Tests** cover `AccountMentionPill` and extend linkify expectations; **passkey-recovery** tests only fix `@noble/hashes` import paths to `.js` suffixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd53fa95910e9ce84f5e9c0b746d7f09c8150fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->