### PR TITLE
Feat/advanced token tag row

### DIFF
--- a/src/components/social/PostTokenTag.tsx
+++ b/src/components/social/PostTokenTag.tsx
@@ -1,12 +1,14 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { TokensService } from '@/api/generated';
 import type { TokenDto } from '@/api/generated/models/TokenDto';
 import { toTokenLookupParam } from '@/utils/address';
 import { DEFAULT_PAST_TIMEFRAME } from '@/utils/constants';
 import PriceDataFormatter from '@/features/shared/components/PriceDataFormatter';
-import { TokenLineChart } from '@/features/trending/components/TokenLineChart';
 import type { TokenTagDisplayOptions } from '@/utils/tokenTagEnvelope';
 import EntityPill from './EntityPill';
+import TokenTagCandleChart from './TokenTagCandleChart';
 import { PillChangeBadge, isFlatChange } from './pillParts';
 
 // Long symbols clip with an ellipsis rather than pushing the price out of the card.
@@ -35,34 +37,138 @@ export interface TokenPillProps {
   status: TokenPillStatus;
   offline?: boolean; // query paused on cached data → last-known, not live
   staleHours?: number; // age of the cached value, spoken label only
+  preview?: boolean; // rendered in the composer ladder, not the post → tighter row sizing
 }
+
+function tokenTarget(normalized: string): string {
+  return `/trends/tokens/${encodeURIComponent(normalized.toUpperCase())}?showTrade=0`;
+}
+
+interface TokenRowProps {
+  symbol: string; // normalized, without the leading '#'
+  options: TokenTagDisplayOptions;
+  token: TokenDto | null | undefined;
+  status: TokenPillStatus;
+  preview?: boolean; // composer ladder → shorter candlestick, tighter spacing
+}
+
+// The advanced full-row: name, price, market cap and a small candlestick, one link to the token.
+// Reached only when `options.chart` resolves true (TokenPill dispatches here). Every slot is
+// data-gated on its own — a missing part is dropped, the row is never blanked — and the
+// candlestick no longer depends on price, so `{mode=advanced;price=0}` is a row without a price.
+const TokenRow = ({
+  symbol, options, token, status, preview = false,
+}: TokenRowProps) => {
+  const { t } = useTranslation();
+  const normalized = symbol.replace(/^#/, '');
+  const loading = status === 'loading';
+
+  const changePct = readChangePercent(token);
+  const hasChange = changePct !== null;
+  const showChange = options.change && hasChange;
+  const isPositive = (changePct ?? 0) >= 0;
+
+  const showPrice = options.price && Boolean(token?.price_data);
+  const showMcap = Boolean(token?.market_cap_data);
+  const showChart = Boolean(token?.sale_address); // price precondition dropped in the row
+
+  // One spoken label for the whole row, assembled from what actually renders.
+  const spoken = [normalized];
+  if (loading) spoken.push('loading');
+  if (showPrice) spoken.push('with price');
+  if (showMcap) spoken.push('market cap');
+  if (showChange) {
+    spoken.push(isFlatChange(changePct ?? 0)
+      ? 'unchanged over 24 hours'
+      : `${isPositive ? 'up' : 'down'} ${Math.abs(changePct ?? 0).toFixed(1)} percent`);
+  }
+  if (showChart) spoken.push('candlestick chart');
+  spoken.push('link');
+  const ariaLabel = spoken.join(', ').replace(/, link$/, ' — link');
+
+  const chartHeight = preview ? 44 : 72;
+
+  return (
+    <Link
+      to={tokenTarget(normalized)}
+      aria-label={ariaLabel}
+      className={`sh-token-row${preview ? ' sh-token-row--preview' : ''}`}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <span className="sh-token-row__head" aria-hidden="true">
+        <span className="sh-token-row__symbol">{`#${normalized}`}</span>
+        {showChange && <PillChangeBadge changePercent={changePct ?? 0} />}
+      </span>
+
+      <span className="sh-token-row__stats" aria-hidden="true">
+        {showPrice ? (
+          <span className="sh-token-row__stat">
+            <span className="sh-token-row__stat-label">{t('social.tokenTag.priceLabel')}</span>
+            <span className="sh-token-row__price">
+              <PriceDataFormatter priceData={token!.price_data} watchPrice hideFiatPrice />
+            </span>
+          </span>
+        ) : (
+          loading && <span className="sh-pill__skel sh-pill__skel--price" />
+        )}
+        {showMcap && (
+          <span className="sh-token-row__stat">
+            <span className="sh-token-row__stat-label">{t('social.tokenTag.marketCap')}</span>
+            <span className="sh-token-row__mcap">
+              <PriceDataFormatter priceData={token!.market_cap_data} bignumber hideFiatPrice />
+            </span>
+          </span>
+        )}
+      </span>
+
+      {showChart ? (
+        <TokenTagCandleChart token={token!} height={chartHeight} className="sh-token-row__chart" />
+      ) : (
+        loading && <span className="sh-pill__skel sh-token-row__chart-skel" style={{ height: chartHeight }} />
+      )}
+    </Link>
+  );
+};
 
 // Presentational token pill — pure in its inputs, so every state renders directly from props.
 export const TokenPill = ({
-  symbol, options, token, status, offline = false, staleHours,
+  symbol, options, token, status, offline = false, staleHours, preview = false,
 }: TokenPillProps) => {
   const normalized = symbol.replace(/^#/, '');
   const display = truncateSymbol(normalized);
 
-  // Unknown / delisted: plain dashed text, no pill, no link.
+  // Unknown / delisted: plain dashed text, no pill, no link — the same in either layout.
   if (status === 'unknown') {
     return (
       <EntityPill plain sigil="#" label={display} ariaLabel={`${normalized} — unknown token`} />
     );
   }
 
-  const target = `/trends/tokens/${encodeURIComponent(normalized.toUpperCase())}?showTrade=0`;
+  // The row switch: `chart` resolved true promotes the tag to a full row (name · price · market
+  // cap · candlestick). It is derived from the parsed options alone, never a wire mode name, so
+  // any payload resolving to `chart: true` renders identically. `chart` false is the inline pill.
+  if (options.chart) {
+    return (
+      <TokenRow
+        symbol={normalized}
+        options={options}
+        token={token}
+        status={status}
+        preview={preview}
+      />
+    );
+  }
+
+  const target = tokenTarget(normalized);
   const loading = status === 'loading';
 
   const changePct = readChangePercent(token);
   const hasChange = changePct !== null;
   const hasPrice = Boolean(token?.price_data);
-  const hasChart = Boolean(token?.sale_address);
 
-  // Data-gated in ladder order: the chart needs the price present; a missing part drops it.
+  // Inline pill covers rungs 0-2 only; `chart: true` routes to TokenRow above, so no chart slot.
   const showChange = options.change && hasChange;
   const showPrice = options.price && hasPrice;
-  const showChart = options.chart && hasChart && showPrice;
   const isPositive = (changePct ?? 0) >= 0;
 
   // Spoken label — one sentence, assembled from what actually renders.
@@ -74,7 +180,6 @@ export const TokenPill = ({
       ? 'unchanged over 24 hours'
       : `${isPositive ? 'up' : 'down'} ${Math.abs(changePct ?? 0).toFixed(1)} percent`);
   }
-  if (showChart) spoken.push('24-hour chart');
   if (offline && staleHours !== undefined) spoken.push(`last known ${staleHours}h ago`);
   spoken.push('link');
   const ariaLabel = `${spoken.join(', ').replace(/, link$/, ' — link')}`;
@@ -90,13 +195,6 @@ export const TokenPill = ({
         loading && options.price && <span className="sh-pill__skel sh-pill__skel--price" aria-hidden="true" />
       )}
       {showChange && <PillChangeBadge changePercent={changePct ?? 0} />}
-      {showChart ? (
-        <span className="sh-pill__chart" aria-hidden="true">
-          <TokenLineChart saleAddress={token!.sale_address!} height={18} width={60} interval="all-time" />
-        </span>
-      ) : (
-        loading && options.chart && <span className="sh-pill__skel sh-pill__skel--chart" aria-hidden="true" />
-      )}
     </>
   );
 
@@ -106,7 +204,7 @@ export const TokenPill = ({
       label={display}
       to={target}
       ariaLabel={ariaLabel}
-      rich={options.price || options.chart}
+      rich={options.price}
       trailing={trailing}
     />
   );

--- a/src/components/social/TokenTagCandleChart.tsx
+++ b/src/components/social/TokenTagCandleChart.tsx
@@ -1,0 +1,116 @@
+import {
+  useCallback, useEffect, useMemo, useRef,
+} from 'react';
+import { ColorType, CandlestickSeries, ISeriesApi } from 'lightweight-charts';
+import { Encoded } from '@aeternity/aepp-sdk';
+import moment from 'moment';
+import { useQuery } from '@tanstack/react-query';
+
+import { TokenDto, TransactionHistoricalService } from '@/api/generated';
+import { useChart } from '@/hooks/useChart';
+
+// A compact, read-only candlestick for the advanced token-tag row. The full
+// TokenCandlestickChart is a detail-page widget — interval switcher, live clock, websocket
+// updates and an overlay positioned above its own box — none of which belongs inline in a
+// feed post, so this renders only the series over a fixed recent window. Same data source
+// (TransactionHistoricalService) and same up/down inks as the detail chart.
+const UP = '#2BCC61';
+const DOWN = '#F5274E';
+const DAILY = 24 * 60 * 60; // one candle per day
+const WINDOW = 60; // last ~60 days, enough to read a trend at this size
+
+interface TokenTagCandleChartProps {
+  token: TokenDto;
+  height?: number;
+  className?: string;
+}
+
+interface Candle {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+const TokenTagCandleChart = ({ token, height = 72, className = '' }: TokenTagCandleChartProps) => {
+  const saleAddress = token?.sale_address;
+  const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
+
+  const { data } = useQuery({
+    queryKey: ['token-tag-candles', saleAddress, DAILY],
+    queryFn: () => TransactionHistoricalService.getPaginatedHistory({
+      address: saleAddress as Encoded.ContractAddress,
+      interval: DAILY,
+      convertTo: 'ae' as any,
+      page: 1,
+      limit: WINDOW,
+    }),
+    enabled: Boolean(saleAddress),
+    staleTime: 60 * 1000,
+    retry: false,
+  });
+
+  const candles = useMemo<Candle[]>(() => {
+    if (!Array.isArray(data)) return [];
+    return data
+      .map((item: any) => ({
+        time: moment(item.timeClose).unix(),
+        open: Number(item.quote?.open),
+        high: Number(item.quote?.high),
+        low: Number(item.quote?.low),
+        close: Number(item.quote?.close),
+      }))
+      .filter((c) => Number.isFinite(c.open) && Number.isFinite(c.close))
+      .sort((a, b) => a.time - b.time)
+      .reduce<Candle[]>((acc, c) => {
+        if (!acc.some((x) => x.time === c.time)) acc.push(c);
+        return acc;
+      }, []);
+  }, [data]);
+
+  const paint = useCallback((series: ISeriesApi<'Candlestick'>, points: Candle[]) => {
+    series.setData(points as any);
+  }, []);
+
+  const { chartContainer, chart } = useChart({
+    height,
+    chartOptions: {
+      handleScroll: false,
+      handleScale: false,
+      leftPriceScale: { visible: false },
+      rightPriceScale: { visible: false },
+      timeScale: { visible: false },
+      crosshair: { horzLine: { visible: false }, vertLine: { visible: false } },
+      grid: { horzLines: { visible: false }, vertLines: { visible: false } },
+      layout: { background: { color: 'transparent', type: ColorType.Solid } },
+    },
+    onChartReady: (instance) => {
+      const series = instance.addSeries(CandlestickSeries, {
+        upColor: UP,
+        downColor: DOWN,
+        wickUpColor: UP,
+        wickDownColor: DOWN,
+        borderVisible: false,
+        priceLineVisible: false,
+        lastValueVisible: false,
+      });
+      seriesRef.current = series;
+      if (candles.length) {
+        paint(series, candles);
+        instance.timeScale().fitContent();
+      }
+    },
+  });
+
+  // Re-paint whenever the data arrives after the chart, or the series is rebuilt.
+  useEffect(() => {
+    if (!chart || !seriesRef.current || !candles.length) return;
+    paint(seriesRef.current, candles);
+    chart.timeScale().fitContent();
+  }, [chart, candles, paint]);
+
+  return <div ref={chartContainer} className={className} style={{ height }} aria-hidden="true" />;
+};
+
+export default TokenTagCandleChart;

--- a/src/components/social/__tests__/PostTokenTag.test.tsx
+++ b/src/components/social/__tests__/PostTokenTag.test.tsx
@@ -8,20 +8,29 @@ import type { TokenDto } from '@/api/generated/models/TokenDto';
 import { DEFAULT_PAST_TIMEFRAME } from '@/utils/constants';
 import { TokenPill } from '../PostTokenTag';
 
-// The price and chart slots pull in currency/i18n and a network sparkline; the pill's job under
-// test is choosing which slots render, so they are stubbed to markers.
+// The price slot pulls in currency/i18n; the candlestick pulls in lightweight-charts and a
+// network query. The pill's job under test is choosing which slots render, so both are stubbed
+// to markers. Price and market cap share the formatter — `bignumber` distinguishes market cap.
 vi.mock('@/features/shared/components/PriceDataFormatter', () => ({
-  default: () => <span data-testid="price">0.004078 AE</span>,
+  default: ({ bignumber }: { bignumber?: boolean }) => (
+    <span data-testid={bignumber ? 'mcap' : 'price'}>{bignumber ? '$1.2M' : '0.004078 AE'}</span>
+  ),
 }));
-vi.mock('@/features/trending/components/TokenLineChart', () => ({
-  TokenLineChart: () => <span data-testid="chart">chart</span>,
+vi.mock('../TokenTagCandleChart', () => ({
+  default: () => <span data-testid="candles">candles</span>,
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
 }));
 
 const ADVANCED = { chart: true, price: true, change: true };
+const COMPACT = { chart: false, price: true, change: true };
+const SYMBOL_ONLY = { chart: false, price: false, change: false };
 
 function tokenWith(parts: Partial<TokenDto>): TokenDto {
   return {
     price_data: { price: '1' } as any,
+    market_cap_data: { ae: '1200000' } as any,
     performance: { [DEFAULT_PAST_TIMEFRAME]: { current_change_percent: 2.4 } } as any,
     sale_address: 'ct_sale',
     ...parts,
@@ -32,54 +41,7 @@ function renderPill(node: React.ReactElement) {
   return render(<MemoryRouter>{node}</MemoryRouter>);
 }
 
-describe('TokenPill', () => {
-  it('renders rung 3 (mark, symbol, price, change, chart) as one link', () => {
-    renderPill(<TokenPill symbol="SUPERHERO" options={ADVANCED} token={tokenWith({})} status="resolved" />);
-    const link = screen.getByRole('link');
-    expect(link).toHaveTextContent('#SUPERHERO');
-    expect(screen.getByTestId('price')).toBeInTheDocument();
-    expect(screen.getByTestId('chart')).toBeInTheDocument();
-    expect(link.textContent).toContain('2.4%');
-    // One spoken label, not four fragments.
-    expect(link).toHaveAttribute('aria-label', expect.stringContaining('SUPERHERO'));
-    expect(link.getAttribute('aria-label')).toContain('link');
-  });
-
-  it('degrades to price + change when the chart series is missing (no sale_address)', () => {
-    renderPill(
-      <TokenPill symbol="SUPERHERO" options={ADVANCED} token={tokenWith({ sale_address: undefined })} status="resolved" />,
-    );
-    expect(screen.getByTestId('price')).toBeInTheDocument();
-    expect(screen.queryByTestId('chart')).not.toBeInTheDocument();
-    expect(screen.getByRole('link').textContent).toContain('2.4%');
-  });
-
-  it('degrades to symbol + change when the price is unavailable (drops price and chart)', () => {
-    renderPill(
-      <TokenPill symbol="SUPERHERO" options={ADVANCED} token={tokenWith({ price_data: undefined })} status="resolved" />,
-    );
-    expect(screen.queryByTestId('price')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('chart')).not.toBeInTheDocument();
-    expect(screen.getByRole('link').textContent).toContain('2.4%');
-  });
-
-  it('falls to symbol only when the 24h change is unavailable', () => {
-    const token = tokenWith({ performance: undefined, price_data: undefined, sale_address: undefined });
-    renderPill(<TokenPill symbol="SUPERHERO" options={ADVANCED} token={token} status="resolved" />);
-    const link = screen.getByRole('link');
-    expect(link).toHaveTextContent('#SUPERHERO');
-    expect(link.textContent).not.toContain('%');
-  });
-
-  it('never skeletons the symbol while loading — only the data slots do', () => {
-    const { container } = renderPill(
-      <TokenPill symbol="SUPERHERO" options={ADVANCED} token={undefined} status="loading" />,
-    );
-    expect(screen.getByRole('link')).toHaveTextContent('#SUPERHERO');
-    expect(container.querySelector('.sh-pill__skel--price')).toBeTruthy();
-    expect(screen.queryByTestId('price')).not.toBeInTheDocument();
-  });
-
+describe('TokenPill — inline (rungs 0-2)', () => {
   it('renders an unknown / delisted token as plain dashed text, no pill and no link', () => {
     const { container } = renderPill(
       <TokenPill symbol="NOTATOKEN" options={ADVANCED} token={null} status="unknown" />,
@@ -90,17 +52,92 @@ describe('TokenPill', () => {
 
   it('truncates a long symbol with an ellipsis', () => {
     renderPill(
-      <TokenPill symbol="VERYLONGTOKENNAME" options={{ chart: false, price: false, change: false }} token={tokenWith({})} status="resolved" />,
+      <TokenPill symbol="VERYLONGTOKENNAME" options={SYMBOL_ONLY} token={tokenWith({})} status="resolved" />,
     );
     expect(screen.getByRole('link').textContent).toContain('…');
   });
 
   it('marks the last-known value with a stale dot when offline', () => {
     const { container } = renderPill(
-      <TokenPill symbol="SUPERHERO" options={{ chart: false, price: true, change: true }} token={tokenWith({})} status="resolved" offline staleHours={2} />,
+      <TokenPill symbol="SUPERHERO" options={COMPACT} token={tokenWith({})} status="resolved" offline staleHours={2} />,
     );
     expect(container.querySelector('.sh-pill__stale-dot')).toBeTruthy();
     expect(screen.getByRole('link').getAttribute('aria-label')).toContain('last known 2h ago');
+  });
+});
+
+describe('TokenPill — advanced row (chart resolved true)', () => {
+  it('renders the full row — symbol, price, market cap, change and candlestick — as one link', () => {
+    renderPill(<TokenPill symbol="SUPERHERO" options={ADVANCED} token={tokenWith({})} status="resolved" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('sh-token-row');
+    expect(link).toHaveTextContent('#SUPERHERO');
+    expect(screen.getByTestId('price')).toBeInTheDocument();
+    expect(screen.getByTestId('mcap')).toBeInTheDocument();
+    expect(screen.getByTestId('candles')).toBeInTheDocument();
+    expect(link.textContent).toContain('2.4%');
+    expect(link.getAttribute('aria-label')).toContain('SUPERHERO');
+    expect(link.getAttribute('aria-label')).toContain('link');
+  });
+
+  it('keeps the candlestick when the price is unavailable — the price precondition is dropped', () => {
+    renderPill(
+      <TokenPill symbol="SUPERHERO" options={ADVANCED} token={tokenWith({ price_data: undefined })} status="resolved" />,
+    );
+    expect(screen.queryByTestId('price')).not.toBeInTheDocument();
+    expect(screen.getByTestId('candles')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveClass('sh-token-row');
+    expect(screen.getByRole('link').textContent).toContain('2.4%');
+  });
+
+  it('drops only the candlestick when the token has no sale_address, still a row', () => {
+    renderPill(
+      <TokenPill symbol="SUPERHERO" options={ADVANCED} token={tokenWith({ sale_address: undefined })} status="resolved" />,
+    );
+    expect(screen.getByTestId('price')).toBeInTheDocument();
+    expect(screen.queryByTestId('candles')).not.toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveClass('sh-token-row');
+  });
+
+  it('omits the market-cap slot when market_cap_data is absent, without blanking the row', () => {
+    renderPill(
+      <TokenPill symbol="SUPERHERO" options={ADVANCED} token={tokenWith({ market_cap_data: undefined })} status="resolved" />,
+    );
+    expect(screen.queryByTestId('mcap')).not.toBeInTheDocument();
+    expect(screen.getByTestId('price')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveTextContent('#SUPERHERO');
+  });
+
+  it('honours {mode=advanced;price=0} — a row without a price but with the candlestick', () => {
+    renderPill(
+      <TokenPill symbol="SUPERHERO" options={{ chart: true, price: false, change: true }} token={tokenWith({})} status="resolved" />,
+    );
+    expect(screen.queryByTestId('price')).not.toBeInTheDocument();
+    expect(screen.getByTestId('candles')).toBeInTheDocument();
+    expect(screen.getByTestId('mcap')).toBeInTheDocument();
+  });
+
+  it('falls to symbol only when price, chart and change are all unavailable', () => {
+    const token = tokenWith({
+      performance: undefined,
+      price_data: undefined,
+      sale_address: undefined,
+      market_cap_data: undefined,
+    });
+    renderPill(<TokenPill symbol="SUPERHERO" options={ADVANCED} token={token} status="resolved" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveTextContent('#SUPERHERO');
+    expect(link.textContent).not.toContain('%');
+    expect(screen.queryByTestId('candles')).not.toBeInTheDocument();
+  });
+
+  it('never skeletons the symbol while loading — only the data slots do', () => {
+    const { container } = renderPill(
+      <TokenPill symbol="SUPERHERO" options={ADVANCED} token={undefined} status="loading" />,
+    );
+    expect(screen.getByRole('link')).toHaveTextContent('#SUPERHERO');
+    expect(container.querySelector('.sh-pill__skel--price')).toBeTruthy();
+    expect(screen.queryByTestId('price')).not.toBeInTheDocument();
   });
 
   it('renders a flat (0%) token neutrally — no arrow, no direction spoken', () => {

--- a/src/features/social/components/ReplyToFeedItem.tsx
+++ b/src/features/social/components/ReplyToFeedItem.tsx
@@ -402,6 +402,8 @@ const ReplyToFeedItem = memo(({
                       Object.values(chainNames || {}).map((n) => n?.toLowerCase()),
                     ),
                     hashtagVariant: 'post-inline',
+                    // Clamped preview inside a <button>: inline pill only, never the block row.
+                    tokenTagInline: true,
                     trendMentions: (parent as any)?.trend_mentions,
                     hashtagAllowedChars,
                   })}

--- a/src/features/social/components/TokenTagOptionsBar.tsx
+++ b/src/features/social/components/TokenTagOptionsBar.tsx
@@ -284,7 +284,13 @@ const RungLadderDialog = ({
                 }`}
               />
               <span aria-hidden className="sh-pill-preview pointer-events-none flex-1 min-w-0 overflow-hidden text-[13px] leading-snug">
-                <TokenPill symbol={symbol} options={options} token={token} status={previewStatus} />
+                <TokenPill
+                  symbol={symbol}
+                  options={options}
+                  token={token}
+                  status={previewStatus}
+                  preview
+                />
               </span>
               <span aria-hidden className="flex flex-col items-end text-right flex-shrink-0">
                 <span className={`text-[11px] tabular-nums ${exceeds ? 'text-rose-400 font-semibold' : 'text-white/80'}`}>{`${cost.total} ${ts('chars')}`}</span>

--- a/src/features/social/components/TokenTagOptionsBar.tsx
+++ b/src/features/social/components/TokenTagOptionsBar.tsx
@@ -25,12 +25,12 @@ type Translate = (key: string, options?: Record<string, unknown>) => string;
 // Where the portalled dialog paints: anchored under the chip on desktop, or a bottom sheet.
 type Placement = { desktop: boolean; top: number; left: number };
 
-// The four rungs, strictly monotonic. Rung 0 is the badge-less "just the symbol" form —
-// `{change=0}` on the wire — a first-class choice, not an override buried behind a toggle.
-// No preset name (`tag`/`compact`/`advanced`) ever reaches the UI: each rung is labelled by
+// The three rungs, strictly monotonic, numbered 1–3 so the percentage-only default stays rung 1.
+// The badge-less `{change=0}` form is still a readable wire value, but it is no longer offered as
+// a rung — an author who wants it reaches it through Customize, where it reads as an off-ladder
+// mix. No preset name (`tag`/`compact`/`advanced`) ever reaches the UI: each rung is labelled by
 // what it shows, and the live preview is the real label.
 const RUNG_OPTIONS: TokenTagDisplayOptions[] = [
-  { chart: false, price: false, change: false }, // 0 · Symbol only
   MODE_PRESETS.tag, // 1 · Symbol + 24h change (default)
   MODE_PRESETS.compact, // 2 · + price
   MODE_PRESETS.advanced, // 3 · + price + chart
@@ -38,9 +38,9 @@ const RUNG_OPTIONS: TokenTagDisplayOptions[] = [
 
 const PART_KEYS: (keyof TokenTagDisplayOptions)[] = ['change', 'price', 'chart'];
 
-// Which rung a set of options is, or 'custom' for an off-ladder mix.
+// Which rung a set of options is, or 'custom' for an off-ladder mix — the badge-less `{change=0}`
+// form now among them, since it is no longer a rung of its own.
 function rungOf(options: TokenTagDisplayOptions): number | 'custom' {
-  if (!options.change && !options.price && !options.chart) return 0;
   const preset = matchPreset(options);
   if (preset === 'tag') return 1;
   if (preset === 'compact') return 2;
@@ -50,8 +50,7 @@ function rungOf(options: TokenTagDisplayOptions): number | 'custom' {
 
 // Character cost of a rung: the whole `#SYMBOL{...}` length, and the delta over the bare
 // `#SYMBOL`. The macro counts against the post limit, so this is the one consequence the author
-// cannot otherwise see — including that rung 0 costs more than the default, because turning the
-// badge off means writing `{change=0}`.
+// cannot otherwise see.
 function rungCost(symbol: string, options: TokenTagDisplayOptions) {
   const envelope = serializeTokenTagEnvelope(options);
   const bare = symbol.length + 1; // '#' + symbol
@@ -79,7 +78,7 @@ interface RungLadderDialogProps {
 }
 
 /**
- * The select-mode dialog: four rungs as a radiogroup, each a live preview of the pill at real
+ * The select-mode dialog: three rungs as a radiogroup, each a live preview of the pill at real
  * size, plus a "Customize parts" disclosure that auto-opens on an off-ladder mix. Anchored below
  * the composer on desktop, a bottom sheet on narrow — never over the text being edited.
  */
@@ -168,8 +167,9 @@ const RungLadderDialog = ({
     if (wouldExceed(next)) return;
     onChange(next);
   };
+  // Rungs are numbered 1–3; RUNG_OPTIONS is 0-indexed, so a rung maps to `rung - 1`.
   const setRung = (rung: number) => applyIfFits(
-    applyTokenTagOptions(value, active.index, RUNG_OPTIONS[rung], allowedChars),
+    applyTokenTagOptions(value, active.index, RUNG_OPTIONS[rung - 1], allowedChars),
   );
   const togglePart = (key: keyof TokenTagDisplayOptions) => applyIfFits(
     applyTokenTagOptions(
@@ -180,7 +180,7 @@ const RungLadderDialog = ({
     ),
   );
 
-  const focusRung = (rung: number) => rungRefs.current[Math.max(0, Math.min(3, rung))]?.focus();
+  const focusRung = (rung: number) => rungRefs.current[Math.max(1, Math.min(3, rung))]?.focus();
 
   // ↑↓ / ←→ move and select; Space/Enter select. Handled per-radio so the radiogroup container
   // carries no keyboard listener of its own.
@@ -193,7 +193,7 @@ const RungLadderDialog = ({
       setRung(next); focusRung(next);
     } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
       e.preventDefault();
-      const next = Math.max(0, rung - 1);
+      const next = Math.max(1, rung - 1);
       setRung(next); focusRung(next);
     }
   };
@@ -250,7 +250,8 @@ const RungLadderDialog = ({
         aria-label={ts('optionsFor', { symbol })}
         className="mt-2 flex flex-col gap-1"
       >
-        {RUNG_OPTIONS.map((options, rung) => {
+        {RUNG_OPTIONS.map((options, i) => {
+          const rung = i + 1; // rungs are 1-based; the badge-less rung 0 was removed
           const selected = currentRung === rung;
           const cost = rungCost(symbol, options);
           const label = ts(`rung${rung}`);
@@ -391,7 +392,7 @@ type OpenState = { ordinal: number; symbol: string } | null;
 
 /**
  * A chip bar over the composer: one chip per token occurrence in the post, each showing the
- * shape it is currently set to. Tapping a chip opens a ladder of four rungs — each a live
+ * shape it is currently set to. Tapping a chip opens a ladder of three rungs — each a live
  * preview of the widget at real size. The bar edits the `{...}` envelope directly in the single
  * composer string, so nothing is held in side-state a paste or edit could desync. Renders nothing
  * when there are no tags.

--- a/src/features/social/components/__tests__/TokenTagOptionsBar.test.tsx
+++ b/src/features/social/components/__tests__/TokenTagOptionsBar.test.tsx
@@ -10,7 +10,6 @@ import TokenTagOptionsBar from '../TokenTagOptionsBar';
 
 const LABELS: Record<string, string> = {
   'social.tokenTag.barLabel': 'In this post',
-  'social.tokenTag.rung0': 'Symbol only',
   'social.tokenTag.rung1': 'Symbol + 24h change',
   'social.tokenTag.rung2': '+ price',
   'social.tokenTag.rung3': '+ price + chart',
@@ -87,19 +86,21 @@ describe('TokenTagOptionsBar — chip bar', () => {
 });
 
 describe('TokenTagOptionsBar — rung ladder', () => {
-  it('opens a ladder of four content-labelled rungs with per-rung character cost', () => {
+  it('opens a ladder of three content-labelled rungs, percentage-only the default', () => {
     renderBar('#SUPERHERO');
     fireEvent.click(chips()[0]);
 
     const dialog = screen.getByRole('dialog');
-    expect(within(dialog).getByRole('radio', { name: 'Symbol only' })).toBeInTheDocument();
+    // The badge-less "Symbol only" rung is gone; the ladder opens on the percentage-only default.
+    expect(within(dialog).queryByRole('radio', { name: 'Symbol only' })).not.toBeInTheDocument();
+    expect(within(dialog).getAllByRole('radio')).toHaveLength(3);
     expect(within(dialog).getByRole('radio', { name: 'Symbol + 24h change, default' })).toBeInTheDocument();
     expect(within(dialog).getByRole('radio', { name: '+ price' })).toBeInTheDocument();
     expect(within(dialog).getByRole('radio', { name: '+ price + chart' })).toBeInTheDocument();
 
-    // Rung 0 (`{change=0}`) costs more than the default: #SUPERHERO{change=0} = 20 chars, +10.
-    expect(within(dialog).getByText('20 ch')).toBeInTheDocument();
-    expect(within(dialog).getByText('+10')).toBeInTheDocument();
+    // The +price rung's cost is shown: #SUPERHERO{mode=compact} = 24 chars, +14 over the bare tag.
+    expect(within(dialog).getByText('24 ch')).toBeInTheDocument();
+    expect(within(dialog).getByText('+14')).toBeInTheDocument();
   });
 
   it('emits {mode=advanced} when the +price+chart rung is chosen', () => {
@@ -146,8 +147,8 @@ describe('TokenTagOptionsBar — serialized cap gate', () => {
 
   it('refuses a rung that would cross the serialized cap, but allows one that fits', () => {
     const onChange = vi.fn();
-    // Display 228 chars; serialized 268. Cap 280 → 12 chars of wire room.
-    const value = `${'z'.repeat(217)} #SUPERHERO`;
+    // Display 226 chars; serialized 266. Cap 280 → 14 chars of wire room.
+    const value = `${'z'.repeat(215)} #SUPERHERO`;
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     render(
       <QueryClientProvider client={client}>
@@ -161,15 +162,15 @@ describe('TokenTagOptionsBar — serialized cap gate', () => {
     );
     fireEvent.click(chips()[0]);
 
-    // +price+chart adds `{mode=advanced}` (15) → 283 serialized. The display math (243) would
+    // +price+chart adds `{mode=advanced}` (15) → 281 serialized. The display math (241) would
     // wrongly say it fits; the serialized gate refuses it.
     fireEvent.click(screen.getByRole('radio', { name: '+ price + chart' }));
     expect(onChange).not.toHaveBeenCalled();
 
-    // Symbol only adds `{change=0}` (10) → 278 serialized ≤ 280: accepted.
-    fireEvent.click(screen.getByRole('radio', { name: 'Symbol only' }));
+    // +price adds `{mode=compact}` (14) → 280 serialized ≤ 280: accepted.
+    fireEvent.click(screen.getByRole('radio', { name: '+ price' }));
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith(`${'z'.repeat(217)} #SUPERHERO{change=0}`);
+    expect(onChange).toHaveBeenCalledWith(`${'z'.repeat(215)} #SUPERHERO{mode=compact}`);
   });
 });
 

--- a/src/features/wallet/__tests__/passkey-recovery.test.ts
+++ b/src/features/wallet/__tests__/passkey-recovery.test.ts
@@ -20,8 +20,8 @@ const authenticator = vi.hoisted(() => ({
 }));
 
 vi.mock('../webauthn', async () => {
-  const { hmac } = await import('@noble/hashes/hmac');
-  const { sha256 } = await import('@noble/hashes/sha2');
+  const { hmac } = await import('@noble/hashes/hmac.js');
+  const { sha256 } = await import('@noble/hashes/sha2.js');
   const prf = (id: string, salt: Uint8Array) => (
     hmac(sha256, authenticator.credentials.get(id)!, salt)
   );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1798,7 +1798,7 @@
       "rung0": "Symbol only",
       "rung1": "Symbol + 24h change",
       "rung2": "+ price",
-      "rung3": "+ price + chart",
+      "rung3": "Full row + market cap + chart",
       "marketCap": "Market cap",
       "priceLabel": "Price",
       "default": "default",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1795,7 +1795,6 @@
       "optionsFor": "Display options for #{{symbol}}",
       "occurrence": "occurrence {{n}}",
       "howItAppears": "How it appears in your post",
-      "rung0": "Symbol only",
       "rung1": "Symbol + 24h change",
       "rung2": "+ price",
       "rung3": "Full row + market cap + chart",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1799,6 +1799,8 @@
       "rung1": "Symbol + 24h change",
       "rung2": "+ price",
       "rung3": "+ price + chart",
+      "marketCap": "Market cap",
+      "priceLabel": "Price",
       "default": "default",
       "custom": "Custom",
       "customize": "Customize parts",

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -847,6 +847,106 @@ textarea:disabled {
    squeezing the symbol into an ellipsis and overlapping the price. */
 .sh-pill-preview .sh-pill { max-width: none; }
 
+/* ==========================================================================
+   Advanced token-tag row (.sh-token-row)
+   Name · price · market cap · small candlestick. Promoted from the inline pill
+   when `chart` resolves true. A whole row cannot sit on the text baseline, so
+   it is a deliberate block that breaks the inline run it is spliced into — the
+   body wrapper it lands in is a <div> (flow content), so a block child is valid.
+   Every slot is data-gated by the renderer; CSS only lays out what is passed.
+   ========================================================================== */
+.sh-token-row {
+  display: block; /* breaks the inline run — the row owns its own lines */
+  width: 100%;
+  max-width: 420px;
+  margin: 0.45em 0;
+  padding: 0.6em 0.75em;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--standard-font-color);
+  text-decoration: none;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+.sh-token-row:hover {
+  background: rgba(255, 255, 255, 0.07);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+.sh-token-row:focus-visible {
+  outline: 2px solid var(--neon-blue);
+  outline-offset: 1px;
+}
+.sh-token-row__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5em;
+}
+.sh-token-row__symbol {
+  min-width: 0;
+  color: var(--neon-blue);
+  font-weight: 700;
+  font-size: 1.02em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sh-token-row__stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.3em 1.15em;
+  margin-top: 0.3em;
+}
+.sh-token-row__stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35em;
+}
+.sh-token-row__stat-label {
+  font-size: 0.72em;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-weight: 600;
+  color: var(--light-font-color);
+}
+.sh-token-row__price,
+.sh-token-row__mcap {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--standard-font-color);
+}
+.sh-token-row__chart {
+  display: block;
+  width: 100%;
+  margin-top: 0.5em;
+}
+.sh-token-row__chart-skel {
+  display: block;
+  width: 100%;
+  margin-top: 0.5em;
+  border-radius: 8px;
+}
+/* Composer ladder preview: no outer margin, fills its slot, a touch tighter. */
+.sh-token-row--preview {
+  margin: 0;
+  max-width: none;
+  padding: 0.45em 0.55em;
+}
+
+:root[data-theme='light'] {
+  .sh-token-row {
+    background: rgba(0, 0, 0, 0.04);
+    border-color: rgba(0, 0, 0, 0.1);
+    color: #0f172a;
+  }
+  .sh-token-row:hover {
+    background: rgba(0, 0, 0, 0.07);
+    border-color: rgba(0, 0, 0, 0.18);
+  }
+  .sh-token-row__symbol { color: #0e7490; }
+}
+
 /* Reduced motion: the skeleton holds a flat tint and does not shimmer. */
 @media (prefers-reduced-motion: reduce) {
   .sh-pill__skel {

--- a/src/utils/__tests__/linkify.test.tsx
+++ b/src/utils/__tests__/linkify.test.tsx
@@ -396,6 +396,22 @@ describe('linkify token-tag envelope reader', () => {
     expect(widget).toHaveAttribute('data-change', 'true');
   });
 
+  it('tokenTagInline forces the inline pill — advanced renders with the chart off', () => {
+    renderLinkify('#SUPERHERO{mode=advanced}', { tokenTagInline: true } as any);
+
+    const widget = screen.getByTestId('post-token-tag');
+    expect(widget).toHaveAttribute('data-chart', 'false');
+    expect(widget).toHaveAttribute('data-price', 'true');
+    expect(widget).toHaveAttribute('data-change', 'true');
+  });
+
+  it('tokenTagInline drops a chart-only envelope to the plain tag, never a widget', () => {
+    renderLinkify('#SUPERHERO{mode=advanced;price=0}', { tokenTagInline: true } as any);
+
+    expect(screen.queryByTestId('post-token-tag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('content').textContent).toBe('#SUPERHERO');
+  });
+
   // The forward-compatibility proof: an envelope written by a future client renders as a
   // clean plain tag in today's client, never as broken text.
   it('renders an unknown future envelope as a clean plain tag', () => {

--- a/src/utils/linkify.tsx
+++ b/src/utils/linkify.tsx
@@ -69,6 +69,13 @@ export function linkify(
   options?: {
     knownChainNames?: Set<string>;
     hashtagVariant?: 'post-inline';
+    /**
+     * Suppress the advanced token-tag row, forcing the inline pill instead. Set in constrained
+     * contexts where a block row cannot render — a line-clamped parent/quoted preview inside a
+     * `<button>`, where a `display:block` `<a>` carrying the chart's `<div>` would be invalid
+     * nesting and visibly broken. Price/change still show; only the row layout is dropped.
+     */
+    tokenTagInline?: boolean;
     trendMentions?: TrendMention[];
     /**
      * Regex character-class body (e.g. from `mergedCollectionNameCharsPattern`) covering the
@@ -181,7 +188,11 @@ export function linkify(
           ? fullRun.slice(symEnd).match(TOKEN_TAG_ENVELOPE_REGEX)
           : null;
         if (envMatch) {
-          const tagOptions = parseTokenTagEnvelope(envMatch[1]);
+          const parsed = parseTokenTagEnvelope(envMatch[1]);
+          // In a clamped preview the full row cannot render, so drop the row switch: the inline
+          // pill still carries price/change, and a chart-only envelope falls through to the plain
+          // tag below rather than a broken block inside a <button>.
+          const tagOptions = options?.tokenTagInline ? { ...parsed, chart: false } : parsed;
           nodes.push(
             isTokenTagEnhanced(tagOptions) ? (
               <PostTokenTag


### PR DESCRIPTION


<!-- screenshots-report-bot -->
---
📸 [Screenshots report](https://superhero-com.github.io/superhero/pr/666/) — updated Wed, 26 Aug 2026 08:16:06 GMT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Feed rendering and linkify behavior change for advanced token tags (new network chart query per tag row), with HTML nesting constraints handled via `tokenTagInline`; wallet test-only import tweak is low risk.
> 
> **Overview**
> **Advanced token tags** (`chart: true`, e.g. `{mode=advanced}`) now render as a **block row** (`.sh-token-row`) instead of an inline pill with a sparkline: symbol, optional 24h change, labeled price and market cap, and a compact **daily candlestick** via new `TokenTagCandleChart` (replaces `TokenLineChart` on the pill). Each slot is data-gated independently—the chart no longer requires price, so envelopes like `{mode=advanced;price=0}` still show market cap and candles.
> 
> **Inline pill** paths (rungs without chart) keep price and change only; the composer ladder drops the old “symbol only” rung (now **three rungs**, 1–3), renames the top rung in copy, and passes **`preview`** for tighter row sizing in the options dialog.
> 
> **Constrained embeds** get `linkify`’s **`tokenTagInline`**, which forces `chart: false` so parent post previews inside a `<button>` never nest the block row (used in `ReplyToFeedItem`).
> 
> Includes SCSS for the row, i18n keys, and test updates; unrelated **passkey recovery** test fix for `@noble/hashes` `.js` import paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d1f790a060af21ab61ef0755bf1181d6cea242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->